### PR TITLE
Add support for the Wave XLR MK.2

### DIFF
--- a/wavexlr/app.py
+++ b/wavexlr/app.py
@@ -10,7 +10,7 @@ import os
 import sys
 import threading
 
-from .device import WaveXLR
+from .device import WaveXLR, WaveXLRMk2, detect_pid, PID_MK2
 from .meter import MeterMonitor
 from .mixer import Mixer
 from .mixmatrix import MixMatrix
@@ -31,8 +31,13 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self._last_state = None
         self._poll_id = None
         self._stream_poll_id = None
-        self._gain_timeout = None
-        self._hp_timeout = None
+        # Live-update throttle state for the device sliders (gain, hp).
+        self._thr_pending = {}   # name -> latest value awaiting send
+        self._thr_tid = {}       # name -> GLib timeout id (None = idle)
+        self._thr_send = {}      # name -> setter callable
+        # HP detent dB list when the device has a non-linear (stepped) HP
+        # control; None = continuous dB slider. Set in _apply_caps.
+        self._hp_detents = None
         # Debounce slider events to coalesce a flurry of value-changed signals
         # during a drag into one set_cell. {(source_id, mix_id): timeout_id}.
         self._cell_debounce_ids = {}
@@ -183,7 +188,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         mic_group.add(mute_row)
 
         gain_row = Adw.ActionRow(title="Gain")
-        self.gain_label = Gtk.Label(label="0x0000", width_chars=8, xalign=1)
+        self.gain_label = Gtk.Label(label="—", width_chars=8, xalign=1)
         self.gain_label.add_css_class("monospace")
         gain_row.add_suffix(self.gain_label)
         mic_group.add(gain_row)
@@ -203,6 +208,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self.knob_label = Gtk.Label(label="Gain")
         self.knob_label.add_css_class("dim-label")
         knob_row.add_suffix(self.knob_label)
+        self.knob_row = knob_row
         mic_group.add(knob_row)
 
         # --- Headphone controls ---
@@ -305,6 +311,12 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self.status_label.set_label("Connecting...")
         def _connect():
             self.xlr.disconnect()
+            # Pick the backend for whichever Wave XLR is attached.
+            if detect_pid() == PID_MK2:
+                if not isinstance(self.xlr, WaveXLRMk2):
+                    self.xlr = WaveXLRMk2()
+            elif not isinstance(self.xlr, WaveXLR):
+                self.xlr = WaveXLR()
             self.xlr.connect()
             info = {}
             try:
@@ -315,6 +327,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         def _done(result):
             self.status_label.set_label("OpenWave")
             self.status_label.remove_css_class("dim-label")
+            self._apply_caps()
             self._apply_state(result["state"])
             info = result["info"]
             self.fw_label.set_label(info.get("fw_version", "—"))
@@ -322,6 +335,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
             self.serial_label.set_label(info.get("serial", "—"))
             self._start_polling()
         def _fail(e):
+            logging.getLogger("wavexlr.app").warning("Connect failed: %r", e)
             self.status_label.set_label("Disconnected")
             self.status_label.add_css_class("dim-label")
         self._usb_async(_connect, _done, _fail)
@@ -356,15 +370,51 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self.xlr.disconnect()
         self._stop_polling()
 
+    def _apply_caps(self):
+        """Enable/disable device-specific controls based on backend support."""
+        lowz = getattr(self.xlr, "supports_low_impedance", True)
+        self.lowz_row.set_sensitive(lowz)
+        self.lowz_row.set_subtitle(
+            "For low impedance headphones" if lowz
+            else "Not yet supported on Wave XLR MK.2"
+        )
+        self.knob_row.set_visible(getattr(self.xlr, "supports_volume_select", True))
+
+        # Configure the HP slider: stepped detents (MK.2) or continuous dB (mk1).
+        self._hp_detents = getattr(self.xlr, "hp_detents", None)
+        adj = self.hp_scale.get_adjustment()
+        self._updating_ui = True
+        if self._hp_detents:
+            adj.set_lower(0)
+            adj.set_upper(len(self._hp_detents) - 1)
+            adj.set_step_increment(1)
+            adj.set_page_increment(4)
+        else:
+            adj.set_lower(-60.0)
+            adj.set_upper(0.0)
+            adj.set_step_increment(0.5)
+            adj.set_page_increment(2.0)
+        self._updating_ui = False
+
+    def _hp_detent_index(self, db):
+        """Nearest HP detent index for a dB value (detent mode only)."""
+        return min(range(len(self._hp_detents)),
+                   key=lambda i: abs(self._hp_detents[i] - db))
+
     def _apply_state(self, state):
         """Update UI from device state dict (must be called on GTK thread)."""
         self._updating_ui = True
         self._last_state = state
         self.mute_row.set_active(state["mute"])
         self.gain_scale.set_value(state["gain_raw"])
