### PR TITLE
Give loopback nodes a stable media.name

### DIFF
--- a/wavexlr/mixer.py
+++ b/wavexlr/mixer.py
@@ -262,11 +262,16 @@ class Mixer:
             proc = subprocess.Popen(
                 [
                     "pw-loopback",
+                    # media.name is set explicitly because pw-loopback
+                    # otherwise derives it from its own PID, and WirePlumber
+                    # keys restore-stream on it.
                     "--capture-props="
                     f"node.autoconnect=false node.name={capture_node_name} "
+                    f"media.name={capture_node_name} "
                     "audio.channels=2 audio.position=[FL,FR]",
                     "--playback-props="
                     f"target.object={playback_target} node.name={node_name} "
+                    f"media.name={node_name} "
                     "audio.channels=2 audio.position=[FL,FR]",
                 ],
                 stdout=subprocess.DEVNULL,


### PR DESCRIPTION
`_spawn_loopback` sets `node.name` on both sides but not `media.name`, so pw-loopback falls back to deriving it from its own PID:

```
openwave_loop_personal_to_hp        media.name='pw-loopback-39482 output'
openwave_loop_personal_to_hp_cap    media.name='pw-loopback-39482 input'
```

WirePlumber's restore-stream keys on `media.name` when `application.name` is absent, which is the case for these nodes. The PID is different on every spawn, so each loopback the mixer creates writes two permanent entries under a name that will never match anything again.

On my machine that accounts for 328 of the 369 keys in `~/.local/state/wireplumber/stream-properties`, all dead:

```
369  total keys
328  pw-loopback-<PID> input/output   (89%)
```

It grows by two per loopback per start, so it is unbounded over the life of the install. The second effect is quieter: restore-stream has never actually applied to these nodes, because the key it saves under is new every time.

`node.name` is already stable and unique per loopback, so this uses it for `media.name` too. Verified that pw-loopback accepts the property and that the resulting nodes come up with the intended name rather than the PID-derived default.

Independent of #10, though both touch `_spawn_loopback`, so whichever lands second may need a trivial rebase.
