### PR TITLE
Add Elgato Wave:3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 *.pyo
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ install:
 	printf '#!/bin/sh\nexec %s -m wavexlr "$$@"\n' "$(PYTHON)" > $(BINDIR)/openwave
 	chmod 755 $(BINDIR)/openwave
 	install -Dm644 wavexlr.desktop $(DESKTOPDIR)/openwave.desktop
+	install -Dm644 openwave-autostart.desktop $(APPDIR)/openwave-autostart.desktop
 	install -Dm644 wireplumber/51-openwave-wave-xlr.conf $(APPDIR)/wireplumber/51-openwave-wave-xlr.conf
 	install -Dm644 pipewire/52-openwave-mixes.conf $(APPDIR)/pipewire/52-openwave-mixes.conf
 	install -Dm644 README.md $(DOCDIR)/README.md

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SITEPKG := $(shell $(PYTHON) -c "import site; print(site.getsitepackages()[0])")
 
 install:
 	install -dm755 $(DESTDIR)$(SITEPKG)/wavexlr
-	install -m644 wavexlr/__init__.py wavexlr/__main__.py wavexlr/app.py wavexlr/audio.py wavexlr/daemon.py wavexlr/device.py wavexlr/meter.py wavexlr/mixer.py wavexlr/mixmatrix.py wavexlr/service.py wavexlr/setup.py wavexlr/sourcedialog.py wavexlr/sources.py wavexlr/style.css wavexlr/tray.py $(DESTDIR)$(SITEPKG)/wavexlr/
+	install -m644 wavexlr/__init__.py wavexlr/__main__.py wavexlr/app.py wavexlr/audio.py wavexlr/daemon.py wavexlr/device.py wavexlr/meter.py wavexlr/mixer.py wavexlr/mixmatrix.py wavexlr/probe.py wavexlr/profiles.py wavexlr/service.py wavexlr/setup.py wavexlr/sourcedialog.py wavexlr/sources.py wavexlr/style.css wavexlr/tray.py $(DESTDIR)$(SITEPKG)/wavexlr/
 	install -dm755 $(BINDIR)
 	printf '#!/bin/sh\nexec %s -m wavexlr "$$@"\n' "$(PYTHON)" > $(BINDIR)/openwave
 	chmod 755 $(BINDIR)/openwave

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=openwave
 pkgver=1.0.0
 pkgrel=1