-        self.gain_label.set_label(f"0x{state['gain_raw']:04X}")
-        self.hp_scale.set_value(state["hp_volume_db"])
-        self.hp_label.set_label(f"{state['hp_volume_db']:.1f} dB")
+        self.gain_label.set_label(self.xlr.format_gain(state["gain_raw"]))
+        if self._hp_detents:
+            idx = self._hp_detent_index(state["hp_volume_db"])
+            self.hp_scale.set_value(idx)
+            self.hp_label.set_label(f"{self._hp_detents[idx]:.1f} dB")
+        else:
+            self.hp_scale.set_value(state["hp_volume_db"])
+            self.hp_label.set_label(f"{state['hp_volume_db']:.1f} dB")
         self.lowz_row.set_active(state["low_impedance"])
         self.knob_label.set_label("Headphones" if state["volume_select"] == "hp" else "Gain")
         self.mic_source.set_volume(state["gain_raw"] / GAIN_MAX)
@@ -383,34 +433,49 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         muted = row.get_active()
         self._usb_async(lambda: self.xlr.set_mute(muted), on_error=self._on_usb_error)
 
+    # Live-update throttle: send on the leading edge, then at most every
+    # _THROTTLE_MS while the value keeps changing, plus a trailing send — so
+    # sliders/wheel move the device in real time without flooding it.
+    _THROTTLE_MS = 80
+
+    def _throttle(self, name, value, send_fn):
+        self._thr_pending[name] = value
+        self._thr_send[name] = send_fn
+        if self._thr_tid.get(name) is None:
+            self._thr_flush(name)
+            self._thr_tid[name] = GLib.timeout_add(self._THROTTLE_MS, self._thr_tick, name)
+
+    def _thr_tick(self, name):
+        if name in self._thr_pending:
+            self._thr_flush(name)
+            return True  # keep ticking while values are still arriving
+        self._thr_tid[name] = None
+        return False
+
+    def _thr_flush(self, name):
+        if name not in self._thr_pending:
+            return
+        value = self._thr_pending.pop(name)
+        send_fn = self._thr_send[name]
+        self._usb_async(lambda: send_fn(value), on_error=self._on_usb_error)
+
     def _on_gain_changed(self, scale):
         if self._updating_ui or not self.xlr.connected:
             return
         val = int(scale.get_value())
-        self.gain_label.set_label(f"0x{val:04X}")
-        # Debounce — only send after slider stops moving for 200ms
-        if hasattr(self, '_gain_timeout') and self._gain_timeout:
-            GLib.source_remove(self._gain_timeout)
-        self._gain_timeout = GLib.timeout_add(200, self._send_gain, val)
-
-    def _send_gain(self, val):
-        self._gain_timeout = None
-        self._usb_async(lambda: self.xlr.set_gain_raw(val), on_error=self._on_usb_error)
-        return False
+        self.gain_label.set_label(self.xlr.format_gain(val))
+        self._throttle("gain", val, self.xlr.set_gain_raw)
 
     def _on_hp_changed(self, scale):
         if self._updating_ui or not self.xlr.connected:
             return
-        db = scale.get_value()
+        if self._hp_detents:
+            idx = max(0, min(len(self._hp_detents) - 1, int(round(scale.get_value()))))
+            db = self._hp_detents[idx]
+        else:
+            db = scale.get_value()
         self.hp_label.set_label(f"{db:.1f} dB")
