### PR TITLE
Show the uninstall button whenever there is something to uninstall

### DIFF
--- a/wavexlr/app.py
+++ b/wavexlr/app.py
@@ -284,7 +284,6 @@ class WaveXLRWindow(Adw.ApplicationWindow):
             self.audio_status_icon.set_from_icon_name("emblem-ok-symbolic")
             self.audio_status_icon.remove_css_class("dim-label")
             self.audio_status_row.set_subtitle("Audio service running")
-            self.uninstall_btn.set_visible(True)
         else:
             self.audio_status_icon.set_from_icon_name("dialog-warning-symbolic")
             # Distinguish a service that never came up from one that is not
@@ -297,12 +296,19 @@ class WaveXLRWindow(Adw.ApplicationWindow):
             else:
                 subtitle = "Audio service not running"
             self.audio_status_row.set_subtitle(subtitle)
-            self.uninstall_btn.set_visible(False)
+
+        # Shown whenever there is something to remove, rather than only while
+        # the service runs. A stopped or failed service is when removing it
+        # matters most, and the udev rule and the config drop-ins outlive it
+        # either way.
+        self.uninstall_btn.set_visible(setup.anything_installed())
 
     def _on_uninstall_clicked(self, btn):
         dialog = Adw.AlertDialog(
             heading="Uninstall Capture Fix?",
-            body="This will remove the audio service and USB permissions.\n\nYou can reinstall them by restarting OpenWave.",
+            body="This will remove the audio service, the WirePlumber rule, "
+                 "the mix sinks and the USB permissions.\n\nYou can reinstall "
+                 "them by restarting OpenWave.",
         )
         dialog.add_response("cancel", "Cancel")
         dialog.add_response("uninstall", "Uninstall")

--- a/wavexlr/setup.py
+++ b/wavexlr/setup.py
@@ -87,6 +87,20 @@ def needs_setup():
     )
 
 
+def anything_installed():
+    """Whether any part of the integration is still on disk.
+
+    Not the inverse of needs_setup(): a partial install both needs setup and
+    has things left to remove.
+    """
+    return (
+        udev_installed()
+        or service_installed()
+        or wireplumber_installed()
+        or mixes_installed()
+    )
+
+
 def install_udev():
     """Install udev rules via pkexec."""
     rules = "\n".join(UDEV_RULES)


### PR DESCRIPTION
Came out of #9, where someone who installed with the one-liner could not work out how to remove it. Part of that is the installer leaving no checkout behind, but the app makes it harder than it needs to be.

`_update_service_status` ties the button's visibility to `service.is_running()`, so it is hidden in every state where the service is not up: never installed, installed but stopped, and failed to start. The middle two are exactly when someone wants to remove it, and from the UI there is no way to.

The service is also not the only thing `run_uninstall()` takes out. The udev rule, the WirePlumber rule and the mix sinks all outlive it, so they can be sitting on disk with the button hidden and nothing in the UI acknowledging they are there.

This gates on `anything_installed()` instead, the OR of the four things `run_uninstall()` acts on. It is deliberately not the inverse of `needs_setup()`, since a partial install both needs setup and has things left to remove.

Checked against a live install, including the case the old code got wrong:

```
service.is_running()      True
udev_installed()          False
service_installed()       True
wireplumber_installed()   False
mixes_installed()         True
anything_installed()      True

with service_installed() and udev_installed() forced False:
anything_installed()      True     (button still shown)

with all four forced False:
anything_installed()      False    (button hidden)
```

Only two call sites and neither is on a timer, so the extra checks cost nothing.

Second commit-worthy detail folded in: the confirmation dialog said "This will remove the audio service and USB permissions", which understates it. It now names the WirePlumber rule and the mix sinks as well.

Independent of #10 and #11.
