### PR TITLE
Add serialized 48V phantom power control

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Linux control application for **Elgato Wave** audio devices — the **Wave XLR**
 
 | Device | USB ID | Controls |
 |---|---|---|
-| Wave XLR | `0fd9:007d` | Gain, mute, headphone volume, low impedance mode |
-| XLR Dock (`00a6` variant) | `0fd9:00a6` | Gain, mute, headphone volume, low impedance mode |
+| Wave XLR | `0fd9:007d` | Gain, mute, 48 V phantom power, headphone volume, low impedance mode |
+| XLR Dock (`00a6` variant) | `0fd9:00a6` | Gain, mute, 48 V phantom power, headphone volume, low impedance mode |
 | Wave:3 | `0fd9:0070` | Gain, mute, headphone volume, monitor mix |
 
 ## Features
 
-- **Microphone controls** — Gain, mute (syncs with hardware button)
+- **Microphone controls** — Gain, mute (syncs with hardware button), and profile-gated 48 V phantom power
 - **Headphone controls** — Volume (syncs with hardware knob), low impedance mode
 - **Hardware sync** — 10 Hz polling keeps the app in sync with physical controls
 - **System integration** — Mute and HP volume sync bidirectionally with PipeWire/ALSA
@@ -24,7 +24,7 @@ Linux control application for **Elgato Wave** audio devices — the **Wave XLR**
 
 Wave devices use USB Class control transfers on endpoint 0 for device configuration. On Linux, `snd-usb-audio` normally blocks these transfers because `wIndex=0x3300` routes through interface 0 (owned by the audio driver). OpenWave uses `wIndex=0x3303` instead — the firmware only checks the `0x33` prefix, while the kernel sees interface 3 (unclaimed) and lets the transfer through. No driver detach needed, audio is never interrupted.
 
-The Wave XLR and `0fd9:00a6` XLR Dock share a 34-byte config block (gain uint16 Q8.8 dB @0, mute @4, HP volume int16 Q8.8 @9, knob mode @14, low-Z @33). The Wave:3 uses a 16-byte block (gain uint16 Q8.8 dB @0, mute @4, HP volume int16 Q8.8 @7, monitor mix uint16 Q8.8 percent @10, dial mode @12 — 1=gain, 2=headphones, 3=mix). All use USB Class control transfers (`bRequest` 0x85 read / 0x05 write). Per-model constants live in `wavexlr/profiles.py`; `python3 -m wavexlr.probe` (`dump` / `watch` / `poke`) verifies a device against its profile and helps map new fields. The device services vendor transfers from only one process at a time, so quit OpenWave before probing.
+The Wave XLR and `0fd9:00a6` XLR Dock share a 34-byte config block (gain uint16 Q8.8 dB @0, mute @4, 48 V phantom power @6, HP volume int16 Q8.8 @9, knob mode @14, low-Z @33). The Wave:3 uses a 16-byte block (gain uint16 Q8.8 dB @0, mute @4, HP volume int16 Q8.8 @7, monitor mix uint16 Q8.8 percent @10, dial mode @12 — 1=gain, 2=headphones, 3=mix). All use USB Class control transfers (`bRequest` 0x85 read / 0x05 write). Per-model constants live in `wavexlr/profiles.py`; `python3 -m wavexlr.probe` (`dump` / `watch` / `poke`) verifies a device against its profile and helps map new fields. The device services vendor transfers from only one process at a time, so quit OpenWave before probing.
 
 ## Install
 

--- a/tests/test_hardware_support.py
+++ b/tests/test_hardware_support.py
@@ -1,7 +1,9 @@
+import threading
 import unittest
 
+from wavexlr.device import WaveDevice
 from wavexlr.mixer import _is_wave_card
-from wavexlr.profiles import PROFILES, WAVE_XLR, WAVE_XLR_MK2
+from wavexlr.profiles import PROFILES, WAVE3, WAVE_XLR, WAVE_XLR_MK2
 from wavexlr.setup import UDEV_RULES
 
 