-        if hasattr(self, '_hp_timeout') and self._hp_timeout:
-            GLib.source_remove(self._hp_timeout)
-        self._hp_timeout = GLib.timeout_add(200, self._send_hp, db)
-
-    def _send_hp(self, db):
-        self._hp_timeout = None
-        self._usb_async(lambda: self.xlr.set_hp_volume_db(db), on_error=self._on_usb_error)
-        return False
+        self._throttle("hp", db, self.xlr.set_hp_volume_db)
 
     def _on_lowz_changed(self, row, _pspec):
         if self._updating_ui or not self.xlr.connected:
@@ -422,13 +487,11 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         if self._updating_ui or not self.xlr.connected:
             return
         raw = int(value * GAIN_MAX)
-        self.gain_label.set_label(f"0x{raw:04X}")
+        self.gain_label.set_label(self.xlr.format_gain(raw))
         self._updating_ui = True
         self.gain_scale.set_value(raw)
         self._updating_ui = False
-        if self._gain_timeout:
-            GLib.source_remove(self._gain_timeout)
-        self._gain_timeout = GLib.timeout_add(200, self._send_gain, raw)
+        self._throttle("gain", raw, self.xlr.set_gain_raw)
 
     def _on_mic_matrix_mute_toggled(self, _source, muted):
         if self._updating_ui or not self.xlr.connected:

--- a/wavexlr/audio.py
+++ b/wavexlr/audio.py
@@ -30,7 +30,10 @@ import logging
 
 log = logging.getLogger("wavexlr.audio")
 
-SOURCE_MATCH = "alsa_input.usb-Elgato_Systems_Elgato_Wave_XLR"
+# Substring of the PipeWire node name. Kept loose ("Wave_XLR" rather than the
+# full Elgato_Systems_Elgato_Wave_XLR prefix) so it matches both the Wave XLR
+# and the Wave XLR mk 2 regardless of their exact USB string descriptors.
+SOURCE_MATCH = "Wave_XLR"
 
 # Seconds without byte flow before we consider the keepalive wedged. At
 # 48 kHz mono s16 the healthy rate is ~96 kB/s, so even 1s of silence is
@@ -77,7 +80,7 @@ def _get_source_node_name():
             continue
         props = obj.get("info", {}).get("props", {})
         name = props.get("node.name", "")
-        if name.startswith(SOURCE_MATCH):
+        if name.startswith("alsa_input") and SOURCE_MATCH in name:
             return name
     return None
 

--- a/wavexlr/device.py
+++ b/wavexlr/device.py
@@ -8,12 +8,22 @@ No driver detach needed — audio is never interrupted.
 
 import ctypes
 import ctypes.util
+import glob
+import logging
+import os
+import re
 import struct
 import subprocess
 import threading
 
+_log = logging.getLogger("wavexlr.device")
+
 VENDOR_ID = 0x0FD9
-PRODUCT_ID = 0x007D
+# Product IDs: MK1 = original UAC1 Wave XLR, MK2 = UAC2 Wave XLR MK.2. They
+# speak different control protocols, so each has its own backend class below
+# (WaveXLR for MK1, WaveXLRMk2 for MK2). detect_pid() picks the right one.
+PID_MK1 = 0x007D
+PID_MK2 = 0x00B6
 
 BREQUEST_READ = 0x85
 BREQUEST_WRITE = 0x05
@@ -123,6 +133,14 @@ def _alsa_hp_to_fw(alsa_hp):
 
 
 class WaveXLR:
+    supports_low_impedance = True
+    supports_volume_select = True
+    hp_detents = None   # continuous dB slider (mk1)
+
+    def format_gain(self, raw):
+        """Human-readable gain for the UI (mk1 gain is an opaque raw value)."""
+        return f"0x{raw:04X}"
+
     def __init__(self):
         self._handle = None
         self._lock = threading.Lock()
@@ -134,7 +152,7 @@ class WaveXLR:
         return self._handle is not None
 
     def connect(self):
-        handle = _lib.libusb_open_device_with_vid_pid(_ctx, VENDOR_ID, PRODUCT_ID)
+        handle = _lib.libusb_open_device_with_vid_pid(_ctx, VENDOR_ID, PID_MK1)
         if not handle:
             raise RuntimeError("Wave XLR not found")
         self._handle = handle
@@ -296,3 +314,364 @@ class WaveXLR:
         config = self.read_config()
         config[OFF_LOW_Z] = 0x01 if enabled else 0x00
         self.write_config(config)
