### PR TITLE
Rebuild routing when PipeWire moves the Wave's nodes

### DIFF
--- a/wavexlr/app.py
+++ b/wavexlr/app.py
@@ -42,10 +42,11 @@ class WaveXLRWindow(Adw.ApplicationWindow):
 
         self._build_ui()
         self._update_service_status()
-        self.mixer = Mixer()
+        # Meter first: the mixer's watchdog can fire as soon as it exists.
+        self.meter = MeterMonitor()
+        self.mixer = Mixer(on_devices_changed=self._on_devices_changed)
         self.mixer.set_sources(self._sources)
         self.mixer.start()
-        self.meter = MeterMonitor()
         self._meter_targets = {}
         self._wire_matrix_cells()
         self._start_meters()
@@ -539,13 +540,29 @@ class WaveXLRWindow(Adw.ApplicationWindow):
 
     def _start_meters(self):
         """Begin metering the mic + any app source that already has a matching stream."""
-        if self.mixer.mic:
-            self.meter.start(
-                "mic", self.mixer.mic,
-                lambda level: self._set_source_level("mic", level),
-            )
+        self._restart_mic_meter()
         for source_id in self._sources.keys():
             self._refresh_app_meter(source_id)
+
+    def _on_devices_changed(self):
+        """Called on the mixer's worker thread."""
+        GLib.idle_add(self._restart_mic_meter)
+
+    def _restart_mic_meter(self):
+        """Point the mic meter at whatever node the mic is on now.
+
+        pw-cat binds a node name at spawn, so a meter left on a destroyed node
+        reads flat zero, which looks the same as a dead mic.
+        """
+        mic = self.mixer.mic
+        if mic:
+            self.meter.start(
+                "mic", mic,
+                lambda level: self._set_source_level("mic", level),
+            )
+        else:
+            self.meter.stop("mic")
+        return False
 
     def _refresh_app_meter(self, source_id):
         """Re-point the meter at the first currently-matching stream, or stop it

--- a/wavexlr/mixer.py
+++ b/wavexlr/mixer.py
@@ -7,6 +7,10 @@ playback node via wpctl.
 
 State is persisted to ~/.config/openwave/mixes.json so per-cell levels survive
 restarts (the loopbacks themselves do not — they're respawned by start()).
+
+PipeWire can destroy and recreate the nodes all of this is named after, and
+nothing announces it, so the worker re-checks device names and loopback
+liveness on a timer and rebuilds whatever no longer matches.
 """
 
 import atexit
@@ -47,6 +51,10 @@ MIX_SINKS = {
     "chat":     "openwave_chat_mix",
     "record":   "openwave_record_mix",
 }
+# How often the worker re-resolves the Wave's node names and checks its
+# loopbacks are alive. A recovery path, not a control one: nothing waits on it.
+DEVICE_RECHECK_INTERVAL = 5.0
+
 PERSONAL_MIX_SINK = "openwave_personal_mix"
 HP_LOOPBACK_KEY = "_personal_to_hp"
 HP_LOOPBACK_NODE = "openwave_loop_personal_to_hp"
@@ -168,13 +176,17 @@ def list_audio_streams():
 class Mixer:
     """Manages pw-loopback subprocesses for the matrix's mic row."""
 
-    def __init__(self):
+    def __init__(self, on_devices_changed=None):
         self._lock = Lock()
         self._procs = {}
         self._state = self._load_state()
         self._sources = {}
         self._streams = {}
         self.mic, self.hp = find_wave_xlr_alsa()
+
+        # Fired on the worker when mic/hp resolve to something different.
+        self.on_devices_changed = on_devices_changed
+        self._last_device_check = time.monotonic()
 
         # Background worker: every operation that talks to pw-loopback /
         # pw-cli / wpctl runs here so the GTK main thread never blocks on a
@@ -216,6 +228,76 @@ class Mixer:
                     _log.exception("mixer task failed: %s", key)
             if not self._worker_running:
                 return
