### PR TITLE
Discover ALSA controls and exact device identity

### DIFF
--- a/tests/test_alsa_identity.py
+++ b/tests/test_alsa_identity.py
@@ -1,0 +1,136 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from wavexlr import device
+
+
+DOCK_CONTROLS = """\
+numid=3,iface=MIXER,name='PCM Playback Switch'
+  ; type=BOOLEAN,access=rw------,values=1
+  : values=on
+numid=4,iface=MIXER,name='PCM Playback Volume'
+  ; type=INTEGER,access=rw---R--,values=1,min=0,max=120,step=0
+  : values=73
+numid=5,iface=MIXER,name='Mic Capture Switch'
+  ; type=BOOLEAN,access=rw------,values=1
+  : values=on
+numid=6,iface=MIXER,name='Mic Capture Volume'
+  ; type=INTEGER,access=rw---R--,values=1,min=0,max=150,step=0
+  : values=150
+numid=2,iface=PCM,name='Capture Channel Map'
+  ; type=INTEGER,access=r--v-R--,values=1,min=0,max=36,step=0
+  : values=2
+"""
+
+SHUFFLED_CONTROLS = """\
+numid=11,iface=MIXER,name='Wave XLR Mk3 Capture Switch'
+  ; type=BOOLEAN,access=rw------,values=1
+  : values=on
+numid=12,iface=MIXER,name='Wave XLR Mk3 Capture Volume'
+  ; type=INTEGER,access=rw---R--,values=1,min=0,max=200,step=0
+  : values=0
+numid=13,iface=MIXER,name='Wave XLR Mk3 Playback Volume'
+  ; type=INTEGER,access=rw---R--,values=1,min=0,max=99,step=0
+  : values=0
+"""
+
+
+class AlsaControlTests(unittest.TestCase):
+    def setUp(self):
+        device._ALSA_NUMIDS.clear()
+        device._ALSA_CTL_MAX.clear()
+        self.addCleanup(device._ALSA_NUMIDS.clear)
+        self.addCleanup(device._ALSA_CTL_MAX.clear)
+
+    def test_roles_and_ranges_follow_driver_names(self):
+        calls = []
+
+        def fake_amixer(card, *args):
+            calls.append((card, args))
+            return SHUFFLED_CONTROLS if args == ("contents",) else ""
+
+        with mock.patch.object(device, "_amixer", fake_amixer):
+            self.assertEqual(device._numid("3", "mute"), 11)
+            self.assertEqual(device._numid("3", "gain"), 12)
+            self.assertEqual(device._numid("3", "hp_vol"), 13)
+            self.assertEqual(device._alsa_ctl_max("3", 12, 150), 200)
+            self.assertEqual(device._alsa_ctl_max("3", 13, 120), 99)
+
+        self.assertEqual(calls, [("3", ("contents",))])
+
+    def test_unreadable_controls_fall_back_without_inventing_state(self):
+        with mock.patch.object(device, "_amixer", return_value=None):
+            self.assertEqual(device._numid("3", "mute"), 5)
+            self.assertEqual(device._numid("3", "gain"), 6)
+            self.assertEqual(device._numid("3", "hp_vol"), 4)
+            self.assertEqual(device._alsa_get("3"), {})
+
+    def test_gain_is_not_truncated_before_the_real_driver_clamp(self):
+        calls = []
+
+        def fake_amixer(card, *args):
+            if args == ("contents",):
+                return DOCK_CONTROLS
+            calls.append(args)
+            return ""
+
+        with mock.patch.object(device, "_amixer", fake_amixer):
+            value = device._fw_gain_to_alsa(75 * 256, 256)
+            device._alsa_set_gain("3", value)
+
+        self.assertEqual(value, 150)
+        self.assertEqual(calls, [("cset", "numid=6", "150")])
+
+
+class CardIdentityTests(unittest.TestCase):
+    def _card_tree(self, cards):
+        root = tempfile.TemporaryDirectory()
+        self.addCleanup(root.cleanup)
+        paths = []
+        for number, (usb_id, usb_bus) in cards.items():
+            card_dir = os.path.join(root.name, f"card{number}")
+            os.makedirs(card_dir)
+            with open(os.path.join(card_dir, "usbid"), "w") as file:
+                file.write(usb_id + "\n")
+            if usb_bus is not None:
+                with open(os.path.join(card_dir, "usbbus"), "w") as file:
+                    file.write(usb_bus + "\n")
+            paths.append(os.path.join(card_dir, "usbid"))
+        return sorted(paths)
+
+    def test_vid_pid_and_bus_select_exact_cards(self):
+        paths = self._card_tree({
+            3: ("0fd9:00a6", "011/007"),
+            4: ("0fd9:007d", "001/036"),
+            5: ("0fd9:00a6", "002/004"),
+        })
+        with mock.patch.object(device.glob, "glob", return_value=paths):
+            self.assertEqual(
+                device._find_card(("Elgato",), vid=0x0FD9, pid=0x007D), "4"
+            )
+            self.assertEqual(
+                device._find_card(
+                    ("Elgato",), vid=0x0FD9, pid=0x00A6,
+                    usbbus="002/004",
+                ),
+                "5",
+            )
+            self.assertIsNone(
+                device._find_card(("Elgato",), vid=0x0FD9, pid=0x0070)
+            )
+
+    def test_missing_bus_identity_never_guesses_a_duplicate(self):
+        paths = self._card_tree({3: ("0fd9:00a6", None)})
+        with mock.patch.object(device.glob, "glob", return_value=paths):
+            with mock.patch.object(device.subprocess, "run") as run:
+                self.assertIsNone(device._find_card(
+                    ("Elgato",), vid=0x0FD9, pid=0x00A6,
+                    usbbus="011/007",
+                ))
+        run.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wavexlr/device.py
+++ b/wavexlr/device.py
@@ -11,6 +11,9 @@ profiles.py; connect() picks the first supported device found.
 
 import ctypes
 import ctypes.util
