### PR TITLE
Add support for the 0fd9:00a6 XLR Dock

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install runtime library
+        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -t .
+      - name: Compile Python sources
+        run: python -m compileall -q wavexlr tests

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # OpenWave
 
-Linux control application for **Elgato Wave** audio devices — the **Wave XLR** microphone interface and the **Wave:3** microphone. A reverse-engineered replacement for Elgato Wave Link, built with GTK4 + Adwaita.
+Linux control application for **Elgato Wave** audio devices — the **Wave XLR**, the `0fd9:00a6` **XLR Dock**, and the **Wave:3** microphone. A reverse-engineered replacement for Elgato Wave Link, built with GTK4 + Adwaita.
 
 ## Supported devices
 
 | Device | USB ID | Controls |
 |---|---|---|
 | Wave XLR | `0fd9:007d` | Gain, mute, headphone volume, low impedance mode |
+| XLR Dock (`00a6` variant) | `0fd9:00a6` | Gain, mute, headphone volume, low impedance mode |
 | Wave:3 | `0fd9:0070` | Gain, mute, headphone volume, monitor mix |
 
 ## Features
@@ -23,7 +24,7 @@ Linux control application for **Elgato Wave** audio devices — the **Wave XLR**
 
 Wave devices use USB Class control transfers on endpoint 0 for device configuration. On Linux, `snd-usb-audio` normally blocks these transfers because `wIndex=0x3300` routes through interface 0 (owned by the audio driver). OpenWave uses `wIndex=0x3303` instead — the firmware only checks the `0x33` prefix, while the kernel sees interface 3 (unclaimed) and lets the transfer through. No driver detach needed, audio is never interrupted.
 
-Both devices speak the same vendor protocol (`bRequest` 0x85 read / 0x05 write) but with different config layouts: the Wave XLR uses a 34-byte block (gain uint16 Q8.8 dB @0, mute @4, HP volume int16 Q8.8 @9, knob mode @14, low-Z @33), the Wave:3 a 16-byte block (gain uint16 Q8.8 dB @0, mute @4, HP volume int16 Q8.8 @7, monitor mix uint16 Q8.8 percent @10, dial mode @12 — 1=gain, 2=headphones, 3=mix). Per-model constants live in `wavexlr/profiles.py`; `python3 -m wavexlr.probe` (`dump` / `watch` / `poke`) verifies a device against its profile and helps map new fields. The device services vendor transfers from only one process at a time, so quit OpenWave before probing.
+The Wave XLR and `0fd9:00a6` XLR Dock share a 34-byte config block (gain uint16 Q8.8 dB @0, mute @4, HP volume int16 Q8.8 @9, knob mode @14, low-Z @33). The Wave:3 uses a 16-byte block (gain uint16 Q8.8 dB @0, mute @4, HP volume int16 Q8.8 @7, monitor mix uint16 Q8.8 percent @10, dial mode @12 — 1=gain, 2=headphones, 3=mix). All use USB Class control transfers (`bRequest` 0x85 read / 0x05 write). Per-model constants live in `wavexlr/profiles.py`; `python3 -m wavexlr.probe` (`dump` / `watch` / `poke`) verifies a device against its profile and helps map new fields. The device services vendor transfers from only one process at a time, so quit OpenWave before probing.
 
 ## Install
 

--- a/flake.nix
+++ b/flake.nix
@@ -53,19 +53,14 @@
             # first run -- consume via services.udev.packages on NixOS
             # and the in-app permission check passes out of the box.
             #
-            # Generated from setup.py's UDEV_RULES rather than restated, because
-            # udev_installed() requires *every* product ID to be present. This
-            # was hardcoded to 007d alone while UDEV_RULES also carries 0070
-            # (Wave:3), so the check failed permanently: run_setup() called
-            # install_udev() on every launch, pkexec-wrote the same file the
-            # package already owns, and returned early on failure -- meaning the
-            # WirePlumber and mix-sink configs after it never got installed
-            # either. On NixOS that pkexec cannot succeed regardless, since
-            # /etc/udev/rules.d/99-openwave.rules is a read-only store symlink.
+            # Generate from setup.py's UDEV_RULES rather than restating them,
+            # because udev_installed() requires every supported product ID.
+            # Importing the installed module also supports profile-derived rules
+            # without maintaining a second literal list for the Nix package.
             postInstall = ''
               mkdir -p $out/lib/udev/rules.d