-pkgdesc="Linux control application for the Elgato Wave XLR"
+pkgdesc="Linux control application for the Elgato Wave XLR and Wave:3"
 arch=('any')
 url="https://github.com/rikkichy/openwave"
 license=('MIT')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -27,6 +27,9 @@ package() {
     # Desktop entry
     install -Dm644 wavexlr.desktop "$pkgdir/usr/share/applications/$pkgname.desktop"
 
+    # Autostart template (user copies to ~/.config/autostart)
+    install -Dm644 openwave-autostart.desktop "$pkgdir/usr/share/openwave/openwave-autostart.desktop"
+
     # License
     install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Linux control application for **Elgato Wave** audio devices — the **Wave XLR**
 
 Wave devices use USB Class control transfers on endpoint 0 for device configuration. On Linux, `snd-usb-audio` normally blocks these transfers because `wIndex=0x3300` routes through interface 0 (owned by the audio driver). OpenWave uses `wIndex=0x3303` instead — the firmware only checks the `0x33` prefix, while the kernel sees interface 3 (unclaimed) and lets the transfer through. No driver detach needed, audio is never interrupted.
 
-Both devices speak the same vendor protocol (`bRequest` 0x85 read / 0x05 write) but with different config layouts: the Wave XLR uses a 34-byte block (gain uint16 @0, mute @4, HP volume int16 Q8.8 @9, knob mode @14, low-Z @33), the Wave:3 a 16-byte block (gain uint16 Q8.8 dB @0, mute @4, HP volume int16 Q8.8 @7, monitor mix uint16 Q8.8 percent @10, dial mode @12 — 1=gain, 2=headphones, 3=mix). Per-model constants live in `wavexlr/profiles.py`; `python3 -m wavexlr.probe` (`dump` / `watch` / `poke`) verifies a device against its profile and helps map new fields.
+Both devices speak the same vendor protocol (`bRequest` 0x85 read / 0x05 write) but with different config layouts: the Wave XLR uses a 34-byte block (gain uint16 @0, mute @4, HP volume int16 Q8.8 @9, knob mode @14, low-Z @33), the Wave:3 a 16-byte block (gain uint16 Q8.8 dB @0, mute @4, HP volume int16 Q8.8 @7, monitor mix uint16 Q8.8 percent @10, dial mode @12 — 1=gain, 2=headphones, 3=mix). Per-model constants live in `wavexlr/profiles.py`; `python3 -m wavexlr.probe` (`dump` / `watch` / `poke`) verifies a device against its profile and helps map new fields. The device services vendor transfers from only one process at a time, so quit OpenWave before probing.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # OpenWave
 
-Linux control application for the **Elgato Wave XLR** microphone interface. A reverse-engineered replacement for Elgato Wave Link, built with GTK4 + Adwaita.
+Linux control application for **Elgato Wave** audio devices — the **Wave XLR** microphone interface and the **Wave:3** microphone. A reverse-engineered replacement for Elgato Wave Link, built with GTK4 + Adwaita.
+
+## Supported devices
+
+| Device | USB ID | Controls |
+|---|---|---|
+| Wave XLR | `0fd9:007d` | Gain, mute, headphone volume, low impedance mode |
+| Wave:3 | `0fd9:0070` | Gain, mute, headphone volume, monitor mix |
 
 ## Features
 
@@ -14,7 +21,9 @@ Linux control application for the **Elgato Wave XLR** microphone interface. A re
 
 ## How it works
 
-The Wave XLR uses USB Class control transfers on endpoint 0 for device configuration. On Linux, `snd-usb-audio` normally blocks these transfers because `wIndex=0x3300` routes through interface 0 (owned by the audio driver). OpenWave uses `wIndex=0x3303` instead — the firmware only checks the `0x33` prefix, while the kernel sees interface 3 (unclaimed) and lets the transfer through. No driver detach needed, audio is never interrupted.
+Wave devices use USB Class control transfers on endpoint 0 for device configuration. On Linux, `snd-usb-audio` normally blocks these transfers because `wIndex=0x3300` routes through interface 0 (owned by the audio driver). OpenWave uses `wIndex=0x3303` instead — the firmware only checks the `0x33` prefix, while the kernel sees interface 3 (unclaimed) and lets the transfer through. No driver detach needed, audio is never interrupted.
+
+Both devices speak the same vendor protocol (`bRequest` 0x85 read / 0x05 write) but with different config layouts: the Wave XLR uses a 34-byte block (gain uint16 @0, mute @4, HP volume int16 Q8.8 @9, knob mode @14, low-Z @33), the Wave:3 a 16-byte block (gain uint16 Q8.8 dB @0, mute @4, HP volume int16 Q8.8 @7, monitor mix uint16 Q8.8 percent @10, dial mode @12 — 1=gain, 2=headphones, 3=mix). Per-model constants live in `wavexlr/profiles.py`; `python3 -m wavexlr.probe` (`dump` / `watch` / `poke`) verifies a device against its profile and helps map new fields.
 
 ## Install
 
@@ -79,6 +88,8 @@ Copy `wavexlr.desktop` to `~/.local/share/applications/` for app launcher integr
 ```
 wavexlr/
   device.py   — USB backend (raw libusb via ctypes, wIndex=0x3303 trick)
+  profiles.py — per-model protocol constants and capabilities
+  probe.py    — vendor protocol verification CLI (dump / watch / poke)
   app.py      — GTK4/Adwaita UI with 10Hz polling
   tray.py     — StatusNotifierItem tray icon via D-Bus
   audio.py    — PipeWire capture keepalive (fixes firmware race condition)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,12 @@ OpenWave detects your init system at runtime:
 
 ### Start hidden in tray
 ```bash
-python3 -m wavexlr -- --hide
+python3 -m wavexlr --hide
+```
+
+### Start at login
+```bash
+cp /usr/share/openwave/openwave-autostart.desktop ~/.config/autostart/
 ```
 
 ### Desktop entry

--- a/openwave-autostart.desktop
+++ b/openwave-autostart.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=OpenWave
+Comment=Elgato Wave Control for Linux
+Exec=openwave --hide
+Icon=audio-input-microphone
+Type=Application
+Categories=Audio;Settings;

--- a/wavexlr.desktop
+++ b/wavexlr.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=OpenWave
-Comment=Elgato Wave XLR Control for Linux
+Comment=Elgato Wave Control for Linux
 Exec=python3 -m wavexlr
 Icon=audio-input-microphone
 Type=Application

--- a/wavexlr/app.py
+++ b/wavexlr/app.py
@@ -1,4 +1,4 @@
-"""OpenWave — GTK4 + Adwaita control application for the Elgato Wave XLR."""
+"""OpenWave — GTK4 + Adwaita control application for Elgato Wave devices."""
 
 import gi
 gi.require_version('Gtk', '4.0')
@@ -10,7 +10,7 @@ import os
 import sys
 import threading
 
-from .device import WaveXLR
+from .device import WaveDevice
 from .meter import MeterMonitor
 from .mixer import Mixer
 from .mixmatrix import MixMatrix
@@ -19,20 +19,22 @@ from . import setup, service, sources as sources_module
 
 logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
 
-GAIN_MAX = 0x5000
+KNOB_LABELS = {"gain": "Gain", "hp": "Headphones", "mix": "Monitor Mix"}
 
 
 class WaveXLRWindow(Adw.ApplicationWindow):
     def __init__(self, **kwargs):
         super().__init__(**kwargs, title="OpenWave", default_width=1100, default_height=620)
         self.set_size_request(900, 520)
-        self.xlr = WaveXLR()
+        self.dev = WaveDevice()
+        self._gain_max = 0x5000
         self._updating_ui = False
         self._last_state = None
         self._poll_id = None
         self._stream_poll_id = None
         self._gain_timeout = None
         self._hp_timeout = None
+        self._mix_timeout = None
         # Debounce slider events to coalesce a flurry of value-changed signals
         # during a drag into one set_cell. {(source_id, mix_id): timeout_id}.
         self._cell_debounce_ids = {}
@@ -114,7 +116,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         )
 
         self.mic_source = self.matrix.add_source(
-            "mic", name="Wave XLR",
+            "mic", name="Microphone",
             icon_name="audio-input-microphone-symbolic",
             has_level=True,
         )
@@ -203,6 +205,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self.knob_label = Gtk.Label(label="Gain")
         self.knob_label.add_css_class("dim-label")
         knob_row.add_suffix(self.knob_label)
+        self.knob_row = knob_row
         mic_group.add(knob_row)
 
         # --- Headphone controls ---
@@ -230,6 +233,26 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         lowz_row.connect("notify::active", self._on_lowz_changed)
         self.lowz_row = lowz_row
         hp_group.add(lowz_row)
+
+        mix_row = Adw.ActionRow(title="Monitor Mix", subtitle="Mic / PC monitoring balance")
+        self.mix_label = Gtk.Label(label="—", width_chars=8, xalign=1)
+        self.mix_label.add_css_class("monospace")
+        mix_row.add_suffix(self.mix_label)
+        self.mix_row = mix_row
+        mix_row.set_visible(False)
+        hp_group.add(mix_row)
+
+        self.mix_scale = Gtk.Scale(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            hexpand=True,
+            draw_value=False,
+            adjustment=Gtk.Adjustment(lower=0, upper=0x6400, step_increment=0x100, page_increment=0x800),
+        )
+        self.mix_scale.set_margin_start(12)
+        self.mix_scale.set_margin_end(12)
+        self.mix_scale.set_visible(False)
+        self.mix_scale.connect("value-changed", self._on_mix_changed)
+        parent.append(self.mix_scale)
 
         # --- Device info ---
         info_group = Adw.PreferencesGroup(title="Device Info")
@@ -304,16 +327,16 @@ class WaveXLRWindow(Adw.ApplicationWindow):
     def _try_connect(self):
         self.status_label.set_label("Connecting...")
         def _connect():
-            self.xlr.disconnect()
-            self.xlr.connect()
+            self.dev.disconnect()
+            self.dev.connect()
             info = {}
             try:
-                info = self.xlr.read_device_info()
+                info = self.dev.read_device_info()
             except Exception:
                 pass
-            return {"state": self.xlr.get_all(), "info": info}
+            return {"state": self.dev.get_all(), "info": info}
         def _done(result):
-            self.status_label.set_label("OpenWave")
+            self._apply_profile(self.dev.profile)
             self.status_label.remove_css_class("dim-label")
             self._apply_state(result["state"])
             info = result["info"]
@@ -339,11 +362,11 @@ class WaveXLRWindow(Adw.ApplicationWindow):
 
     def _poll_tick(self):
         """Called every 100ms — read device state in background."""
-        if not self.xlr.connected:
+        if not self.dev.connected:
             self._poll_id = None
             return False  # stop polling
         # Only poll if not already busy with a user-initiated write
-        self._usb_async(self.xlr.get_all, self._on_poll_result, self._on_poll_error)
+        self._usb_async(self.dev.get_all, self._on_poll_result, self._on_poll_error)
         return True  # keep polling
 
     def _on_poll_result(self, state):
@@ -353,8 +376,27 @@ class WaveXLRWindow(Adw.ApplicationWindow):
     def _on_poll_error(self, e):
         self.status_label.set_label("Disconnected")
         self.status_label.add_css_class("dim-label")
-        self.xlr.disconnect()
+        self.dev.disconnect()
         self._stop_polling()
+
+    def _apply_profile(self, profile):
+        """Adapt the UI to the connected device model."""
+        self._gain_max = profile.gain_max
+        self.gain_scale.get_adjustment().set_upper(profile.gain_max)
+        self.knob_row.set_visible(profile.has_vol_select)
+        self.lowz_row.set_visible(profile.has_low_z)
+        self.mix_row.set_visible(profile.has_monitor_mix)
+        self.mix_scale.set_visible(profile.has_monitor_mix)
+        if profile.has_monitor_mix:
+            self.mix_scale.get_adjustment().set_upper(profile.mix_max)
+        self.mic_source.set_name(profile.display_name)
+        self.status_label.set_label(f"OpenWave — {profile.display_name}")
+
+    def _format_gain(self, raw):
+        scale = self.dev.profile.gain_scale if self.dev.profile else None
+        if scale:
+            return f"{raw / scale:.1f} dB"
+        return f"0x{raw:04X}"
 
     def _apply_state(self, state):
         """Update UI from device state dict (must be called on GTK thread)."""
@@ -362,32 +404,37 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self._last_state = state
         self.mute_row.set_active(state["mute"])
         self.gain_scale.set_value(state["gain_raw"])
-        self.gain_label.set_label(f"0x{state['gain_raw']:04X}")
+        self.gain_label.set_label(self._format_gain(state["gain_raw"]))
         self.hp_scale.set_value(state["hp_volume_db"])
         self.hp_label.set_label(f"{state['hp_volume_db']:.1f} dB")
-        self.lowz_row.set_active(state["low_impedance"])
-        self.knob_label.set_label("Headphones" if state["volume_select"] == "hp" else "Gain")
-        self.mic_source.set_volume(state["gain_raw"] / GAIN_MAX)
+        if "low_impedance" in state:
+            self.lowz_row.set_active(state["low_impedance"])
+        if "volume_select" in state:
+            self.knob_label.set_label(KNOB_LABELS.get(state["volume_select"], "Gain"))
+        if "monitor_mix" in state:
+            self.mix_scale.set_value(state["monitor_mix"])
+            self.mix_label.set_label(f"{state['monitor_mix'] / 256:.0f}%")
+        self.mic_source.set_volume(state["gain_raw"] / self._gain_max)
         self.mic_source.set_muted(state["mute"])
         self._updating_ui = False
 
     def _on_usb_error(self, e):
         self.status_label.set_label("Disconnected")
         self.status_label.add_css_class("dim-label")
-        self.xlr.disconnect()
+        self.dev.disconnect()
         self._stop_polling()
 
     def _on_mute_changed(self, row, _pspec):
-        if self._updating_ui or not self.xlr.connected:
+        if self._updating_ui or not self.dev.connected:
             return
         muted = row.get_active()
-        self._usb_async(lambda: self.xlr.set_mute(muted), on_error=self._on_usb_error)
+        self._usb_async(lambda: self.dev.set_mute(muted), on_error=self._on_usb_error)
 
     def _on_gain_changed(self, scale):
-        if self._updating_ui or not self.xlr.connected:
+        if self._updating_ui or not self.dev.connected:
             return
         val = int(scale.get_value())
-        self.gain_label.set_label(f"0x{val:04X}")
+        self.gain_label.set_label(self._format_gain(val))
         # Debounce — only send after slider stops moving for 200ms
         if hasattr(self, '_gain_timeout') and self._gain_timeout:
             GLib.source_remove(self._gain_timeout)
@@ -395,11 +442,11 @@ class WaveXLRWindow(Adw.ApplicationWindow):
 
     def _send_gain(self, val):
         self._gain_timeout = None
-        self._usb_async(lambda: self.xlr.set_gain_raw(val), on_error=self._on_usb_error)
+        self._usb_async(lambda: self.dev.set_gain_raw(val), on_error=self._on_usb_error)
         return False
 
     def _on_hp_changed(self, scale):
-        if self._updating_ui or not self.xlr.connected:
+        if self._updating_ui or not self.dev.connected:
             return
         db = scale.get_value()
         self.hp_label.set_label(f"{db:.1f} dB")
@@ -409,20 +456,34 @@ class WaveXLRWindow(Adw.ApplicationWindow):
 
     def _send_hp(self, db):
         self._hp_timeout = None
-        self._usb_async(lambda: self.xlr.set_hp_volume_db(db), on_error=self._on_usb_error)
+        self._usb_async(lambda: self.dev.set_hp_volume_db(db), on_error=self._on_usb_error)
         return False
 
     def _on_lowz_changed(self, row, _pspec):
-        if self._updating_ui or not self.xlr.connected:
+        if self._updating_ui or not self.dev.connected:
             return
         enabled = row.get_active()
-        self._usb_async(lambda: self.xlr.set_low_impedance(enabled), on_error=self._on_usb_error)
+        self._usb_async(lambda: self.dev.set_low_impedance(enabled), on_error=self._on_usb_error)
+
+    def _on_mix_changed(self, scale):
+        if self._updating_ui or not self.dev.connected:
+            return
+        val = int(scale.get_value())
+        self.mix_label.set_label(f"{val / 256:.0f}%")
+        if self._mix_timeout:
+            GLib.source_remove(self._mix_timeout)
+        self._mix_timeout = GLib.timeout_add(200, self._send_mix, val)
+
+    def _send_mix(self, val):
+        self._mix_timeout = None
+        self._usb_async(lambda: self.dev.set_monitor_mix(val), on_error=self._on_usb_error)
+        return False
 
     def _on_mic_matrix_volume_changed(self, _source, value):
-        if self._updating_ui or not self.xlr.connected:
+        if self._updating_ui or not self.dev.connected:
             return
-        raw = int(value * GAIN_MAX)
-        self.gain_label.set_label(f"0x{raw:04X}")
+        raw = int(value * self._gain_max)
+        self.gain_label.set_label(self._format_gain(raw))
         self._updating_ui = True
         self.gain_scale.set_value(raw)
         self._updating_ui = False
@@ -431,12 +492,12 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self._gain_timeout = GLib.timeout_add(200, self._send_gain, raw)
 
     def _on_mic_matrix_mute_toggled(self, _source, muted):
-        if self._updating_ui or not self.xlr.connected:
+        if self._updating_ui or not self.dev.connected:
             return
         self._updating_ui = True
         self.mute_row.set_active(muted)
         self._updating_ui = False
-        self._usb_async(lambda: self.xlr.set_mute(muted), on_error=self._on_usb_error)
+        self._usb_async(lambda: self.dev.set_mute(muted), on_error=self._on_usb_error)
 
     def _wire_matrix_cells(self):
         """Bind each per-cell slider/mute to the mixer + restore persisted levels."""
@@ -661,10 +722,10 @@ class WaveXLRApp(Adw.Application):
         self.hold()
 
     def _toggle_mute(self):
-        if self._window and self._window.xlr.connected:
+        if self._window and self._window.dev.connected:
             current = self._window._last_state and self._window._last_state.get("mute", False)
             self._window._usb_async(
-                lambda: self._window.xlr.set_mute(not current),
+                lambda: self._window.dev.set_mute(not current),
                 on_error=self._window._on_usb_error,
             )
 
@@ -706,7 +767,7 @@ class WaveXLRApp(Adw.Application):
         if success:
             replug_dialog = Adw.AlertDialog(
                 heading="Setup Complete",
-                body=f"{message}.\n\nPlease replug your Wave XLR, then click Continue.",
+                body=f"{message}.\n\nPlease replug your Elgato Wave device, then click Continue.",
             )
             replug_dialog.add_response("continue", "Continue")
             replug_dialog.set_default_response("continue")
@@ -734,7 +795,7 @@ class WaveXLRApp(Adw.Application):
     def do_shutdown(self):
         if self._window:
             self._window._stop_polling()
-            self._window.xlr.disconnect()
+            self._window.dev.disconnect()
         Adw.Application.do_shutdown(self)
 
 

--- a/wavexlr/audio.py
+++ b/wavexlr/audio.py
@@ -1,7 +1,7 @@
 """
-Wave XLR PipeWire audio manager.
+Elgato Wave PipeWire audio manager (Wave XLR, Wave:3).
 
-The Wave XLR is a UAC1 USB device whose capture and playback iso endpoints
+These are UAC1 USB devices whose capture and playback iso endpoints
 share a single audio clock. Anything that triggers a format renegotiation
 or stream tear-down on the kernel-side ALSA stream takes both directions
 silent for the duration. WirePlumber's idle-suspend behavior, plus apps
@@ -30,7 +30,7 @@ import logging
 
 log = logging.getLogger("wavexlr.audio")
 
-SOURCE_MATCH = "alsa_input.usb-Elgato_Systems_Elgato_Wave_XLR"
+SOURCE_MATCH = "alsa_input.usb-Elgato_Systems_Elgato_Wave_"
 
 # Seconds without byte flow before we consider the keepalive wedged. At
 # 48 kHz mono s16 the healthy rate is ~96 kB/s, so even 1s of silence is
@@ -71,7 +71,7 @@ def _pw_dump():
 
 
 def _get_source_node_name():
-    """Get the full node name of the Wave XLR source."""
+    """Get the full node name of the Elgato Wave source."""
     for obj in _pw_dump():
         if obj.get("type") != "PipeWire:Interface:Node":
             continue

--- a/wavexlr/device.py
+++ b/wavexlr/device.py
@@ -1,9 +1,12 @@
-"""Wave XLR USB device backend.
+"""Elgato Wave USB device backend.
 
 Uses raw libusb control transfers with wIndex=0x3303 to bypass the Linux
 kernel's interface routing. The kernel sees interface 3 (unclaimed) and
 lets the transfer through, while the firmware only checks the 0x33 prefix.
 No driver detach needed — audio is never interrupted.
+
+Per-model constants (USB IDs, config offsets, capabilities) live in
+profiles.py; connect() picks the first supported device found.
 """
 
 import ctypes
@@ -12,26 +15,13 @@ import struct
 import subprocess
 import threading
 
-VENDOR_ID = 0x0FD9
-PRODUCT_ID = 0x007D
+from .profiles import PROFILES
 
 BREQUEST_READ = 0x85
 BREQUEST_WRITE = 0x05
-WVALUE_CONFIG = 0x0000
-WVALUE_METER = 0x0001
-WVALUE_DEVINFO = 0x000A
-WINDEX = 0x3303  # 0x3303 not 0x3300 — bypasses snd-usb-audio ownership check
-CONFIG_LEN = 34
-METER_LEN = 10
 
 RT_CLASS_IN = 0xA1
 RT_CLASS_OUT = 0x21
-
-OFF_GAIN = 0
-OFF_MUTE = 4
-OFF_HP_VOL = 9
-OFF_VOL_SELECT = 14
-OFF_LOW_Z = 33
 
 # --- Raw libusb setup ---
 _lib_path = ctypes.util.find_library("usb-1.0") or "libusb-1.0.so.0"
@@ -54,12 +44,12 @@ _ctx = ctypes.c_void_p()
 _lib.libusb_init(ctypes.byref(_ctx))
 
 
-def _find_card():
-    """Find the ALSA card number for the Wave XLR."""
+def _find_card(matches):
+    """Find the ALSA card number for the device."""
     try:
         r = subprocess.run(["aplay", "-l"], capture_output=True, text=True, timeout=3)
         for line in r.stdout.splitlines():
-            if "Wave XLR" in line or "Elgato" in line:
+            if any(m in line for m in matches):
                 return line.split(":")[0].split()[-1]
     except Exception:
         pass
@@ -104,41 +94,45 @@ def _alsa_set_hp_vol(card, value):
     _amixer(card, "cset", "numid=4", str(max(0, min(120, value))))
 
 
-def _fw_hp_to_alsa(fw_hp_raw):
+def _fw_hp_to_alsa(fw_hp_raw, scale):
     """Map firmware HP to ALSA (0-120).
 
-    Firmware: int16 Q8.8, range -32768 (-128 dB) to 0 (0 dB).
+    Firmware: raw / scale dB (XLR: int16 Q8.8, Wave:3: int8 whole-dB).
     ALSA driver caps lower at 0 → -60 dB; anything below saturates.
     ALSA step = 0.5 dB, so dB = (value - 120) * 0.5 → value = dB / 0.5 + 120.
     """
-    db = fw_hp_raw / 256.0
+    db = fw_hp_raw / scale
     return max(0, min(120, round(db / 0.5 + 120)))
 
 
-def _alsa_hp_to_fw(alsa_hp):
-    """Map ALSA HP (0-120) to firmware HP (int16 Q8.8)."""
+def _alsa_hp_to_fw(alsa_hp, scale):
+    """Map ALSA HP (0-120) to firmware HP raw."""
     db = (alsa_hp - 120) * 0.5  # 0→-60, 120→0
     db = max(-128.0, min(0.0, db))  # firmware range
-    return int(db * 256)
+    return int(db * scale)
 
 
-class WaveXLR:
+class WaveDevice:
     def __init__(self):
         self._handle = None
         self._lock = threading.Lock()
         self._card = None
         self._last_fw = None  # last known firmware state for change detection
+        self.profile = None
 
     @property
     def connected(self):
         return self._handle is not None
 
     def connect(self):
-        handle = _lib.libusb_open_device_with_vid_pid(_ctx, VENDOR_ID, PRODUCT_ID)
-        if not handle:
-            raise RuntimeError("Wave XLR not found")
-        self._handle = handle
-        self._card = _find_card()
+        for profile in PROFILES:
+            handle = _lib.libusb_open_device_with_vid_pid(_ctx, profile.vid, profile.pid)
+            if handle:
+                self._handle = handle
+                self.profile = profile
+                self._card = _find_card(profile.card_match)
+                return
+        raise RuntimeError("No supported Elgato Wave device found")
 
     def disconnect(self):
         if self._handle:
@@ -152,7 +146,7 @@ class WaveXLR:
         buf = (ctypes.c_ubyte * length)()
         with self._lock:
             ret = _lib.libusb_control_transfer(
-                self._handle, RT_CLASS_IN, BREQUEST_READ, wValue, WINDEX,
+                self._handle, RT_CLASS_IN, BREQUEST_READ, wValue, self.profile.windex,
                 buf, length, 1000,
             )
         if ret < 0:
@@ -165,58 +159,71 @@ class WaveXLR:
         buf = (ctypes.c_ubyte * len(data))(*data)
         with self._lock:
             ret = _lib.libusb_control_transfer(
-                self._handle, RT_CLASS_OUT, BREQUEST_WRITE, wValue, WINDEX,
+                self._handle, RT_CLASS_OUT, BREQUEST_WRITE, wValue, self.profile.windex,
                 buf, len(data), 1000,
             )
         if ret < 0:
             raise RuntimeError(f"USB write failed (err {ret})")
 
     def read_config(self):
-        return self._ctrl_read(WVALUE_CONFIG, CONFIG_LEN)
+        return self._ctrl_read(self.profile.wvalue_config, self.profile.config_len)
 
     def write_config(self, config):
-        self._ctrl_write(WVALUE_CONFIG, config)
+        self._ctrl_write(self.profile.wvalue_config, config)
 
     def read_meters(self):
-        data = self._ctrl_read(WVALUE_METER, METER_LEN)
+        data = self._ctrl_read(self.profile.wvalue_meter, self.profile.meter_len)
         left = struct.unpack_from('<I', data, 0)[0]
         right = struct.unpack_from('<I', data, 4)[0]
         return left, right
 
     def read_device_info(self):
-        """Read and parse the 51-byte device info block."""
-        data = self._ctrl_read(WVALUE_DEVINFO, 51)
-        serial = bytes(data[27:47]).decode('ascii', errors='replace').rstrip('\x00')
+        """Read and parse the device info block."""
+        p = self.profile
+        data = self._ctrl_read(p.wvalue_devinfo, p.devinfo_len)
+        serial = bytes(data[p.devinfo_serial[0]:p.devinfo_serial[1]]).decode(
+            'ascii', errors='replace').rstrip('\x00')
         return {
-            "api_version": f"{data[0]}.{data[1]}",
-            "fw_version": f"{data[6]}.{data[7]}.{data[8]}",
+            "api_version": f"{data[p.devinfo_api[0]]}.{data[p.devinfo_api[1]]}",
+            "fw_version": f"{data[p.devinfo_fw[0]]}.{data[p.devinfo_fw[1]]}.{data[p.devinfo_fw[2]]}",
             "serial": serial,
         }
 
     # --- High-level getters ---
 
     def get_gain_raw(self):
-        return struct.unpack_from('<H', self.read_config(), OFF_GAIN)[0]
+        return struct.unpack_from('<H', self.read_config(), self.profile.off_gain)[0]
 
     def get_mute(self):
-        return bool(self.read_config()[OFF_MUTE])
+        return bool(self.read_config()[self.profile.off_mute])
 
     def get_hp_volume_db(self):
-        raw = struct.unpack_from('<h', self.read_config(), OFF_HP_VOL)[0]
-        return raw / 256.0
+        p = self.profile
+        raw = struct.unpack_from(p.hp_fmt, self.read_config(), p.off_hp_vol)[0]
+        return raw / p.hp_scale
 
     def get_low_impedance(self):
-        return bool(self.read_config()[OFF_LOW_Z])
+        if self.profile.off_low_z is None:
+            return None
+        return bool(self.read_config()[self.profile.off_low_z])
 
     def get_volume_select(self):
-        val = self.read_config()[OFF_VOL_SELECT]
-        return "hp" if val == 2 else "gain"
+        if self.profile.off_vol_select is None:
+            return None
+        val = self.read_config()[self.profile.off_vol_select]
+        return self.profile.vol_select_map.get(val, "gain")
+
+    def get_monitor_mix(self):
+        if self.profile.off_monitor_mix is None:
+            return None
+        return struct.unpack_from('<H', self.read_config(), self.profile.off_monitor_mix)[0]
 
     def get_all(self):
+        p = self.profile
         config = self.read_config()
-        fw_gain = struct.unpack_from('<H', config, OFF_GAIN)[0]
-        fw_hp = struct.unpack_from('<h', config, OFF_HP_VOL)[0]
-        fw_mute = bool(config[OFF_MUTE])
+        fw_gain = struct.unpack_from('<H', config, p.off_gain)[0]
+        fw_hp = struct.unpack_from(p.hp_fmt, config, p.off_hp_vol)[0]
+        fw_mute = bool(config[p.off_mute])
 
         fw_now = {"mute": fw_mute, "gain": fw_gain, "hp": fw_hp}
 
@@ -227,25 +234,29 @@ class WaveXLR:
 
             if self._last_fw is not None:
                 # --- Mute ---
-                if fw_mute != self._last_fw["mute"]:
-                    _alsa_set_mute(self._card, fw_mute)
-                elif alsa.get("mute") is not None and alsa["mute"] != fw_mute:
-                    config[OFF_MUTE] = 0x01 if alsa["mute"] else 0x00
-                    fw_mute = alsa["mute"]
-                    dirty = True
+                if p.sync_alsa_mute:
+                    if fw_mute != self._last_fw["mute"]:
+                        _alsa_set_mute(self._card, fw_mute)
+                    elif alsa.get("mute") is not None and alsa["mute"] != fw_mute:
+                        config[p.off_mute] = 0x01 if alsa["mute"] else 0x00
+                        fw_mute = alsa["mute"]
+                        dirty = True
 
                 # --- HP volume ---
-                if fw_hp != self._last_fw["hp"]:
-                    _alsa_set_hp_vol(self._card, _fw_hp_to_alsa(fw_hp))
-                elif "hp_vol" in alsa and alsa["hp_vol"] != _fw_hp_to_alsa(self._last_fw["hp"]):
-                    fw_hp = _alsa_hp_to_fw(alsa["hp_vol"])
-                    struct.pack_into('<h', config, OFF_HP_VOL, fw_hp)
-                    dirty = True
+                if p.sync_alsa_hp:
+                    if fw_hp != self._last_fw["hp"]:
+                        _alsa_set_hp_vol(self._card, _fw_hp_to_alsa(fw_hp, p.hp_scale))
+                    elif "hp_vol" in alsa and alsa["hp_vol"] != _fw_hp_to_alsa(self._last_fw["hp"], p.hp_scale):
+                        fw_hp = _alsa_hp_to_fw(alsa["hp_vol"], p.hp_scale)
+                        struct.pack_into(p.hp_fmt, config, p.off_hp_vol, fw_hp)
+                        dirty = True
 
             else:
                 # First poll — sync firmware state to ALSA
-                _alsa_set_mute(self._card, fw_mute)
-                _alsa_set_hp_vol(self._card, _fw_hp_to_alsa(fw_hp))
+                if p.sync_alsa_mute:
+                    _alsa_set_mute(self._card, fw_mute)
+                if p.sync_alsa_hp:
+                    _alsa_set_hp_vol(self._card, _fw_hp_to_alsa(fw_hp, p.hp_scale))
 
             if dirty:
                 self.write_config(config)
@@ -254,45 +265,65 @@ class WaveXLR:
         else:
             self._last_fw = fw_now
 
-        return {
+        state = {
             "gain_raw": fw_gain,
             "mute": fw_mute,
-            "hp_volume_db": fw_hp / 256.0,
-            "volume_select": "hp" if config[OFF_VOL_SELECT] == 2 else "gain",
-            "low_impedance": bool(config[OFF_LOW_Z]),
+            "hp_volume_db": fw_hp / p.hp_scale,
         }
+        if p.off_vol_select is not None:
+            state["volume_select"] = p.vol_select_map.get(config[p.off_vol_select], "gain")
+        if p.off_low_z is not None:
+            state["low_impedance"] = bool(config[p.off_low_z])
+        if p.off_monitor_mix is not None:
+            state["monitor_mix"] = struct.unpack_from('<H', config, p.off_monitor_mix)[0]
+        return state
 
     # --- High-level setters (read-modify-write) ---
 
     def set_gain_raw(self, value):
         value = max(0, min(0xFFFF, value))
         config = self.read_config()
-        struct.pack_into('<H', config, OFF_GAIN, value)
+        struct.pack_into('<H', config, self.profile.off_gain, value)
         self.write_config(config)
         if self._last_fw:
             self._last_fw["gain"] = value
 
     def set_mute(self, muted):
         config = self.read_config()
-        config[OFF_MUTE] = 0x01 if muted else 0x00
+        config[self.profile.off_mute] = 0x01 if muted else 0x00
         self.write_config(config)
         if self._last_fw:
             self._last_fw["mute"] = muted
-        if self._card:
+        if self._card and self.profile.sync_alsa_mute:
             _alsa_set_mute(self._card, muted)
 
     def set_hp_volume_db(self, db):
+        p = self.profile
         db = max(-128.0, min(0.0, db))
-        raw = int(db * 256)
+        raw = int(db * p.hp_scale)
         config = self.read_config()
-        struct.pack_into('<h', config, OFF_HP_VOL, raw)
+        struct.pack_into(p.hp_fmt, config, p.off_hp_vol, raw)
         self.write_config(config)
         if self._last_fw:
             self._last_fw["hp"] = raw
-        if self._card:
-            _alsa_set_hp_vol(self._card, _fw_hp_to_alsa(raw))
+        if self._card and p.sync_alsa_hp:
+            _alsa_set_hp_vol(self._card, _fw_hp_to_alsa(raw, p.hp_scale))
 
     def set_low_impedance(self, enabled):
+        if self.profile.off_low_z is None:
+            return
         config = self.read_config()
-        config[OFF_LOW_Z] = 0x01 if enabled else 0x00
+        config[self.profile.off_low_z] = 0x01 if enabled else 0x00
         self.write_config(config)
+
+    def set_monitor_mix(self, value):
+        p = self.profile
+        if p.off_monitor_mix is None:
+            return
+        value = max(0, min(p.mix_max, int(value)))
+        config = self.read_config()
+        struct.pack_into('<H', config, p.off_monitor_mix, value)
+        self.write_config(config)
+
+
+WaveXLR = WaveDevice

--- a/wavexlr/device.py
+++ b/wavexlr/device.py
@@ -94,6 +94,17 @@ def _alsa_set_hp_vol(card, value):
     _amixer(card, "cset", "numid=4", str(max(0, min(120, value))))
 
 
+def _alsa_set_gain(card, value):
+    """Set ALSA mic gain (numid=6, 0-80)."""
+    _amixer(card, "cset", "numid=6", str(max(0, min(80, value))))
+
+
+def _fw_gain_to_alsa(fw_gain_raw, scale):
+    """Map firmware gain (raw / scale dB) to ALSA (0-80, 0.5 dB steps)."""
+    db = fw_gain_raw / scale
+    return max(0, min(80, round(db / 0.5)))
+
+
 def _fw_hp_to_alsa(fw_hp_raw, scale):
     """Map firmware HP to ALSA (0-120).
 
@@ -251,12 +262,19 @@ class WaveDevice:
                         struct.pack_into(p.hp_fmt, config, p.off_hp_vol, fw_hp)
                         dirty = True
 
+                # --- Gain (push only: ALSA writes mirror back into firmware) ---
+                if p.sync_alsa_gain:
+                    if fw_gain != self._last_fw["gain"]:
+                        _alsa_set_gain(self._card, _fw_gain_to_alsa(fw_gain, p.gain_scale))
+
             else:
                 # First poll — sync firmware state to ALSA
                 if p.sync_alsa_mute:
                     _alsa_set_mute(self._card, fw_mute)
                 if p.sync_alsa_hp:
                     _alsa_set_hp_vol(self._card, _fw_hp_to_alsa(fw_hp, p.hp_scale))
+                if p.sync_alsa_gain:
+                    _alsa_set_gain(self._card, _fw_gain_to_alsa(fw_gain, p.gain_scale))
 
             if dirty:
                 self.write_config(config)
@@ -287,6 +305,8 @@ class WaveDevice:
         self.write_config(config)
         if self._last_fw:
             self._last_fw["gain"] = value
+        if self._card and self.profile.sync_alsa_gain:
+            _alsa_set_gain(self._card, _fw_gain_to_alsa(value, self.profile.gain_scale))
 
     def set_mute(self, muted):
         config = self.read_config()

--- a/wavexlr/mixer.py
+++ b/wavexlr/mixer.py
@@ -67,12 +67,12 @@ def find_wave_xlr_alsa():
     """Return (mic_node_name, hp_node_name); either may be None if unplugged."""
     mic = next(
         (p[1] for p in _pactl_short("sources")
-         if len(p) > 1 and p[1].startswith("alsa_input") and "Wave_XLR" in p[1]),
+         if len(p) > 1 and p[1].startswith("alsa_input") and "Elgato_Wave_" in p[1]),
         None,
     )
     hp = next(
         (p[1] for p in _pactl_short("sinks")
-         if len(p) > 1 and p[1].startswith("alsa_output") and "Wave_XLR" in p[1]),
+         if len(p) > 1 and p[1].startswith("alsa_output") and "Elgato_Wave_" in p[1]),
         None,
     )
     return mic, hp

--- a/wavexlr/mixmatrix.py
+++ b/wavexlr/mixmatrix.py
@@ -239,6 +239,9 @@ class SourceCell(Gtk.Box):
             remove_btn.connect("clicked", lambda _: self.emit("remove-clicked"))
             inner.append(remove_btn)
 
+    def set_name(self, name):
+        self._name_lbl.set_label(name)
+
     def set_volume(self, value):
         """Update the master slider without firing the changed signal."""
         with GObject.signal_handler_block(self._scale, self._scale_handler):

--- a/wavexlr/probe.py
+++ b/wavexlr/probe.py
@@ -1,0 +1,123 @@
+"""Vendor protocol probe — verify a device behaves like the known profiles.
+
+    python3 -m wavexlr.probe dump [--wvalue 0xN] [--len 512]
+    python3 -m wavexlr.probe watch [--interval 0.1]
+    python3 -m wavexlr.probe poke --offset N --byte 0xNN
+    python3 -m wavexlr.probe poke --noop
+
+dump with no --wvalue reads the profile's config/meter/devinfo blocks and
+reports the actual returned lengths. watch polls the config block and prints
+per-offset byte diffs while you twiddle the hardware controls.
+"""
+
+import argparse
+import sys
+import time
+
+from .device import WaveDevice
+
+
+def _hexdump(data):
+    for i in range(0, len(data), 16):
+        chunk = data[i:i + 16]
+        hexs = " ".join(f"{b:02x}" for b in chunk)
+        text = "".join(chr(b) if 32 <= b < 127 else "." for b in chunk)
+        print(f"  {i:04x}  {hexs:<47}  {text}")
+
+
+def _read(dev, wvalue, length):
+    try:
+        data = dev._ctrl_read(wvalue, length)
+    except RuntimeError as e:
+        print(f"wValue 0x{wvalue:04X}: {e}")
+        return None
+    print(f"wValue 0x{wvalue:04X}: {len(data)} bytes")
+    _hexdump(data)
+    return data
+
+
+def cmd_dump(dev, args):
+    if args.wvalue is not None:
+        _read(dev, args.wvalue, args.len)
+        return
+    p = dev.profile
+    for name, wvalue, expected in (
+        ("config", p.wvalue_config, p.config_len),
+        ("meter", p.wvalue_meter, p.meter_len),
+        ("devinfo", p.wvalue_devinfo, p.devinfo_len),
+    ):
+        print(f"-- {name} (expected {expected} bytes)")
+        data = _read(dev, wvalue, args.len)
+        if data is not None and len(data) != expected:
+            print(f"   DEVIATION: expected {expected} bytes, got {len(data)}")
+
+
+def cmd_watch(dev, args):
+    last = dev.read_config()
+    print(f"config: {len(last)} bytes — twiddle controls, Ctrl+C to stop")
+    _hexdump(last)
+    while True:
+        time.sleep(args.interval)
+        cur = dev.read_config()
+        if cur != last:
+            ts = time.strftime("%H:%M:%S")
+            for off, (a, b) in enumerate(zip(last, cur)):
+                if a != b:
+                    print(f"{ts}  off {off:2d}: {a:02x} -> {b:02x}")
+            last = cur
+
+
+def cmd_poke(dev, args):
+    config = dev.read_config()
+    if args.noop:
+        dev.write_config(config)
+        print(f"wrote back {len(config)} bytes unchanged")
+        return
+    if args.offset is None or args.byte is None:
+        sys.exit("poke needs --offset and --byte (or --noop)")
+    old = config[args.offset]
+    print(f"off {args.offset}: {old:02x} -> {args.byte:02x}")
+    if not args.yes and input("write? [y/N] ").strip().lower() != "y":
+        return
+    config[args.offset] = args.byte
+    dev.write_config(config)
+    _hexdump(dev.read_config())
+
+
+def main():
+    parser = argparse.ArgumentParser(prog="python3 -m wavexlr.probe")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    d = sub.add_parser("dump")
+    d.add_argument("--wvalue", type=lambda x: int(x, 0))
+    d.add_argument("--len", type=lambda x: int(x, 0), default=512)
+
+    w = sub.add_parser("watch")
+    w.add_argument("--interval", type=float, default=0.1)
+
+    k = sub.add_parser("poke")
+    k.add_argument("--offset", type=lambda x: int(x, 0))
+    k.add_argument("--byte", type=lambda x: int(x, 0))
+    k.add_argument("--noop", action="store_true")
+    k.add_argument("--yes", action="store_true")
+
+    args = parser.parse_args()
+    sys.stdout.reconfigure(line_buffering=True)
+
+    dev = WaveDevice()
+    try:
+        dev.connect()
+    except RuntimeError as e:
+        sys.exit(str(e))
+    print(f"connected: {dev.profile.display_name} (card {dev._card})")
+
+    try:
+        {"dump": cmd_dump, "watch": cmd_watch, "poke": cmd_poke}[args.cmd](dev, args)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        dev.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/wavexlr/probe.py
+++ b/wavexlr/probe.py
@@ -8,6 +8,9 @@
 dump with no --wvalue reads the profile's config/meter/devinfo blocks and
 reports the actual returned lengths. watch polls the config block and prints
 per-offset byte diffs while you twiddle the hardware controls.
+
+The device services vendor transfers from only one process at a time — quit
+OpenWave (including the tray icon) before probing, or reads fail with -EIO.
 """
 
 import argparse

--- a/wavexlr/profiles.py
+++ b/wavexlr/profiles.py
@@ -1,0 +1,124 @@
+"""Per-model device profiles: USB protocol constants and capabilities.
+
+Config offsets set to None mean the device lacks that feature.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DeviceProfile:
+    key: str
+    display_name: str
+    vid: int
+    pid: int
+    wvalue_config: int
+    wvalue_meter: int
+    wvalue_devinfo: int
+    windex: int
+    config_len: int
+    meter_len: int
+    devinfo_len: int
+    devinfo_api: tuple
+    devinfo_fw: tuple
+    devinfo_serial: tuple
+    off_gain: int
+    gain_max: int
+    gain_scale: int | None  # raw units per dB; None = opaque raw (hex display)
+    off_mute: int
+    off_hp_vol: int
+    hp_fmt: str  # struct format of the HP volume field
+    hp_scale: int  # raw units per dB
+    off_vol_select: int | None
+    vol_select_map: dict
+    off_low_z: int | None
+    off_monitor_mix: int | None
+    mix_max: int
+    card_match: tuple
+    sync_alsa_mute: bool
+    sync_alsa_hp: bool
+
+    @property
+    def has_low_z(self):
+        return self.off_low_z is not None
+
+    @property
+    def has_vol_select(self):
+        return self.off_vol_select is not None
+
+    @property
+    def has_monitor_mix(self):
+        return self.off_monitor_mix is not None
+
+
+# Values identical to the pre-refactor device.py constants (v1.0.0).
+WAVE_XLR = DeviceProfile(
+    key="wave_xlr",
+    display_name="Wave XLR",
+    vid=0x0FD9,
+    pid=0x007D,
+    wvalue_config=0x0000,
+    wvalue_meter=0x0001,
+    wvalue_devinfo=0x000A,
+    windex=0x3303,
+    config_len=34,
+    meter_len=10,
+    devinfo_len=51,
+    devinfo_api=(0, 1),
+    devinfo_fw=(6, 7, 8),
+    devinfo_serial=(27, 47),
+    off_gain=0,
+    gain_max=0x5000,
+    gain_scale=None,
+    off_mute=4,
+    off_hp_vol=9,
+    hp_fmt='<h',
+    hp_scale=256,
+    off_vol_select=14,
+    vol_select_map={0x02: "hp"},
+    off_low_z=33,
+    off_monitor_mix=None,
+    mix_max=0,
+    card_match=("Wave XLR", "Elgato"),
+    sync_alsa_mute=True,
+    sync_alsa_hp=True,
+)
+
+# Verified on hardware (fw 1.2.2): 16-byte config — gain uint16 Q8.8 dB @0,
+# mute @4, HP volume int16 Q8.8 @7, monitor mix uint16 Q8.8 percent @10
+# (0..0x6400), dial mode @12 (1=gain, 2=hp, 3=mix). ALSA csets mirror into
+# the config block but not the reverse, same one-way coupling as the XLR.
+# Bytes 3 and 5 never moved during probing (Clipguard candidates).
+WAVE3 = DeviceProfile(
+    key="wave3",
+    display_name="Wave:3",
+    vid=0x0FD9,
+    pid=0x0070,
+    wvalue_config=0x0000,
+    wvalue_meter=0x0001,
+    wvalue_devinfo=0x000A,
+    windex=0x3303,
+    config_len=16,
+    meter_len=8,
+    devinfo_len=64,
+    devinfo_api=(0, 1),
+    devinfo_fw=(21, 22, 23),
+    devinfo_serial=(36, 48),
+    off_gain=0,
+    gain_max=0x2800,
+    gain_scale=256,
+    off_mute=4,
+    off_hp_vol=7,
+    hp_fmt='<h',
+    hp_scale=256,
+    off_vol_select=12,
+    vol_select_map={0x01: "gain", 0x02: "hp", 0x03: "mix"},
+    off_low_z=None,
+    off_monitor_mix=10,
+    mix_max=0x6400,
+    card_match=("Wave3", "Elgato"),
+    sync_alsa_mute=True,
+    sync_alsa_hp=True,
+)
+
+PROFILES = (WAVE_XLR, WAVE3)

--- a/wavexlr/profiles.py
+++ b/wavexlr/profiles.py
@@ -37,6 +37,7 @@ class DeviceProfile:
     card_match: tuple
     sync_alsa_mute: bool
     sync_alsa_hp: bool
+    sync_alsa_gain: bool
 
     @property
     def has_low_z(self):
@@ -82,6 +83,7 @@ WAVE_XLR = DeviceProfile(
     card_match=("Wave XLR", "Elgato"),
     sync_alsa_mute=True,
     sync_alsa_hp=True,
+    sync_alsa_gain=False,
 )
 
 # Verified on hardware (fw 1.2.2): 16-byte config — gain uint16 Q8.8 dB @0,
@@ -119,6 +121,7 @@ WAVE3 = DeviceProfile(
     card_match=("Wave3", "Elgato"),
     sync_alsa_mute=True,
     sync_alsa_hp=True,
+    sync_alsa_gain=True,
 )
 
 PROFILES = (WAVE_XLR, WAVE3)

--- a/wavexlr/profiles.py
+++ b/wavexlr/profiles.py
@@ -52,7 +52,6 @@ class DeviceProfile:
         return self.off_monitor_mix is not None
 
 
-# Values identical to the pre-refactor device.py constants (v1.0.0).
 WAVE_XLR = DeviceProfile(
     key="wave_xlr",
     display_name="Wave XLR",
@@ -61,7 +60,7 @@ WAVE_XLR = DeviceProfile(
     wvalue_config=0x0000,
     wvalue_meter=0x0001,
     wvalue_devinfo=0x000A,
-    windex=0x3303,
+    windex=0x3303,  # 0x3303 not 0x3300 — bypasses snd-usb-audio ownership check
     config_len=34,
     meter_len=10,
     devinfo_len=51,
@@ -86,11 +85,6 @@ WAVE_XLR = DeviceProfile(
     sync_alsa_gain=False,
 )
 
-# Verified on hardware (fw 1.2.2): 16-byte config — gain uint16 Q8.8 dB @0,
-# mute @4, HP volume int16 Q8.8 @7, monitor mix uint16 Q8.8 percent @10
-# (0..0x6400), dial mode @12 (1=gain, 2=hp, 3=mix). ALSA csets mirror into
-# the config block but not the reverse, same one-way coupling as the XLR.
-# Bytes 3 and 5 never moved during probing (Clipguard candidates).
 WAVE3 = DeviceProfile(
     key="wave3",
     display_name="Wave:3",
@@ -99,7 +93,7 @@ WAVE3 = DeviceProfile(
     wvalue_config=0x0000,
     wvalue_meter=0x0001,
     wvalue_devinfo=0x000A,
-    windex=0x3303,
+    windex=0x3303,  # 0x3303 not 0x3300 — bypasses snd-usb-audio ownership check
     config_len=16,
     meter_len=8,
     devinfo_len=64,

--- a/wavexlr/setup.py
+++ b/wavexlr/setup.py
@@ -5,7 +5,10 @@ import subprocess
 
 from . import service
 
-UDEV_RULE = 'SUBSYSTEM=="usb", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="007d", MODE="0666"'
+UDEV_RULES = (
+    'SUBSYSTEM=="usb", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="007d", MODE="0666"',  # Wave XLR
+    'SUBSYSTEM=="usb", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="0070", MODE="0666"',  # Wave:3
+)
 UDEV_PATH = "/etc/udev/rules.d/99-openwave.rules"
 UDEV_PATH_OLD = "/etc/udev/rules.d/99-wavexlr.rules"
 
@@ -33,8 +36,9 @@ def udev_installed():
     for path in (UDEV_PATH, UDEV_PATH_OLD):
         try:
             with open(path) as f:
-                if "0fd9" in f.read():
-                    return True
+                content = f.read()
+            if all(pid in content for pid in ("007d", "0070")):
+                return True
         except (FileNotFoundError, PermissionError):
             continue
     return False
@@ -45,7 +49,18 @@ def service_installed():
 
 
 def wireplumber_installed():
-    return os.path.exists(WIREPLUMBER_PATH)
+    try:
+        with open(WIREPLUMBER_PATH) as f:
+            installed = f.read()
+    except OSError:
+        return False
+    for src in WIREPLUMBER_SOURCES:
+        try:
+            with open(src) as f:
+                return f.read() == installed
+        except OSError:
+            continue
+    return True
 
 
 def mixes_installed():
@@ -62,11 +77,15 @@ def needs_setup():
 
 
 def install_udev():
-    """Install udev rule via pkexec."""
+    """Install udev rules via pkexec."""
+    rules = "\n".join(UDEV_RULES)
     script = f"""#!/bin/sh
-echo '{UDEV_RULE}' > {UDEV_PATH}
+cat > {UDEV_PATH} <<'EOF'
+{rules}
+EOF
 udevadm control --reload-rules
 udevadm trigger --subsystem-match=usb --attr-match=idVendor=0fd9 --attr-match=idProduct=007d
+udevadm trigger --subsystem-match=usb --attr-match=idVendor=0fd9 --attr-match=idProduct=0070
 # Also chmod the device node directly so no replug is needed
 for dev in /dev/bus/usb/*/; do
     for f in "$dev"*; do

--- a/wavexlr/tray.py
+++ b/wavexlr/tray.py
@@ -159,7 +159,7 @@ class TrayIcon:
             "Title": GLib.Variant("s", "OpenWave"),
             "Status": GLib.Variant("s", "Active"),
             "IconName": GLib.Variant("s", "audio-input-microphone-symbolic"),
-            "ToolTip": GLib.Variant("(sa(iiay)ss)", ("", [], "OpenWave", "Elgato Wave XLR Control")),
+            "ToolTip": GLib.Variant("(sa(iiay)ss)", ("", [], "OpenWave", "Elgato Wave Control")),
             "Menu": GLib.Variant("o", "/MenuBar"),
             "ItemIsMenu": GLib.Variant("b", False),
         }

--- a/wireplumber/51-openwave-wave-xlr.conf
+++ b/wireplumber/51-openwave-wave-xlr.conf
@@ -1,6 +1,6 @@
-# OpenWave — Elgato Wave XLR (USB ID 0fd9:007d).
+# OpenWave — Elgato Wave XLR (0fd9:007d) and Wave:3 (0fd9:0070).
 #
-# UAC1 device: capture and playback share one iso clock. Format/rate
+# UAC1 devices: capture and playback share one iso clock. Format/rate
 # renegotiation tears down both directions briefly, and is one of the
 # triggers for the keepalive-wedge state the daemon recovers from.
 # The properties below remove most reasons the device would ever be
@@ -21,8 +21,8 @@
 monitor.alsa.rules = [
   {
     matches = [
-      { node.name = "~alsa_input.usb-Elgato_Systems_Elgato_Wave_XLR.*" }
-      { node.name = "~alsa_output.usb-Elgato_Systems_Elgato_Wave_XLR.*" }
+      { node.name = "~alsa_input.usb-Elgato_Systems_Elgato_Wave_.*" }
+      { node.name = "~alsa_output.usb-Elgato_Systems_Elgato_Wave_.*" }
     ]
     actions = {
       update-props = {


### PR DESCRIPTION
Hello there! Thank you for this awesome project, really really useful as I just started out with CachyOS and it's a pain to use the Elgato Wave 3 with linux.

I did create most of the code changes using Claude Code, but I manually reviewed every patch and adjusted where needed. Feel free to change as needed but I hope this PR proves useful.

I tested changing gain, volume, mix and mute status from the OpenWave UI, physically from the microphone, and from the OS's volumes panel. They're all synchronized (as long as OpenWave is running, at least minimized).
Volume restore also seems to be working as expected (OpenWave sends the gain/volume to ALSA, WirePlumber/PipeWire recognizes it, at reboot it sets it back as expected).

Feel free to edit/override as you see fit.

Now to the full description:

OpenWave supports the Wave XLR (`0fd9:007d`). This PR adds support for the **Wave:3** microphone (`0fd9:0070`): gain, mute, headphone volume, monitor mix, dial-mode display, bidirectional hardware ↔ OS volume sync, the capture-fix daemon, and first-run setup.

### Approach

The Wave:3 speaks the same vendor protocol as the XLR (control transfers via the unclaimed vendor interface, `wIndex=0x3303`), but with a different config-block layout. All device-specific constants were moved into per-model profiles (`wavexlr/profiles.py`); `device.py` is parameterized by profile and connects to the first supported device it finds (one device at a time). The Wave XLR profile reproduces the previously hardcoded constants 1:1, so XLR behavior is unchanged.

The Wave:3 layout was reverse-engineered and verified on hardware (fw 1.2.2) — 16-byte config block:

| Field | Offset | Encoding |
|---|---|---|
| Gain | 0–1 | uint16 LE, Q8.8 dB (0 … +40 dB) |
| Mute | 4 | u8, same as XLR |
| HP volume | 7–8 | int16 LE, Q8.8 dB |
| Monitor mix | 10–11 | uint16 LE, Q8.8 percent (0–100%) |
| Dial mode | 12 | 1=gain, 2=headphones, 3=monitor mix |

The UI adapts to the connected model's capabilities: monitor-mix slider (Wave:3), low-impedance toggle (XLR only), gain shown in dB where the firmware works in dB. The probe CLI used for the mapping (`python3 -m wavexlr.probe` — `dump`/`watch`/`poke`) is included to make supporting future devices easier.

### Also in this PR

- udev rules cover both PIDs; setup now detects outdated rules/configs on upgrade and re-installs them
- Daemon, mixer, and WirePlumber node matching generalized to the shared `Elgato_Wave_` prefix
- Wave:3 only: firmware gain changes are pushed to the ALSA `Mic Capture Volume` control, so desktop volume panels follow the physical dial (the XLR exposes no ALSA gain control)
- New `openwave-autostart.desktop` template (installed to `share/openwave/`, opt-in via `~/.config/autostart/`)
- README fix: the start-hidden flag is `--hide`, not `-- --hide` — GLib treats `--` as end-of-options, so the documented form never worked

### Notes

- **Wave XLR changes are verified by inspection only** (profile values diff 1:1 against the old constants; the ALSA sync logic is control-flow identical) — I don't own an XLR to retest on hardware.
- The Wave:3 firmware services vendor requests from **one process at a time**; concurrent access fails with I/O errors. Documented in the README — quit OpenWave before running the probe.
- Clipguard is not implemented: it has no physical control to diff against; config bytes 3 and 5 remain unidentified candidates.