+
+
+# ---------------------------------------------------------------------------
+# Wave XLR MK.2 (0fd9:00b6) backend
+#
+# Unlike the original (UAC1 + vendor control transfers), the MK.2 is a UAC2
+# device that exposes mic mute/gain and headphone volume as standard ALSA
+# feature-unit controls. We drive those via amixer — no vendor protocol, no
+# USB permissions needed for the core controls. Hardware button/dial changes
+# surface in the same ALSA controls, so polling get_all() keeps the UI synced.
+#
+# Low impedance and volume-select live in the vendor settings block (read
+# wValue 0x0004) and need a vendor *write* to change — not wired yet, so the
+# backend reports them unsupported and the UI greys/hides them.
+
+_MK2_UI_GAIN_MAX = 0x5000   # mirror app.GAIN_MAX: mic gain 0..max -> 0..this
+_MK2_HP_DB_MIN = -60.0      # headphone dB range (matches device + UI slider)
+_MK2_HP_DB_MAX = 0.0
+
+# MK.2 vendor control protocol (decoded from a Wave Link USB capture).
+#   read : bmRequestType=0xC1, bRequest=0x01, wValue=block, wIndex=0x0203
+#   write: bmRequestType=0x41, bRequest=0x01, wValue=block, wIndex=0x0203, data=block
+# The analog mic gain is byte 0 of settings block 0x0004 (0..80, == ALSA range).
+# It is firmware-owned: ALSA writes to numid=4 get reverted by PipeWire, but a
+# vendor write changes the real hardware gain (and the device's LED ring).
+_MK2_VINDEX = 0x0203
+_MK2_VREQ = 0x01
+_MK2_RT_VREAD = 0xC1
+_MK2_RT_VWRITE = 0x41
+_MK2_BLOCK_SETTINGS = 0x0004   # byte0=gain, byte1=flags (bit0=mute)
+_MK2_SETTINGS_LEN = 38
+_MK2_GAIN_OFFSET = 0
+_MK2_HW_GAIN_MAX = 80
+_MK2_BLOCK_HP = 0x0005         # byte0=hp volume, byte1=flags (bit1=low impedance)
+_MK2_HP_LEN = 2
+_MK2_HP_VOL_OFFSET = 0         # block 0x0005 byte0 = hp volume (0=loudest..240=quietest)
+_MK2_FLAGS_OFFSET = 1          # byte 1 of these blocks holds flag bits
+_MK2_MUTE_MASK = 0x01          # block 0x0004 byte1 bit0: 1 = muted
+_MK2_LOWZ_MASK = 0x02          # block 0x0005 byte1 bit1: 1 = low impedance on
+
+# Headphone volume is non-linear: the hardware wheel steps through these native
+# byte0 values (captured from a full wheel sweep), loudest(0) -> quietest(240).
+# dB = -byte0/4. The UI slider steps through these so one notch = one hardware
+# detent = one LED step. 240 (=-60 dB, the floor below the lowest wheel detent)
+# is appended so the slider can reach minimum.
+_MK2_HP_DETENTS = [
+    0, 2, 3, 5, 7, 8, 10, 12, 13, 15, 17, 18, 20, 22, 25, 28, 30, 33, 35, 37,
+    40, 43, 45, 48, 50, 53, 57, 60, 63, 67, 70, 73, 77, 80, 83, 87, 90, 97,
+    103, 110, 117, 124, 133, 142, 155, 168, 187, 213, 240,
+]
+# dB per slider index, quietest(index 0) -> loudest(last). app.py uses this.
+_MK2_HP_DETENTS_DB = [-b / 4.0 for b in reversed(_MK2_HP_DETENTS)]
+
+# ALSA control name suffix -> role. The product-string prefix varies between
+# units/firmware, the suffix does not, so match on the suffix.
+_MK2_ROLE_BY_SUFFIX = {
+    "Capture Switch": "mic_mute",
+    "Capture Volume": "mic_gain",
+    "Playback Switch": "hp_mute",
+    "Playback Volume": "hp_vol",
+}
+
+
+def detect_pid():
+    """Return the connected Wave XLR product id (PID_MK1/PID_MK2), or None.
+
+    Reads sysfs only — no USB permissions needed, so this works even before the
+    udev rule is installed."""
+    wanted = {f"{PID_MK1:04x}", f"{PID_MK2:04x}"}
+    for idp in glob.glob("/sys/bus/usb/devices/*/idProduct"):
+        try:
+            with open(idp) as f:
+                pid = f.read().strip().lower()
+            with open(os.path.join(os.path.dirname(idp), "idVendor")) as f:
+                vid = f.read().strip().lower()
+        except OSError:
+            continue
+        if vid == "0fd9" and pid in wanted:
+            return int(pid, 16)
+    return None
+
+
+def _mk2_sysfs_dir():
+    """sysfs device directory for the MK.2, or None."""
+    target = f"{PID_MK2:04x}"
+    for idp in glob.glob("/sys/bus/usb/devices/*/idProduct"):
+        try:
+            with open(idp) as f:
+                pid = f.read().strip().lower()
+            with open(os.path.join(os.path.dirname(idp), "idVendor")) as f:
+                vid = f.read().strip().lower()
+        except OSError:
+            continue
+        if vid == "0fd9" and pid == target:
+            return os.path.dirname(idp)
+    return None
+
+
+def _mk2_find_card():
+    """ALSA card index for the MK.2 via /proc/asound (no perms needed)."""
+    target = f"0fd9:{PID_MK2:04x}"
+    for path in glob.glob("/proc/asound/card*/usbid"):
+        try:
+            with open(path) as f:
+                if f.read().strip().lower() == target:
+                    return path.split("/card", 1)[1].split("/", 1)[0]
+        except OSError:
+            continue
+    return None
+
+
+def _mk2_vendor_read(wValue, length=64):
+    """Best-effort vendor control-IN read (0xC1/0x01/wIndex=3). Needs the udev
+    rule; raises on any failure so callers can degrade gracefully."""
+    handle = _lib.libusb_open_device_with_vid_pid(_ctx, VENDOR_ID, PID_MK2)
+    if not handle:
+        raise RuntimeError("open failed")
+    try:
+        buf = (ctypes.c_ubyte * length)()
+        ret = _lib.libusb_control_transfer(
+            handle, 0xC1, 0x01, wValue, 0x0003, buf, length, 500
+        )
+        if ret < 0:
+            raise RuntimeError(f"read failed ({ret})")
+        return bytearray(buf[:ret])
+    finally:
+        _lib.libusb_close(handle)
+
+
+class WaveXLRMk2:
+    """ALSA-driven backend for the Wave XLR MK.2. Same surface as WaveXLR."""
+
+    supports_low_impedance = True
+    supports_volume_select = False
+    hp_detents = _MK2_HP_DETENTS_DB   # discrete detent slider (quietest..loudest)
+
+    def format_gain(self, raw):
+        """Human-readable gain for the UI: the MK.2 mic gain is 0..80 dB."""
+        return f"{round(raw / _MK2_UI_GAIN_MAX * _MK2_HW_GAIN_MAX)} dB"
+
+    def __init__(self):
+        self._card = None
+        self._numid = {}   # role -> numid
+        self._max = {}     # role -> control max value
+        self._h = None     # libusb handle for the vendor protocol (gain)
+        self._lock = threading.Lock()  # serialize vendor transfers (poll + writes)
+
+    @property
+    def connected(self):
+        return self._card is not None
+
+    def connect(self):
+        card = _mk2_find_card()
+        if card is None:
+            raise RuntimeError("Wave XLR MK.2 not found")
+        self._card = card  # set first so _amixer() works during discovery
+        try:
+            numid, maxv = self._discover()
+        except Exception:
+            self._card = None
+            raise
+        if not {"mic_mute", "mic_gain", "hp_vol"} <= set(numid):
+            self._card = None
+            raise RuntimeError("Wave XLR MK.2 ALSA controls not found")
+        self._numid, self._max = numid, maxv
+        # Best-effort vendor handle for gain read/write (needs the udev rule).
+        self._h = _lib.libusb_open_device_with_vid_pid(_ctx, VENDOR_ID, PID_MK2) or None
+
+    def disconnect(self):
+        if self._h:
+            _lib.libusb_close(self._h)
+            self._h = None
+        self._card = None
+
+    # --- vendor control protocol (gain) ---
+
+    def _vread(self, block, length):
+        buf = (ctypes.c_ubyte * length)()
+        with self._lock:
+            ret = _lib.libusb_control_transfer(
+                self._h, _MK2_RT_VREAD, _MK2_VREQ, block, _MK2_VINDEX, buf, length, 500)
+        if ret < 0:
+            raise RuntimeError(f"vendor read failed ({ret})")
+        return bytearray(buf[:ret])
+
+    def _vwrite(self, block, data):
+        data = bytes(data)
+        buf = (ctypes.c_ubyte * len(data))(*data)
+        with self._lock:
+            ret = _lib.libusb_control_transfer(
+                self._h, _MK2_RT_VWRITE, _MK2_VREQ, block, _MK2_VINDEX, buf, len(data), 500)
+        if ret < 0:
+            raise RuntimeError(f"vendor write failed ({ret})")
+
+    # --- amixer plumbing ---
+
+    def _amixer(self, *args):
+        try:
+            r = subprocess.run(
+                ["amixer", "-c", self._card, *args],
+                capture_output=True, text=True, timeout=3,
+            )
+            return r.stdout
+        except (OSError, subprocess.SubprocessError):
+            return ""
+
+    def _discover(self):
+        """Map control roles to numids and capture each control's max, by
+        scanning `amixer contents` and matching the control-name suffix."""
+        numid, maxv = {}, {}
+        cur_id = cur_name = None
+        for line in self._amixer("contents").splitlines():
+            s = line.strip()
+            m = re.match(r"numid=(\d+),iface=(\w+),name='(.*)'", s)
+            if m:
+                cur_id, iface, cur_name = int(m.group(1)), m.group(2), m.group(3)
+                if iface != "MIXER":
+                    cur_id = cur_name = None
+                continue
+            if cur_id is not None and s.startswith("; type="):
+                role = next((r for suf, r in _MK2_ROLE_BY_SUFFIX.items()
+                             if cur_name.endswith(suf)), None)
+                if role:
+                    numid[role] = cur_id
+                    mm = re.search(r"max=(\d+)", s)
+                    if mm:
+                        maxv[role] = int(mm.group(1))
+        return numid, maxv
+
+    def _values(self):
+        """{numid: value_string} from one `amixer contents` call."""
+        vals = {}
+        cur_id = None
+        for line in self._amixer("contents").splitlines():
+            s = line.strip()
+            m = re.match(r"numid=(\d+)", s)
+            if m:
+                cur_id = int(m.group(1))
+            elif cur_id is not None and s.startswith(": values="):
+                vals[cur_id] = s.split("values=", 1)[1].strip()
+        return vals
+
+    def _cset(self, role, value):
+        nid = self._numid.get(role)
+        if nid is not None:
+            self._amixer("cset", f"numid={nid}", str(value))
+
+    # --- interface expected by app.py ---
+
+    def read_device_info(self):
+        info = {"api_version": "—", "fw_version": "—", "serial": "—"}
+        d = _mk2_sysfs_dir()
+        if d:
+            try:
+                with open(os.path.join(d, "serial")) as f:
+                    info["serial"] = f.read().strip()
+            except OSError:
+                pass
+            try:
+                with open(os.path.join(d, "bcdDevice")) as f:
+                    bcd = f.read().strip()
+                if len(bcd) >= 3:
+                    info["fw_version"] = f"{int(bcd[:-2])}.{bcd[-2:]}"
+            except (OSError, ValueError):
+                pass
+        try:
+            blk = _mk2_vendor_read(0x0000)
+            if len(blk) >= 2:
+                info["api_version"] = f"{blk[0]}.{blk[1]}"
+        except Exception:
+            pass
+        return info
+
+    def _alsa_gain(self, vals):
+        try:
+            return int(vals.get(self._numid["mic_gain"], "0"))
+        except ValueError:
+            return 0
+
+    def get_all(self):
+        # Preferred path: read everything from the vendor blocks (authoritative,
+        # matches the LEDs). gain+mute in 0x0004, hp+low-Z in 0x0005.
+        if self._h:
+            try:
+                b4 = self._vread(_MK2_BLOCK_SETTINGS, _MK2_SETTINGS_LEN)
+                b5 = self._vread(_MK2_BLOCK_HP, _MK2_HP_LEN)
+                return {
+                    "gain_raw": round(b4[_MK2_GAIN_OFFSET] / _MK2_HW_GAIN_MAX * _MK2_UI_GAIN_MAX),
+                    "mute": bool(b4[_MK2_FLAGS_OFFSET] & _MK2_MUTE_MASK),
+                    "hp_volume_db": -b5[_MK2_HP_VOL_OFFSET] / 4.0,
+                    "volume_select": "gain",
+                    "low_impedance": bool(b5[_MK2_FLAGS_OFFSET] & _MK2_LOWZ_MASK),
+                }
+            except Exception:
+                pass
+
+        # Fallback (no USB access): ALSA for gain/mute/hp; low-Z unavailable.
+        vals = self._values()
+        hpmax = self._max.get("hp_vol") or 240
+        try:
+            hpv = int(vals.get(self._numid["hp_vol"], "0"))
+        except ValueError:
+            hpv = 0
+        span = _MK2_HP_DB_MAX - _MK2_HP_DB_MIN
+        return {
+            "gain_raw": round(self._alsa_gain(vals) / _MK2_HW_GAIN_MAX * _MK2_UI_GAIN_MAX),
+            "mute": vals.get(self._numid.get("mic_mute"), "on") == "off",
+            "hp_volume_db": _MK2_HP_DB_MIN + hpv / hpmax * span,
+            "volume_select": "gain",
+            "low_impedance": False,
+        }
+
+    def set_mute(self, muted):
+        if self._h:
+            # Mute = block 0x0004 byte1 bit0 (1 = muted).
+            block = self._vread(_MK2_BLOCK_SETTINGS, _MK2_SETTINGS_LEN)
+            if muted:
+                block[_MK2_FLAGS_OFFSET] |= _MK2_MUTE_MASK
+            else:
+                block[_MK2_FLAGS_OFFSET] &= ~_MK2_MUTE_MASK
+            self._vwrite(_MK2_BLOCK_SETTINGS, block)
+            _log.info("set_mute(%s) -> block 0x04 byte1=0x%02x", muted, block[_MK2_FLAGS_OFFSET])
+        else:
+            self._cset("mic_mute", "off" if muted else "on")
+
+    def set_gain_raw(self, value):
+        value = max(0, min(_MK2_UI_GAIN_MAX, value))
+        hw = round(value / _MK2_UI_GAIN_MAX * _MK2_HW_GAIN_MAX)  # 0..80
+        if self._h:
+            block = self._vread(_MK2_BLOCK_SETTINGS, _MK2_SETTINGS_LEN)
+            block[_MK2_GAIN_OFFSET] = hw
+            self._vwrite(_MK2_BLOCK_SETTINGS, block)
+            _log.debug("set_gain_raw(%s) -> vendor block 0x04 gain=%d", value, hw)
+        else:
+            # No USB access — ALSA write (PipeWire usually reverts this).
+            self._cset("mic_gain", hw)
+            _log.warning("set_gain_raw: no USB handle; used ALSA (may not stick)")
+
+    def set_hp_volume_db(self, db):
+        # Snap to the nearest hardware detent and write the native value, so the
+        # device/LEDs land exactly on a real wheel step.
+        byte0 = min(_MK2_HP_DETENTS, key=lambda b: abs(-b / 4.0 - db))
+        if self._h:
+            block = self._vread(_MK2_BLOCK_HP, _MK2_HP_LEN)
+            block[_MK2_HP_VOL_OFFSET] = byte0
+            self._vwrite(_MK2_BLOCK_HP, block)
+            _log.debug("set_hp_volume_db(%.1f) -> byte0=%d", db, byte0)
+        else:
+            self._cset("hp_vol", 240 - byte0)
+
+    def set_low_impedance(self, enabled):
+        if not self._h:
+            return  # needs USB access; nothing we can do via ALSA
+        # Low impedance = block 0x0005 byte1 bit1 (1 = on).
+        block = self._vread(_MK2_BLOCK_HP, _MK2_HP_LEN)
+        if enabled:
+            block[_MK2_FLAGS_OFFSET] |= _MK2_LOWZ_MASK
+        else:
+            block[_MK2_FLAGS_OFFSET] &= ~_MK2_LOWZ_MASK
+        self._vwrite(_MK2_BLOCK_HP, block)
+        _log.info("set_low_impedance(%s) -> block 0x05 byte1=0x%02x", enabled, block[_MK2_FLAGS_OFFSET])