@@ -31,6 +33,64 @@ class DockProfileTests(unittest.TestCase):
         self.assertFalse(_is_wave_card(
             "alsa_input.usb-Elgato_Systems_Stream_Deck_A1-00.mono-fallback"
         ))
+
+
+class _MemoryDevice(WaveDevice):
+    def __init__(self, profile):
+        self.profile = profile
+        self._lock = threading.RLock()
+        self._card = None
+        self._last_fw = None
+        self.config = bytearray(profile.config_len)
+        self.phantom_read = threading.Event()
+        self.release_phantom = threading.Event()
+        self.lowz_read = threading.Event()
+        self.pause_phantom = False
+
+    def read_config(self):
+        if threading.current_thread().name == "phantom" and self.pause_phantom:
+            self.phantom_read.set()
+            self.release_phantom.wait(timeout=2)
+        elif threading.current_thread().name == "lowz":
+            self.lowz_read.set()
+        return bytearray(self.config)
+
+    def write_config(self, config):
+        self.config[:] = config
+
+
+class PhantomPowerTests(unittest.TestCase):
+    def test_state_is_exposed_only_by_powered_xlr_profiles(self):
+        xlr = _MemoryDevice(WAVE_XLR)
+        xlr.config[WAVE_XLR.off_phantom] = 1
+        self.assertTrue(xlr.get_all()["phantom"])
+
+        wave3 = _MemoryDevice(WAVE3)
+        wave3.set_phantom(True)
+        self.assertNotIn("phantom", wave3.get_all())
+
+    def test_concurrent_config_updates_cannot_overwrite_each_other(self):
+        device = _MemoryDevice(WAVE_XLR)
+        device.pause_phantom = True
+        phantom = threading.Thread(
+            name="phantom", target=lambda: device.set_phantom(True)
+        )
+        lowz = threading.Thread(
+            name="lowz", target=lambda: device.set_low_impedance(True)
+        )
+
+        phantom.start()
+        self.assertTrue(device.phantom_read.wait(timeout=1))
+        lowz.start()
+        self.assertFalse(device.lowz_read.wait(timeout=0.1))
+        device.release_phantom.set()
+        phantom.join(timeout=1)
+        lowz.join(timeout=1)
+
+        self.assertFalse(phantom.is_alive())
+        self.assertFalse(lowz.is_alive())
+        self.assertEqual(device.config[WAVE_XLR.off_phantom], 1)
+        self.assertEqual(device.config[WAVE_XLR.off_low_z], 1)
 
 
 if __name__ == "__main__":

--- a/wavexlr/app.py
+++ b/wavexlr/app.py
@@ -212,6 +212,15 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self.gain_scale.connect("value-changed", self._on_gain_changed)
         parent.append(self.gain_scale)
 
+        phantom_row = Adw.SwitchRow(
+            title="48V Phantom Power",
+            subtitle="For condenser microphones; turn off before unplugging",
+        )
+        phantom_row.connect("notify::active", self._on_phantom_changed)
+        self.phantom_row = phantom_row
+        mic_group.add(phantom_row)
+
+
         knob_row = Adw.ActionRow(title="Knob Controls", subtitle="What the physical knob adjusts")
         self.knob_label = Gtk.Label(label="Gain")
         self.knob_label.add_css_class("dim-label")
@@ -488,6 +497,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self.gain_scale.get_adjustment().set_upper(profile.gain_max)
         self.knob_row.set_visible(profile.has_vol_select)
         self.lowz_row.set_visible(profile.has_low_z)
+        self.phantom_row.set_visible(profile.has_phantom)
         self.mix_row.set_visible(profile.has_monitor_mix)
         self.mix_scale.set_visible(profile.has_monitor_mix)
         if profile.has_monitor_mix:
@@ -512,6 +522,8 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self.hp_label.set_label(f"{state['hp_volume_db']:.1f} dB")
         if "low_impedance" in state:
             self.lowz_row.set_active(state["low_impedance"])