+import glob
+import os
+import re
 import struct
 import subprocess
 import threading
@@ -55,16 +58,45 @@ _ctx = ctypes.c_void_p()
 _lib.libusb_init(ctypes.byref(_ctx))
 
 
-def _find_card(matches):
-    """Find the ALSA card number for the device."""
+def _find_card(matches, *, vid=None, pid=None, usbbus=None):
+    """Find the ALSA card for one USB device without guessing its identity."""
+    paths = sorted(glob.glob("/proc/asound/card*/usbid"))
+    if vid is not None and pid is not None and paths:
+        wanted_id = f"{vid:04x}:{pid:04x}"
+        readable = False
+        for path in paths:
+            try:
+                with open(path) as f:
+                    actual_id = f.read().strip().lower()
+            except OSError:
+                continue
+            readable = True
+            if actual_id != wanted_id:
+                continue
+            if usbbus is not None:
+                try:
+                    with open(os.path.join(os.path.dirname(path), "usbbus")) as f:
+                        actual_bus = f.read().strip()
+                except OSError:
+                    continue
+                if actual_bus != usbbus:
+                    continue
+            card_dir = os.path.basename(os.path.dirname(path))
+            if card_dir.startswith("card") and card_dir[4:].isdigit():
+                return card_dir[4:]
+        if readable:
+            return None
+
+    # Older kernels may not expose /proc/asound/card*/usbid. Only that case
+    # falls back to product-name matching, which cannot distinguish duplicates.
     try:
-        r = subprocess.run(
+        result = subprocess.run(
             ["aplay", "-l"], capture_output=True, text=True, timeout=3
         )
-        if r.returncode != 0:
+        if result.returncode != 0:
             return None
-        for line in r.stdout.splitlines():
-            if any(m in line for m in matches):
+        for line in result.stdout.splitlines():
+            if any(match in line for match in matches):
                 return line.split(":")[0].split()[-1]
     except Exception:
         pass
@@ -74,52 +106,124 @@ def _find_card(matches):
 def _amixer(card, *args):
     """Run amixer, returning None when the control interface did not answer."""
     try:
-        r = subprocess.run(
+        result = subprocess.run(
             ["amixer", "-c", card, *args],
             capture_output=True, text=True, timeout=3,
         )
-        return r.stdout if r.returncode == 0 else None
+        return result.stdout if result.returncode == 0 else None
     except Exception:
         return None
 
 
+_ALSA_ROLE_SUFFIX = {
+    "Capture Switch": "mute",
+    "Capture Volume": "gain",
+    "Playback Volume": "hp_vol",
+}
+_ALSA_ROLE_FALLBACK = {"mute": 5, "gain": 6, "hp_vol": 4}
+_ALSA_NUMIDS = {}
+_ALSA_CTL_MAX = {}
+
+
+def _discover_numids(card):
+    """Discover control roles and ranges from one `amixer contents` pass."""
+    if card in _ALSA_NUMIDS:
+        return _ALSA_NUMIDS[card]
+    found = {}
+    current_id = None
+    current_name = None
+    for line in (_amixer(card, "contents") or "").splitlines():
+        stripped = line.strip()
+        match = re.match(r"numid=(\d+),iface=(\w+),name='(.*)'", stripped)
+        if match:
+            current_id = int(match.group(1))
+            current_name = match.group(3)
+            if match.group(2) != "MIXER":
+                current_id = current_name = None
+            continue
+        if current_id is None or not stripped.startswith("; type="):
+            continue
+        role = next(
+            (
+                role
+                for suffix, role in _ALSA_ROLE_SUFFIX.items()
+                if current_name.endswith(suffix)
+            ),
+            None,
+        )
+        if role and role not in found:
+            found[role] = current_id
+            maximum = re.search(r",max=(-?\d+)", stripped)
+            if maximum:
+                _ALSA_CTL_MAX[(card, current_id)] = int(maximum.group(1))
+    _ALSA_NUMIDS[card] = found
+    return found
+
+
+def _numid(card, role):
+    return _discover_numids(card).get(role, _ALSA_ROLE_FALLBACK[role])
+
+
+def _alsa_ctl_max(card, numid, fallback):
+    """Return the driver-reported maximum for one ALSA control."""
+    key = (card, numid)
+    if key not in _ALSA_CTL_MAX:
+        output = _amixer(card, "cget", f"numid={numid}") or ""
+        maximum = re.search(r",max=(-?\d+)", output)
+        _ALSA_CTL_MAX[key] = int(maximum.group(1)) if maximum else fallback
+    return _ALSA_CTL_MAX[key]
+
+
+def _forget_alsa_card(card):
+    if card is None:
+        return
+    _ALSA_NUMIDS.pop(card, None)
+    for key in [key for key in _ALSA_CTL_MAX if key[0] == card]:
+        del _ALSA_CTL_MAX[key]
+
+
 def _alsa_get(card):
-    """Read ALSA mute and HP volume."""
+    """Read ALSA mute and headphone volume without inventing failed values."""
     state = {}
-    # Mute (numid=5)
-    out = _amixer(card, "cget", "numid=5")
-    if out is not None and ": values=" in out:
-        state["mute"] = ": values=off" in out
-    # HP volume (numid=4) — raw ALSA value 0-120
-    out = _amixer(card, "cget", "numid=4")
-    if out is not None:
-        for line in out.splitlines():
-            if ": values=" in line:
-                try:
-                    state["hp_vol"] = int(line.split("=")[-1])
-                except ValueError:
-                    pass
+    output = _amixer(card, "cget", f"numid={_numid(card, 'mute')}")
+    if output is not None and ": values=" in output:
+        state["mute"] = ": values=off" in output
+    output = _amixer(card, "cget", f"numid={_numid(card, 'hp_vol')}")
+    if output is not None:
+        for line in output.splitlines():
+            if ": values=" not in line:
+                continue
+            try:
+                state["hp_vol"] = int(line.split("=")[-1])
+            except ValueError:
+                pass
     return state
 
 
 def _alsa_set_mute(card, muted):
-    _amixer(card, "cset", "numid=5", "off" if muted else "on")
+    _amixer(
+        card, "cset", f"numid={_numid(card, 'mute')}",
+        "off" if muted else "on",
+    )
 
 
 def _alsa_set_hp_vol(card, value):
-    """Set ALSA HP volume (numid=4, 0-120)."""
-    _amixer(card, "cset", "numid=4", str(max(0, min(120, value))))
+    """Set ALSA headphone volume within the control's reported range."""
+    numid = _numid(card, "hp_vol")
+    maximum = _alsa_ctl_max(card, numid, 120)
+    _amixer(card, "cset", f"numid={numid}", str(max(0, min(maximum, value))))
 
 
 def _alsa_set_gain(card, value):
-    """Set ALSA mic gain (numid=6, 0-80)."""
-    _amixer(card, "cset", "numid=6", str(max(0, min(80, value))))
+    """Set ALSA microphone gain within the control's reported range."""
+    numid = _numid(card, "gain")
+    maximum = _alsa_ctl_max(card, numid, 150)
+    _amixer(card, "cset", f"numid={numid}", str(max(0, min(maximum, value))))
 
 
 def _fw_gain_to_alsa(fw_gain_raw, scale):
-    """Map firmware gain (raw / scale dB) to ALSA (0-80, 0.5 dB steps)."""
-    db = fw_gain_raw / scale
-    return max(0, min(80, round(db / 0.5)))
+    """Map firmware dB to the ALSA control's half-dB steps."""
+    return max(0, round((fw_gain_raw / scale) / 0.5))
 
 
 def _fw_hp_to_alsa(fw_hp_raw, scale):
@@ -162,13 +266,18 @@ class WaveDevice:
 
             # snd-usb-audio and OpenWave share endpoint 0. Do not start vendor
             # transfers while ALSA is still probing the device at login.
-            card = _find_card(profile.card_match)
+            card = _find_card(
+                profile.card_match, vid=profile.vid, pid=profile.pid
+            )
             if card is None:
                 _lib.libusb_close(handle)
                 raise DeviceNotReadyError(
                     f"{profile.display_name} audio interface is not ready"
                 )
-            if _amixer(card, "cget", "numid=5") is None:
+            _forget_alsa_card(card)
+            mute_numid = _numid(card, "mute")
+            if _amixer(card, "cget", f"numid={mute_numid}") is None:
+                _forget_alsa_card(card)
                 _lib.libusb_close(handle)
                 raise DeviceUnresponsiveError(
                     f"{profile.display_name} control interface is not responding"
@@ -181,12 +290,14 @@ class WaveDevice:
         raise DeviceNotReadyError("No supported Elgato Wave device found")
 
     def disconnect(self):
+        card = self._card
         with self._lock:
             if self._handle:
                 _lib.libusb_close(self._handle)
                 self._handle = None
             self._card = None
             self._last_fw = None
+        _forget_alsa_card(card)
 
     def _ctrl_read(self, wValue, length):
         """USB control read — no detach needed."""


### PR DESCRIPTION
## Summary
- match ALSA cards by USB VID:PID and optional bus/address identity
- fall back to product names only when `/proc/asound` identity is unavailable
- discover mute, gain, and headphone controls by stable name suffixes
- honor driver-reported ranges and preserve unavailable ALSA values as unknown
- keep current not-ready and unresponsive-device behavior

## Verification
- Python 3.13: 10 tests pass
- exact duplicate-device, missing-bus, renumbered-control, driver-range, and unavailable-ALSA regressions covered
- `nix build --no-link path:.#openwave`
- `git diff --check`