-              ${pythonEnv}/bin/python3 -c 'import ast,sys; t=ast.parse(open(sys.argv[1]).read()); v=next(n.value for n in t.body if isinstance(n,ast.Assign) and any(getattr(x,"id",None)=="UDEV_RULES" for x in n.targets)); sys.stdout.write("\n".join(ast.literal_eval(v))+"\n")' \
-                "$out/${sitePkgs}/wavexlr/setup.py" \
+              PYTHONPATH="$out/${sitePkgs}" ${pythonEnv}/bin/python3 -c \
+                'from wavexlr.setup import UDEV_RULES; print(*UDEV_RULES, sep="\n")' \
                 > $out/lib/udev/rules.d/99-openwave.rules
 
               # setup.py looks for the WirePlumber and mix-sink configs next to

--- a/tests/test_hardware_support.py
+++ b/tests/test_hardware_support.py
@@ -1,0 +1,37 @@
+import unittest
+
+from wavexlr.mixer import _is_wave_card
+from wavexlr.profiles import PROFILES, WAVE_XLR, WAVE_XLR_MK2
+from wavexlr.setup import UDEV_RULES
+
+
+class DockProfileTests(unittest.TestCase):
+    def test_00a6_dock_uses_verified_xlr_protocol(self):
+        self.assertEqual((WAVE_XLR_MK2.vid, WAVE_XLR_MK2.pid), (0x0FD9, 0x00A6))
+        self.assertEqual(WAVE_XLR_MK2.config_len, WAVE_XLR.config_len)
+        self.assertEqual(WAVE_XLR_MK2.off_gain, WAVE_XLR.off_gain)
+        self.assertEqual(WAVE_XLR_MK2.off_mute, WAVE_XLR.off_mute)
+        self.assertEqual(WAVE_XLR_MK2.off_hp_vol, WAVE_XLR.off_hp_vol)
+        self.assertEqual(WAVE_XLR_MK2.off_low_z, WAVE_XLR.off_low_z)
+
+    def test_every_profile_has_one_udev_rule(self):
+        for profile in PROFILES:
+            vendor = f'ATTR{{idVendor}}=="{profile.vid:04x}"'
+            product = f'ATTR{{idProduct}}=="{profile.pid:04x}"'
+            matching = [rule for rule in UDEV_RULES if vendor in rule and product in rule]
+            self.assertEqual(len(matching), 1, profile.display_name)
+
+    def test_pipewire_names_recognize_both_xlr_families(self):
+        self.assertTrue(_is_wave_card(
+            "alsa_input.usb-Elgato_Systems_Elgato_XLR_Dock_A1-00.mono-fallback"
+        ))
+        self.assertTrue(_is_wave_card(
+            "alsa_output.usb-Elgato_Systems_Elgato_Wave_XLR_A1-00.analog-stereo"
+        ))
+        self.assertFalse(_is_wave_card(
+            "alsa_input.usb-Elgato_Systems_Stream_Deck_A1-00.mono-fallback"
+        ))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wavexlr/mixer.py
+++ b/wavexlr/mixer.py
@@ -63,16 +63,24 @@ def _pactl_short(kind):
     return [line.split("\t") for line in r.stdout.splitlines() if line.strip()]
 
 
+CARD_NAME_TOKENS = ("Elgato_Wave_", "Elgato_XLR_Dock")
+
+
+def _is_wave_card(node_name):
+    """Whether a PipeWire ALSA node belongs to a supported Wave family."""
+    return any(token in node_name for token in CARD_NAME_TOKENS)
+
+
 def find_wave_xlr_alsa():
     """Return (mic_node_name, hp_node_name); either may be None if unplugged."""
     mic = next(
         (p[1] for p in _pactl_short("sources")
-         if len(p) > 1 and p[1].startswith("alsa_input") and "Elgato_Wave_" in p[1]),
+         if len(p) > 1 and p[1].startswith("alsa_input") and _is_wave_card(p[1])),
         None,
     )
     hp = next(
         (p[1] for p in _pactl_short("sinks")
-         if len(p) > 1 and p[1].startswith("alsa_output") and "Elgato_Wave_" in p[1]),
+         if len(p) > 1 and p[1].startswith("alsa_output") and _is_wave_card(p[1])),
         None,
     )
     return mic, hp

--- a/wavexlr/profiles.py
+++ b/wavexlr/profiles.py
@@ -3,7 +3,7 @@
 Config offsets set to None mean the device lacks that feature.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 
 @dataclass(frozen=True)
@@ -118,4 +118,15 @@ WAVE3 = DeviceProfile(
     sync_alsa_gain=True,
 )
 