--- a/wavexlr/setup.py
+++ b/wavexlr/setup.py
@@ -5,7 +5,12 @@ import subprocess
 
 from . import service
 
-UDEV_RULE = 'SUBSYSTEM=="usb", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="007d", MODE="0666"'
+UDEV_RULES = (
+    # Wave XLR
+    'SUBSYSTEM=="usb", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="007d", MODE="0666"',
+    # Wave XLR mk 2
+    'SUBSYSTEM=="usb", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="00b6", MODE="0666"',
+)
 UDEV_PATH = "/etc/udev/rules.d/99-openwave.rules"
 UDEV_PATH_OLD = "/etc/udev/rules.d/99-wavexlr.rules"
 
@@ -30,13 +35,17 @@ MIXES_PATH = os.path.expanduser(
 
 
 def udev_installed():
+    # Require a rule covering BOTH product IDs — an older 007d-only rule must be
+    # upgraded so the MK.2 (00b6) also gets 0666 access for the vendor protocol.
+    needed = ("007d", "00b6")
     for path in (UDEV_PATH, UDEV_PATH_OLD):
         try:
             with open(path) as f:
-                if "0fd9" in f.read():
-                    return True
+                content = f.read().lower()
         except (FileNotFoundError, PermissionError):
             continue
+        if all(pid in content for pid in needed):
+            return True
     return False
 
 
@@ -63,10 +72,13 @@ def needs_setup():
 
 def install_udev():
     """Install udev rule via pkexec."""
+    rules = "\n".join(UDEV_RULES)
     script = f"""#!/bin/sh
-echo '{UDEV_RULE}' > {UDEV_PATH}
+cat > {UDEV_PATH} <<'EOF'
+{rules}
+EOF
 udevadm control --reload-rules
-udevadm trigger --subsystem-match=usb --attr-match=idVendor=0fd9 --attr-match=idProduct=007d
+udevadm trigger --subsystem-match=usb --attr-match=idVendor=0fd9
 # Also chmod the device node directly so no replug is needed
 for dev in /dev/bus/usb/*/; do
     for f in "$dev"*; do

--- a/wireplumber/51-openwave-wave-xlr.conf
+++ b/wireplumber/51-openwave-wave-xlr.conf
@@ -1,4 +1,4 @@
-# OpenWave — Elgato Wave XLR (USB ID 0fd9:007d).
+# OpenWave — Elgato Wave XLR (0fd9:007d) and Wave XLR mk 2 (0fd9:00b6).
 #
 # UAC1 device: capture and playback share one iso clock. Format/rate
 # renegotiation tears down both directions briefly, and is one of the
@@ -21,8 +21,8 @@
 monitor.alsa.rules = [
   {
     matches = [
-      { node.name = "~alsa_input.usb-Elgato_Systems_Elgato_Wave_XLR.*" }
-      { node.name = "~alsa_output.usb-Elgato_Systems_Elgato_Wave_XLR.*" }
+      { node.name = "~alsa_input.*Wave_XLR.*" }
+      { node.name = "~alsa_output.*Wave_XLR.*" }
     ]
     actions = {
       update-props = {


### PR DESCRIPTION
# Summary
I was unable to get the Wave XLR Mk.2 working out of the box with openwave, so I took it upon myself to add support. I also made the UI bars scale more appropriately and added a disconnected message to see why some handshakes were failing.

# How
I did some packet captures on Windows to see how Elgato's software was communicating to the device and exported the output. I then had Claude pick the exact command signals out and then used Claude to do the boilerplate. The code was all thoroughly reviewed by me and everything that wasn't boilerplate or arduous was hand-written.

# Testing
I was only able to test on my Mk.2, but I believe it should still work on the original device since I only really added extra bits. I tested thoroughly including some hotplugs and unkind kills and it worked well enough.