+            self._device_watchdog()
+
+    # ----- device watchdog -----
+    def _device_watchdog(self):
+        """Re-check what the mixer is built on, and rebuild what moved."""
+        now = time.monotonic()
+        if now - self._last_device_check < DEVICE_RECHECK_INTERVAL:
+            return
+        self._last_device_check = now
+        try:
+            devices_changed = self._refresh_devices()
+            loopbacks_died = self._reap_dead_loopbacks()
+        except Exception:
+            _log.exception("device watchdog failed")
+            return
+        if devices_changed or loopbacks_died:
+            try:
+                self._reconcile_all()
+            except Exception:
+                _log.exception("watchdog reconcile failed")
+        if devices_changed and self.on_devices_changed is not None:
+            try:
+                self.on_devices_changed()
+            except Exception:
+                _log.exception("on_devices_changed callback failed")
+
+    def _refresh_devices(self):
+        """Re-resolve the Wave's node names. True if either moved.
+
+        A moved name leaves loopbacks wired to a node that no longer exists,
+        which liveness alone misses: the process is still running.
+        """
+        mic, hp = find_wave_xlr_alsa()
+        if (mic, hp) == (self.mic, self.hp):
+            return False
+        old_mic, old_hp = self.mic, self.hp
+        self.mic, self.hp = mic, hp
+        _log.info(
+            "Wave nodes moved: mic %s -> %s, hp %s -> %s", old_mic, mic, old_hp, hp,
+        )
+        if mic != old_mic:
+            for key in [
+                k for k in list(self._procs)
+                if isinstance(k, tuple) and k and k[0] == "mic"
+            ]:
+                self._destroy_loopback(key)
+        if hp != old_hp:
+            self._destroy_loopback(HP_LOOPBACK_KEY)
+        return True
+
+    def _reap_dead_loopbacks(self):
+        """Drop entries whose child has exited. True if any had."""
+        dead = [k for k, proc in list(self._procs.items()) if proc.poll() is not None]
+        for key in dead:
+            self._procs.pop(key, None)
+            _log.info("loopback %s exited; rebuilding", key)
+        return bool(dead)
+
+    def _ensure_hp_loopback(self):
+        """Personal Mix → headphones, whenever the Wave has a playback node.
+
+        Reconciled rather than spawned once at start, so it also appears if the
+        Wave arrives late and goes away when it leaves.
+        """
+        if self.hp:
+            self._spawn_loopback(
+                HP_LOOPBACK_KEY, PERSONAL_MIX_SINK, self.hp, HP_LOOPBACK_NODE,
+            )
+        else:
+            self._destroy_loopback(HP_LOOPBACK_KEY)
 
     # ----- persistence -----
     def _load_state(self):
@@ -402,10 +484,6 @@ class Mixer:
     # ----- worker-side implementations -----
     def _do_start(self):
         self._sweep_stale_loopbacks()
-        if self.hp:
-            self._spawn_loopback(
-                HP_LOOPBACK_KEY, PERSONAL_MIX_SINK, self.hp, HP_LOOPBACK_NODE,
-            )
         with self._lock:
             self._streams = {s["id"]: s for s in list_audio_streams()}
         self._reconcile_all()
@@ -432,6 +510,7 @@ class Mixer:
 
     # ----- internal -----
     def _reconcile_all(self):
+        self._ensure_hp_loopback()
         for source_id in (["mic"] + list(self._sources.keys())):
             for mix_id in MIX_SINKS:
                 self._reconcile_cell(source_id, mix_id)

--- a/wavexlr/mixer.py
+++ b/wavexlr/mixer.py
@@ -255,8 +255,13 @@ class Mixer:
         the case for null-sink monitors. The link is set up after a brief
         wait so the node has time to register.
         """
-        if key in self._procs:
-            return
+        proc = self._procs.get(key)
+        if proc is not None:
+            if proc.poll() is None:
+                return
+            # Child is gone but its entry outlived it, which is what stops this
+            # from ever rebuilding.
+            self._procs.pop(key, None)
         capture_node_name = f"{node_name}_cap"
         try:
             proc = subprocess.Popen(


### PR DESCRIPTION
Two fixes for the same failure. The mixer keeps addressing PipeWire nodes that no longer exist, and the routing it thinks it has stops existing with them. Output goes silent while the UI reads as correct, because the only broken thing is a link the UI never draws.

### Re-detect the Wave's nodes instead of caching them at startup

`Mixer` resolves `mic` and `hp` once in its constructor, and every routing decision afterwards uses those two strings. PipeWire is free to destroy and recreate those nodes at any point (a daemon restart, a suspend, the Wave unplugged and returned), and nothing reports it.

The case I hit: the Personal Mix to headphones loopback is spawned once in `_do_start` behind `if self.hp`. Start the app before the Wave enumerates, or restart PipeWire after it, and `hp` is still the `None` from construction. The loopback is skipped, every app keeps feeding `openwave_personal_mix`, and that mix terminates nowhere. The mix matrix, the volumes and the device page all look right.

The worker now re-resolves both names between tasks, tears down whatever was built against a name that moved, and lets reconcile rebuild it. `_ensure_hp_loopback` makes the headphone loopback a reconciled resource like any other cell, so it also appears when the Wave arrives late and goes away when it leaves.

The mic meter has the same latch. `pw-cat` binds a node name at spawn, so a meter left pointed at a destroyed node reads flat zero forever, which is indistinguishable from a dead mic. `Mixer` reports device changes to the UI and the meter is re-pointed with them.

Interval is 5s, two `pactl` calls, on the worker thread. It is a recovery path rather than a control one, so nothing the user does waits on it, and it does no work when nothing has moved.

### Respawn a loopback whose subprocess has exited

Separate bug on the same surface. `_spawn_loopback` treats a key's presence in `_procs` as proof the loopback exists, and nothing removes an entry whose child has died. A PipeWire restart takes every `pw-loopback` with it, so afterwards the dict holds exited processes that reconcile still counts as live routing and never rebuilds.

### Testing

There is no suite in the repo, so I drove the watchdog with the subprocess layer stubbed and checked: the HP loopback is created by reconcile rather than `_do_start`; a dead loopback is respawned; a node rename tears down the stale loopback and rebuilds against the new name; unplugging removes it and replugging restores it; and an idle pass spawns and destroys nothing. Happy to add that as a real test file if you want one in-tree.