-PROFILES = (WAVE_XLR, WAVE3)
+# The 0fd9:00a6 XLR Dock speaks the original Wave XLR vendor protocol.
+# Hardware captures decode the same config and device-info offsets, including
+# a serial at bytes 27..46 that matches the ALSA card identity.
+WAVE_XLR_MK2 = replace(
+    WAVE_XLR,
+    key="wave_xlr_mk2",
+    display_name="Wave XLR MK.2 (0fd9:00a6)",
+    pid=0x00A6,
+    card_match=("XLR Dock", "Wave XLR", "Elgato"),
+)
+
+PROFILES = (WAVE_XLR, WAVE_XLR_MK2, WAVE3)

--- a/wavexlr/setup.py
+++ b/wavexlr/setup.py
@@ -4,11 +4,15 @@ import os
 import subprocess
 
 from . import paths, service
+from .profiles import PROFILES
 
-UDEV_RULES = (
-    'SUBSYSTEM=="usb", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="007d", MODE="0666"',  # Wave XLR
-    'SUBSYSTEM=="usb", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="0070", MODE="0666"',  # Wave:3
+UDEV_RULES = tuple(
+    'SUBSYSTEM=="usb", '
+    f'ATTR{{idVendor}}=="{profile.vid:04x}", '
+    f'ATTR{{idProduct}}=="{profile.pid:04x}", MODE="0666"'
+    for profile in PROFILES
 )
+UDEV_PRODUCT_IDS = tuple(f"{profile.pid:04x}" for profile in PROFILES)
 UDEV_PATH = "/etc/udev/rules.d/99-openwave.rules"
 UDEV_PATH_OLD = "/etc/udev/rules.d/99-wavexlr.rules"
 
@@ -36,7 +40,7 @@ def udev_installed():
         try:
             with open(path) as f:
                 content = f.read()
-            if all(pid in content for pid in ("007d", "0070")):
+            if all(product_id in content for product_id in UDEV_PRODUCT_IDS):
                 return True
         except (FileNotFoundError, PermissionError):
             continue
@@ -104,13 +108,18 @@ def anything_installed():
 def install_udev():
     """Install udev rules via pkexec."""
     rules = "\n".join(UDEV_RULES)
+    trigger_lines = "\n".join(
+        "udevadm trigger --subsystem-match=usb "
+        f"--attr-match=idVendor={profile.vid:04x} "
+        f"--attr-match=idProduct={profile.pid:04x}"
+        for profile in PROFILES
+    )
     script = f"""#!/bin/sh
 cat > {UDEV_PATH} <<'EOF'
 {rules}
 EOF
 udevadm control --reload-rules
-udevadm trigger --subsystem-match=usb --attr-match=idVendor=0fd9 --attr-match=idProduct=007d
-udevadm trigger --subsystem-match=usb --attr-match=idVendor=0fd9 --attr-match=idProduct=0070
+{trigger_lines}
 # Also chmod the device node directly so no replug is needed
 for dev in /dev/bus/usb/*/; do
     for f in "$dev"*; do

--- a/wireplumber/51-openwave-wave-xlr.conf
+++ b/wireplumber/51-openwave-wave-xlr.conf
@@ -1,4 +1,5 @@
-# OpenWave — Elgato Wave XLR (0fd9:007d) and Wave:3 (0fd9:0070).
+# OpenWave — Elgato Wave XLR (0fd9:007d), XLR Dock (0fd9:00a6),
+# and Wave:3 (0fd9:0070).
 #
 # UAC1 devices: capture and playback share one iso clock. Format/rate
 # renegotiation tears down both directions briefly, and is one of the
@@ -21,8 +22,8 @@
 monitor.alsa.rules = [
   {
     matches = [
-      { node.name = "~alsa_input.usb-Elgato_Systems_Elgato_Wave_.*" }
-      { node.name = "~alsa_output.usb-Elgato_Systems_Elgato_Wave_.*" }
+      { node.name = "~alsa_input.usb-Elgato_Systems_Elgato_(Wave|XLR_Dock)_.*" }
+      { node.name = "~alsa_output.usb-Elgato_Systems_Elgato_(Wave|XLR_Dock)_.*" }
     ]
     actions = {
       update-props = {


### PR DESCRIPTION
## Summary
- add the hardware-verified `0fd9:00a6` XLR Dock profile
- recognize Dock ALSA nodes in routing and WirePlumber policy
- derive udev rules and triggers from the supported profile table
- include the generated rule in the Nix package and document the exact supported variant
- add the unit-test workflow and focused hardware-support regression tests

The similarly named `0fd9:00c7` variant remains unverified and unsupported.

## Verification
- `python3 -m unittest discover -s tests -t . -v`
- `nix build --no-link path:.#openwave`
- inspected the built `99-openwave.rules`; it contains `007d`, `00a6`, and `0070`
- `git diff --check`