+        if "phantom" in state:
+            self.phantom_row.set_active(state["phantom"])
         if "volume_select" in state:
             self.knob_label.set_label(KNOB_LABELS.get(state["volume_select"], "Gain"))
         if "monitor_mix" in state:
@@ -571,6 +583,15 @@ class WaveXLRWindow(Adw.ApplicationWindow):
             return
         enabled = row.get_active()
         self._usb_async(lambda: self.dev.set_low_impedance(enabled), on_error=self._on_usb_error)
+
+    def _on_phantom_changed(self, row, _pspec):
+        if self._updating_ui or not self.dev.connected:
+            return
+        enabled = row.get_active()
+        self._usb_async(
+            lambda: self.dev.set_phantom(enabled), on_error=self._on_usb_error
+        )
+
 
     def _on_mix_changed(self, scale):
         if self._updating_ui or not self.dev.connected:

--- a/wavexlr/device.py
+++ b/wavexlr/device.py
@@ -143,7 +143,7 @@ def _alsa_hp_to_fw(alsa_hp, scale):
 class WaveDevice:
     def __init__(self):
         self._handle = None
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._card = None
         self._last_fw = None  # last known firmware state for change detection
         self.profile = None
@@ -181,11 +181,12 @@ class WaveDevice:
         raise DeviceNotReadyError("No supported Elgato Wave device found")
 
     def disconnect(self):
-        if self._handle:
-            _lib.libusb_close(self._handle)
-            self._handle = None
-        self._card = None
-        self._last_fw = None
+        with self._lock:
+            if self._handle:
+                _lib.libusb_close(self._handle)
+                self._handle = None
+            self._card = None
+            self._last_fw = None
 
     def _ctrl_read(self, wValue, length):
         """USB control read — no detach needed."""
@@ -253,6 +254,13 @@ class WaveDevice:
         p = self.profile
         raw = struct.unpack_from(p.hp_fmt, self.read_config(), p.off_hp_vol)[0]
         return raw / p.hp_scale
+
+    def get_phantom(self):
+        """Return phantom-power state, or None without a powered XLR input."""
+        if self.profile.off_phantom is None:
+            return None
+        return bool(self.read_config()[self.profile.off_phantom])
+
 
     def get_low_impedance(self):
         if self.profile.off_low_z is None:
@@ -333,26 +341,38 @@ class WaveDevice:
             state["volume_select"] = p.vol_select_map.get(config[p.off_vol_select], "gain")
         if p.off_low_z is not None:
             state["low_impedance"] = bool(config[p.off_low_z])
+        if p.off_phantom is not None:
+            state["phantom"] = bool(config[p.off_phantom])
         if p.off_monitor_mix is not None:
             state["monitor_mix"] = struct.unpack_from('<H', config, p.off_monitor_mix)[0]
         return state
 
     # --- High-level setters (read-modify-write) ---
+    def _write_config_byte(self, offset, value):
+        """Atomically update one byte in the shared firmware config block."""
+        with self._lock:
+            config = self.read_config()
+            config[offset] = value
+            self.write_config(config)
+
+    def _write_config_value(self, fmt, offset, value):
+        """Atomically update one packed value in the firmware config block."""
+        with self._lock:
+            config = self.read_config()
+            struct.pack_into(fmt, config, offset, value)
+            self.write_config(config)
+
 
     def set_gain_raw(self, value):
         value = max(0, min(0xFFFF, value))
-        config = self.read_config()
-        struct.pack_into('<H', config, self.profile.off_gain, value)
-        self.write_config(config)
+        self._write_config_value('<H', self.profile.off_gain, value)
         if self._last_fw:
             self._last_fw["gain"] = value
         if self._card and self.profile.sync_alsa_gain:
             _alsa_set_gain(self._card, _fw_gain_to_alsa(value, self.profile.gain_scale))
 
     def set_mute(self, muted):
-        config = self.read_config()
-        config[self.profile.off_mute] = 0x01 if muted else 0x00
-        self.write_config(config)
+        self._write_config_byte(self.profile.off_mute, 0x01 if muted else 0x00)
         if self._last_fw:
             self._last_fw["mute"] = muted
         if self._card and self.profile.sync_alsa_mute:
@@ -362,29 +382,34 @@ class WaveDevice:
         p = self.profile
         db = max(-128.0, min(0.0, db))
         raw = int(db * p.hp_scale)
-        config = self.read_config()
-        struct.pack_into(p.hp_fmt, config, p.off_hp_vol, raw)
-        self.write_config(config)
+        self._write_config_value(p.hp_fmt, p.off_hp_vol, raw)
         if self._last_fw:
             self._last_fw["hp"] = raw
         if self._card and p.sync_alsa_hp:
             _alsa_set_hp_vol(self._card, _fw_hp_to_alsa(raw, p.hp_scale))
 
+    def set_phantom(self, enabled):
+        """Switch 48 V phantom power on profiles that expose the control."""
+        if self.profile.off_phantom is None:
+            return
+        self._write_config_byte(
+            self.profile.off_phantom, 0x01 if enabled else 0x00
+        )
+
+
     def set_low_impedance(self, enabled):
         if self.profile.off_low_z is None:
             return
-        config = self.read_config()
-        config[self.profile.off_low_z] = 0x01 if enabled else 0x00
-        self.write_config(config)
+        self._write_config_byte(
+            self.profile.off_low_z, 0x01 if enabled else 0x00
+        )
 
     def set_monitor_mix(self, value):
         p = self.profile
         if p.off_monitor_mix is None:
             return
         value = max(0, min(p.mix_max, int(value)))
-        config = self.read_config()
-        struct.pack_into('<H', config, p.off_monitor_mix, value)
-        self.write_config(config)
+        self._write_config_value('<H', p.off_monitor_mix, value)
 
 
 WaveXLR = WaveDevice

--- a/wavexlr/profiles.py
+++ b/wavexlr/profiles.py
@@ -32,6 +32,9 @@ class DeviceProfile:
     off_vol_select: int | None
     vol_select_map: dict
     off_low_z: int | None
+    # 48 V phantom power. The verified XLR layout stores 0x01/0x00 at byte 6.
+    # None means the profile has no powered XLR input.
+    off_phantom: int | None
     off_monitor_mix: int | None
     mix_max: int
     card_match: tuple
@@ -42,6 +45,11 @@ class DeviceProfile:
     @property
     def has_low_z(self):
         return self.off_low_z is not None
+
+    @property
+    def has_phantom(self):
+        return self.off_phantom is not None
+
 
     @property
     def has_vol_select(self):
@@ -77,6 +85,7 @@ WAVE_XLR = DeviceProfile(
     off_vol_select=14,
     vol_select_map={0x02: "hp"},
     off_low_z=33,
+    off_phantom=6,
     off_monitor_mix=None,
     mix_max=0,
     card_match=("Wave XLR", "Elgato"),
@@ -110,6 +119,7 @@ WAVE3 = DeviceProfile(
     off_vol_select=12,
     vol_select_map={0x01: "gain", 0x02: "hp", 0x03: "mix"},
     off_low_z=None,
+    off_phantom=None,
     off_monitor_mix=10,
     mix_max=0x6400,
     card_match=("Wave3", "Elgato"),


### PR DESCRIPTION
## Summary
- expose the hardware-verified phantom-power byte on XLR profiles
- add the capability-gated GTK switch and live state synchronization
- keep every firmware config read-modify-write transaction atomic
- preserve the existing single USB worker and hide the control on Wave:3

## Verification
- Python 3.13: 5 focused tests pass, including a forced concurrent write regression
- `nix build --no-link path:.#openwave`
- `git diff --check`

Hardware safety: this changes only config byte 6 on the verified `007d`/`00a6` layout; `00c7` remains unsupported.