### PR TITLE
Support independently controlled Wave devices and capture keepalives

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@ Linux control application for **Elgato Wave** audio devices — the **Wave XLR**
 | XLR Dock (`00a6` variant) | `0fd9:00a6` | Gain, mute, 48 V phantom power, headphone volume, low impedance mode |
 | Wave:3 | `0fd9:0070` | Gain, mute, headphone volume, monitor mix |
 
+The similarly named `0fd9:00c7` Dock variant is unverified and is not enabled.
+
 ## Features
 
 - **Microphone controls** — Gain, mute (syncs with hardware button), and profile-gated 48 V phantom power
 - **Headphone controls** — Volume (syncs with hardware knob), low impedance mode
 - **Hardware sync** — 10 Hz polling keeps the app in sync with physical controls
+- **Multiple devices** — Every supported unit is opened and polled independently, including two of the same model. The sidebar selects a device by serial or USB bus/address; each has its own serialized control worker.
+- **Hotplug** — Adding or removing a device preserves the other connected units. The capture daemon maintains one keepalive per Wave input.
 - **System integration** — Mute and HP volume sync bidirectionally with PipeWire/ALSA
 - **Audio capture fix** — Starts capture before playback, keeps it pinned while running, and tears it down after the audio graph so Wave firmware survives warm reboots
 - **System tray** — Runs in background with tray icon, mute from tray menu

--- a/tests/test_audio_pins.py
+++ b/tests/test_audio_pins.py
@@ -1,0 +1,69 @@
+"""Keepalive discovery and aggregation across multiple Wave devices.
+
+The old single-pin manager had two multi-device failures pinned here: its
+source match caught only "Elgato_Wave_" (the XLR Dock enumerates as
+"Elgato_XLR_Dock_" and silently got no keepalive at all), and one healthy
+device could hide another's wedge.
+"""
+
+import unittest
+from unittest import mock
+
+from wavexlr import audio
+
+
+def _node(name):
+    return {"type": "PipeWire:Interface:Node",
+            "info": {"props": {"node.name": name}}}
+
+
+class Discovery(unittest.TestCase):
+    def test_finds_every_wave_family_node(self):
+        dump = [
+            _node("alsa_input.usb-Elgato_Systems_Elgato_Wave_XLR_ABC-00.mono"),
+            _node("alsa_input.usb-Elgato_Systems_Elgato_XLR_Dock_DEF-00.mono"),
+            _node("alsa_input.usb-Elgato_Systems_Elgato_Wave_3_GHI-00.mono"),
+        ]
+        with mock.patch.object(audio, "_pw_dump", return_value=dump):
+            names = audio._get_source_node_names()
+        self.assertEqual(len(names), 3)
+        self.assertTrue(any("XLR_Dock" in n for n in names),
+                        "the Dock must be pinned too")
+
+    def test_other_hardware_is_left_alone(self):
+        dump = [
+            _node("alsa_input.usb-Elgato_Systems_Game_Capture_HD60-00.mono"),
+            _node("alsa_input.usb-SteelSeries_Arctis_Nova-00.mono"),
+            _node("alsa_output.usb-Elgato_Systems_Elgato_Wave_XLR_A-00.st"),
+        ]
+        with mock.patch.object(audio, "_pw_dump", return_value=dump):
+            self.assertEqual(audio._get_source_node_names(), [])
+
+    def test_duplicates_collapse(self):
+        n = _node("alsa_input.usb-Elgato_Systems_Elgato_Wave_XLR_A-00.mono")
+        with mock.patch.object(audio, "_pw_dump", return_value=[n, n]):
+            self.assertEqual(len(audio._get_source_node_names()), 1)
+
+
+class Aggregation(unittest.TestCase):
+    def test_no_pins_is_absent(self):
+        self.assertEqual(audio._aggregate([]), (False, False, "absent"))
+
+    def test_all_ok_is_healthy(self):
+        self.assertEqual(audio._aggregate(["ok", "ok"]), (True, True, "ok"))
+
+    def test_one_wedged_device_cannot_hide_behind_a_healthy_one(self):
+        self.assertEqual(audio._aggregate(["ok", "wedged"]),
+                         (True, False, "wedged"))
+
+    def test_wedged_outranks_silent(self):
+        self.assertEqual(audio._aggregate(["silent", "wedged"]),
+                         (True, False, "wedged"))
+
+    def test_silent_alone_reports_silent(self):
+        self.assertEqual(audio._aggregate(["ok", "silent"]),
+                         (True, False, "silent"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_device_scan.py
+++ b/tests/test_device_scan.py
@@ -1,0 +1,105 @@
+"""Enumerating every supported Wave, including two of the same model.
+
+connect() with no arguments opens the first device of a vid:pid, which
+made a second identical unit invisible; scan() walks the bus and reports
+each one with its (bus, addr) so callers can open them individually.
+"""
+
+import unittest
+from unittest import mock
+
+from wavexlr import device
+from wavexlr.profiles import PROFILES, WAVE3, WAVE_XLR_MK2
+
+
+def _fake_bus(entries):
+    """A _each_usb_device that visits the given (vid, pid, bus, addr)."""
+    def each(visit):
+        for vid, pid, bus, addr in entries:
+            visit(vid, pid, bus, addr, object())
+    return each
+
+
+class Scan(unittest.TestCase):
+    def test_two_identical_models_are_two_results(self):
+        bus = _fake_bus([
+            (WAVE_XLR_MK2.vid, WAVE_XLR_MK2.pid, 1, 5),
+            (WAVE_XLR_MK2.vid, WAVE_XLR_MK2.pid, 3, 2),
+        ])
+        with mock.patch.object(device, "_each_usb_device", bus):
+            found = device.scan()
+        self.assertEqual(len(found), 2)
+        self.assertEqual({(b, a) for _p, b, a in found}, {(1, 5), (3, 2)})
+
+    def test_unsupported_hardware_is_ignored(self):
+        bus = _fake_bus([
+            (0x046D, 0x0825, 1, 4),          # some webcam
+            (WAVE3.vid, 0x9999, 1, 6),        # right vendor, unknown product
+            (WAVE3.vid, WAVE3.pid, 2, 3),
+        ])
+        with mock.patch.object(device, "_each_usb_device", bus):
+            found = device.scan()
+        self.assertEqual([(p.key, b, a) for p, b, a in found],
+                         [("wave3", 2, 3)])
+
+    def test_results_come_in_bus_order(self):
+        entries = [(p.vid, p.pid, bus, addr)
+                   for (p, bus, addr) in zip(PROFILES, (9, 1, 5), (9, 1, 5))]
+        with mock.patch.object(device, "_each_usb_device", _fake_bus(entries)):
+            found = device.scan()
+        self.assertEqual([(b, a) for _p, b, a in found],
+                         [(1, 1), (5, 5), (9, 9)])
+
+
+class ClosedHandle(unittest.TestCase):
+    """A transfer after disconnect must be an error, never a crash.
+
+    get_all() releases the device lock between transfers, and unplug
+    handling can disconnect in that gap. libusb does not NULL-check its
+    handle argument, so before the guard this was a segfault that took the
+    whole app down the moment a device was unplugged mid-poll.
+    """
+
+    def test_read_on_a_cleared_handle_raises(self):
+        dev = device.WaveDevice()
+        dev.profile = WAVE_XLR_MK2
+        with self.assertRaisesRegex(RuntimeError, "[Dd]isconnected"):
+            dev._ctrl_read(0x0000, 34)
+
+    def test_write_on_a_cleared_handle_raises(self):
+        dev = device.WaveDevice()
+        dev.profile = WAVE_XLR_MK2
+        with self.assertRaisesRegex(RuntimeError, "[Dd]isconnected"):
+            dev._ctrl_write(0x0000, b"\x00" * 34)
+
+
+class DeviceReadiness(unittest.TestCase):
+    def test_missing_alsa_closes_opened_handle(self):
+        dev = device.WaveDevice()
+        with mock.patch.object(dev, "_open_at", return_value=42), \
+             mock.patch.object(device, "_find_card", return_value=None), \
+             mock.patch.object(device._lib, "libusb_close") as close:
+            with self.assertRaises(device.DeviceNotReadyError):
+                dev.connect(WAVE_XLR_MK2, 1, 5)
+        self.assertFalse(dev.connected)
+        close.assert_called_once_with(42)
+
+    def test_absent_bus_identity_does_not_use_product_name_fallback(self):
+        with mock.patch.object(device.glob, "glob", return_value=[]), \
+             mock.patch.object(device.subprocess, "run") as run:
+            self.assertIsNone(device._find_card(
+                ("Elgato",), vid=0x0FD9, pid=0x00A6, usbbus="001/005"
+            ))
+        run.assert_not_called()
+
+    def test_short_transfer_is_not_decoded_as_valid_configuration(self):
+        dev = device.WaveDevice()
+        dev.profile = WAVE_XLR_MK2
+        dev._handle = 42
+        with mock.patch.object(device._lib, "libusb_control_transfer", return_value=2):
+            with self.assertRaises(RuntimeError):
+                dev.read_config()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wavexlr/app.py
+++ b/wavexlr/app.py
@@ -10,7 +10,7 @@ import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
 
-from .device import DeviceNotReadyError, DeviceUnresponsiveError, WaveDevice
+from .device import DeviceNotReadyError, DeviceUnresponsiveError, WaveDevice, scan
 from .meter import MeterMonitor
 from .mixer import Mixer
 from .mixmatrix import MixMatrix
@@ -26,18 +26,23 @@ class WaveXLRWindow(Adw.ApplicationWindow):
     def __init__(self, **kwargs):
         super().__init__(**kwargs, title="OpenWave", default_width=1100, default_height=620)
         self.set_size_request(900, 520)
-        self.dev = WaveDevice()
-        # All control transfers share endpoint 0. Keep them on one worker:
-        # overlapping polls can queue behind a one-second USB timeout and keep
-        # hammering a device that is already failing.
+        self._empty_device = WaveDevice()
+        self.dev = self._empty_device
+        self._devs = []
+        self._device_keys = {}
+        self._device_executors = {}
+        self._device_states = {}
+        self._polling_devices = set()
+        self._device_failures = {}
+        self._failed_units = set()
+        self._closing_units = set()
+        self._selector_updating = False
         self._usb_executor = ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="openwave-usb"
+            max_workers=1, thread_name_prefix="openwave-discovery"
         )
         self._shutting_down = False
         self._connect_pending = False
         self._reconnect_id = None
-        self._poll_pending = False
-        self._poll_failures = 0
         self._gain_max = 0x5000
         self._updating_ui = False
         self._last_state = None
@@ -62,6 +67,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self.mixer.start()
         self._start_stream_poll()
         self._try_connect()
+        self._schedule_reconnect()
 
     def _build_ui(self):
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
@@ -185,6 +191,12 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self.audio_status_row.add_suffix(self.uninstall_btn)
 
         status_group.add(self.audio_status_row)
+
+        self._selector_group = Adw.PreferencesGroup(visible=False)
+        parent.append(self._selector_group)
+        self.device_combo = Adw.ComboRow(title="Device")
+        self.device_combo.connect("notify::selected", self._on_device_selected)
+        self._selector_group.add(self.device_combo)
 
         # --- Mic controls ---
         mic_group = Adw.PreferencesGroup(title="Microphone")
@@ -347,99 +359,192 @@ class WaveXLRWindow(Adw.ApplicationWindow):
             err.add_response("ok", "OK")
             err.choose(self, None, lambda d, r: d.choose_finish(r))
 
-    def _usb_async(self, fn, on_done=None, on_error=None):
-        """Run a USB operation on the single device worker."""
+    def _usb_async(self, fn, on_done=None, on_error=None, *, device=None):
+        """Dispatch discovery or one device's serialized operations."""
         if self._shutting_down:
             return None
+        executor = (
+            self._usb_executor if device is None
+            else self._device_executors.get(device)
+        )
+        if executor is None:
+            return None
+        future = executor.submit(fn)
 
-        future = self._usb_executor.submit(fn)
+        def dispatch(callback, value):
+            if not self._shutting_down and (
+                device is None or device in self._device_executors
+            ):
+                callback(value)
+            return False
 
-        def _finished(done):
-            if self._shutting_down:
-                return
+        def finished(done):
             try:
                 result = done.result()
-            except Exception as e:
+            except Exception as error:
                 if on_error:
-                    GLib.idle_add(on_error, e)
+                    GLib.idle_add(dispatch, on_error, error)
             else:
                 if on_done:
-                    GLib.idle_add(on_done, result)
+                    GLib.idle_add(dispatch, on_done, result)
 
-        future.add_done_callback(_finished)
+        future.add_done_callback(finished)
         return future
+
+    def _device_async(self, method, *args):
+        device = self.dev
+        if not device.connected:
+            return None
+        return self._usb_async(
+            lambda: getattr(device, method)(*args),
+            on_error=lambda error: self._on_device_error(device, error),
+            device=device,
+        )
 
     def _try_connect(self):
         if self._connect_pending or self._shutting_down:
             return
-        if self._reconnect_id:
-            GLib.source_remove(self._reconnect_id)
-            self._reconnect_id = None
-        self._stop_polling()
         self._connect_pending = True
-        self.status_label.set_label("Connecting...")
 
-        def _connect():
-            self.dev.disconnect()
-            try:
-                self.dev.connect()
-                info = {}
+        def failed(error):
+            self._connect_pending = False
+            logging.getLogger("openwave.app").warning("USB discovery: %s", error)
+
+        self._usb_async(scan, self._on_devices_scanned, failed)
+
+    def _on_devices_scanned(self, entries):
+        self._connect_pending = False
+        wanted = {(profile.key, bus, addr) for profile, bus, addr in entries}
+        self._failed_units.intersection_update(wanted)
+        for device, key in list(self._device_keys.items()):
+            if key not in wanted:
+                self._retire_device(device)
+        held = set(self._device_keys.values())
+        for profile, bus, addr in entries:
+            key = (profile.key, bus, addr)
+            if key in held or key in self._failed_units or key in self._closing_units:
+                continue
+            device = WaveDevice()
+            self._device_keys[device] = key
+            self._device_executors[device] = ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix=f"openwave-usb-{bus}-{addr}"
+            )
+
+            def connect(dev=device, prof=profile, b=bus, a=addr):
                 try:
-                    info = self.dev.read_device_info()
+                    dev.connect(prof, b, a)
+                    dev.info = dev.read_device_info()
+                    return dev.get_all()
                 except Exception:
-                    pass
-                return {"state": self.dev.get_all(), "info": info}
-            except Exception:
-                self.dev.disconnect()
-                raise
+                    dev.disconnect()
+                    raise
 
-        def _done(result):
-            self._connect_pending = False
-            self._poll_pending = False
-            self._poll_failures = 0
-            self._apply_profile(self.dev.profile)
-            logging.getLogger("openwave.app").info(
-                "Connected to %s", self.dev.profile.display_name
+            self._usb_async(
+                connect,
+                lambda state, dev=device: self._on_device_connected(dev, state),
+                lambda error, dev=device: self._on_device_error(dev, error),
+                device=device,
             )
-            self.status_label.remove_css_class("dim-label")
-            self._apply_state(result["state"])
-            info = result["info"]
-            self.fw_label.set_label(info.get("fw_version", "—"))
-            self.api_label.set_label(info.get("api_version", "—"))
-            self.serial_label.set_label(info.get("serial", "—"))
-            self._start_polling()
 
-        def _fail(e):
-            self._connect_pending = False
-            logging.getLogger("openwave.app").warning(
-                "Device connection failed: %s", e
-            )
-            if isinstance(e, DeviceUnresponsiveError):
-                self.status_label.set_label("Power-cycle Wave device")
-            else:
-                self.status_label.set_label("Disconnected")
+    def _on_device_connected(self, device, state):
+        self._devs.append(device)
+        self._devs.sort(key=lambda dev: self._device_keys[dev][1:])
+        self._device_states[device] = state
+        if self.dev not in self._devs:
+            self._select_device(device)
+        self._refresh_device_selector()
+        self._start_polling()
+
+    def _refresh_device_selector(self):
+        self._selector_updating = True
+        try:
+            labels = []
+            for device in self._devs:
+                serial = device.info.get("serial") or device.usbbus
+                labels.append(f"{device.profile.display_name} — {serial}")
+            self.device_combo.set_model(Gtk.StringList.new(labels))
+            if self.dev in self._devs:
+                self.device_combo.set_selected(self._devs.index(self.dev))
+            self._selector_group.set_visible(len(self._devs) > 1)
+        finally:
+            self._selector_updating = False
+
+    def _on_device_selected(self, row, _param):
+        index = row.get_selected()
+        if not self._selector_updating and 0 <= index < len(self._devs):
+            self._select_device(self._devs[index])
+
+    def _select_device(self, device):
+        # A delayed slider send belongs to the previous device, never the new
+        # selection. Already queued operations captured their device object.
+        for name in ("_gain_timeout", "_hp_timeout", "_mix_timeout"):
+            source_id = getattr(self, name)
+            if source_id:
+                GLib.source_remove(source_id)
+                setattr(self, name, None)
+        self.dev = device
+        self._last_state = None
+        if device is self._empty_device:
+            self.status_label.set_label("Disconnected")
             self.status_label.add_css_class("dim-label")
-            if isinstance(e, DeviceNotReadyError):
-                self._schedule_reconnect()
+            return
+        self._updating_ui = True
+        try:
+            self._apply_profile(device.profile)
+        finally:
+            self._updating_ui = False
+        self.device_combo.set_subtitle(
+            f"USB {device.usbbus} · {device.info.get('serial', 'No serial')}"
+        )
+        self._apply_state(self._device_states[device])
+        self.status_label.remove_css_class("dim-label")
+        self.fw_label.set_label(device.info.get("fw_version", "—"))
+        self.api_label.set_label(device.info.get("api_version", "—"))
+        self.serial_label.set_label(device.info.get("serial", "—"))
 
-        self._usb_async(_connect, _done, _fail)
+    def _retire_device(self, device):
+        executor = self._device_executors.pop(device, None)
+        key = self._device_keys.pop(device, None)
+        self._device_states.pop(device, None)
+        self._device_failures.pop(device, None)
+        self._polling_devices.discard(device)
+        if device in self._devs:
+            self._devs.remove(device)
+        if self.dev is device:
+            self._select_device(self._devs[0] if self._devs else self._empty_device)
+        self._refresh_device_selector()
+        if executor is not None:
+            self._closing_units.add(key)
+            executor.shutdown(wait=False, cancel_futures=True)
+
+            def close():
+                executor.shutdown(wait=True)
+                device.disconnect()
+
+            self._usb_async(close, lambda _: self._closing_units.discard(key))
+
+    def _on_device_error(self, device, error):
+        key = self._device_keys.get(device)
+        logging.getLogger("openwave.app").warning("Device %s: %s", key, error)
+        if key and isinstance(error, DeviceUnresponsiveError):
+            self._failed_units.add(key)
+        self._retire_device(device)
+        if not self._devs and isinstance(error, DeviceUnresponsiveError):
+            self.status_label.set_label("Power-cycle Wave device")
 
     def _schedule_reconnect(self):
         if self._reconnect_id or self._shutting_down:
             return
 
-        def _retry():
-            self._reconnect_id = None
+        def watch():
             self._try_connect()
-            return False
+            return True
 
-        self._reconnect_id = GLib.timeout_add_seconds(2, _retry)
+        self._reconnect_id = GLib.timeout_add_seconds(2, watch)
 
     def _start_polling(self):
-        """Start 10 Hz polling to sync hardware state."""
-        if self._poll_id:
-            GLib.source_remove(self._poll_id)
-        self._poll_id = GLib.timeout_add(100, self._poll_tick)
+        if self._poll_id is None:
+            self._poll_id = GLib.timeout_add(100, self._poll_tick)
 
     def _stop_polling(self):
         if self._poll_id:
@@ -447,49 +552,52 @@ class WaveXLRWindow(Adw.ApplicationWindow):
             self._poll_id = None
 
     def _poll_tick(self):
-        """Queue one poll when the previous poll has completed."""
-        if not self.dev.connected:
-            self._poll_id = None
-            return False
-        if self._poll_pending:
-            return True
-        self._poll_pending = True
-        self._usb_async(
-            self.dev.get_all, self._on_poll_result, self._on_poll_error
-        )
+        for device in self._devs:
+            if device in self._polling_devices:
+                continue
+            self._polling_devices.add(device)
+            self._usb_async(
+                device.get_all,
+                lambda state, dev=device: self._on_poll_result(dev, state),
+                lambda error, dev=device: self._on_poll_error(dev, error),
+                device=device,
+            )
         return True
 
-    def _on_poll_result(self, state):
-        self._poll_pending = False
-        self._poll_failures = 0
-        if state != self._last_state:
+    def _on_poll_result(self, device, state):
+        self._polling_devices.discard(device)
+        self._device_failures[device] = 0
+        self._device_states[device] = state
+        if device is self.dev and state != self._last_state:
             self._apply_state(state)
 
-    def _on_poll_error(self, e):
-        self._poll_pending = False
-        self._poll_failures += 1
-        logging.getLogger("openwave.app").warning(
-            "Device poll failed (%d/3): %s", self._poll_failures, e
-        )
-        if self._poll_failures < 3:
-            return
-        if isinstance(e, DeviceUnresponsiveError):
-            self.status_label.set_label("Power-cycle Wave device")
-        else:
-            self.status_label.set_label("Disconnected")
-        self.status_label.add_css_class("dim-label")
-        self._stop_polling()
-        self._usb_async(self.dev.disconnect)
+    def _on_poll_error(self, device, error):
+        self._polling_devices.discard(device)
+        failures = self._device_failures.get(device, 0) + 1
+        self._device_failures[device] = failures
+        if failures >= 3:
+            self._on_device_error(device, error)
 
     def shutdown(self):
-        """Stop queued USB work before closing the shared libusb handle."""
+        """Quiesce every device worker before closing its libusb handle."""
         self._shutting_down = True
-        if self._reconnect_id:
-            GLib.source_remove(self._reconnect_id)
-            self._reconnect_id = None
-        self._stop_polling()
-        self._usb_executor.shutdown(wait=True, cancel_futures=True)
-        self.dev.disconnect()
+        for name in (
+            "_reconnect_id", "_poll_id", "_stream_poll_id",
+            "_gain_timeout", "_hp_timeout", "_mix_timeout",
+        ):
+            source_id = getattr(self, name, None)
+            if source_id:
+                GLib.source_remove(source_id)
+                setattr(self, name, None)
+        for source_id in self._cell_debounce_ids.values():
+            GLib.source_remove(source_id)
+        self._cell_debounce_ids.clear()
+        self._usb_executor.shutdown(wait=True, cancel_futures=False)
+        for device, executor in self._device_executors.items():
+            executor.shutdown(wait=True, cancel_futures=True)
+            device.disconnect()
+        self._device_executors.clear()
+        self._devs.clear()
 
     def _apply_profile(self, profile):
         """Adapt the UI to the connected device model."""
@@ -533,21 +641,12 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self.mic_source.set_muted(state["mute"])
         self._updating_ui = False
 
-    def _on_usb_error(self, e):
-        logging.getLogger("openwave.app").warning("Device write failed: %s", e)
-        if isinstance(e, DeviceUnresponsiveError):
-            self.status_label.set_label("Power-cycle Wave device")
-        else:
-            self.status_label.set_label("Disconnected")
-        self.status_label.add_css_class("dim-label")
-        self._stop_polling()
-        self._usb_async(self.dev.disconnect)
 
     def _on_mute_changed(self, row, _pspec):
         if self._updating_ui or not self.dev.connected:
             return
         muted = row.get_active()
-        self._usb_async(lambda: self.dev.set_mute(muted), on_error=self._on_usb_error)
+        self._device_async("set_mute", muted)
 
     def _on_gain_changed(self, scale):
         if self._updating_ui or not self.dev.connected:
@@ -561,7 +660,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
 
     def _send_gain(self, val):
         self._gain_timeout = None
-        self._usb_async(lambda: self.dev.set_gain_raw(val), on_error=self._on_usb_error)
+        self._device_async("set_gain_raw", val)
         return False
 
     def _on_hp_changed(self, scale):
@@ -575,22 +674,20 @@ class WaveXLRWindow(Adw.ApplicationWindow):
 
     def _send_hp(self, db):
         self._hp_timeout = None
-        self._usb_async(lambda: self.dev.set_hp_volume_db(db), on_error=self._on_usb_error)
+        self._device_async("set_hp_volume_db", db)
         return False
 
     def _on_lowz_changed(self, row, _pspec):
         if self._updating_ui or not self.dev.connected:
             return
         enabled = row.get_active()
-        self._usb_async(lambda: self.dev.set_low_impedance(enabled), on_error=self._on_usb_error)
+        self._device_async("set_low_impedance", enabled)
 
     def _on_phantom_changed(self, row, _pspec):
         if self._updating_ui or not self.dev.connected:
             return
         enabled = row.get_active()
-        self._usb_async(
-            lambda: self.dev.set_phantom(enabled), on_error=self._on_usb_error
-        )
+        self._device_async("set_phantom", enabled)
 
 
     def _on_mix_changed(self, scale):
@@ -604,7 +701,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
 
     def _send_mix(self, val):
         self._mix_timeout = None
-        self._usb_async(lambda: self.dev.set_monitor_mix(val), on_error=self._on_usb_error)
+        self._device_async("set_monitor_mix", val)
         return False
 
     def _on_mic_matrix_volume_changed(self, _source, value):
@@ -625,7 +722,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self._updating_ui = True
         self.mute_row.set_active(muted)
         self._updating_ui = False
-        self._usb_async(lambda: self.dev.set_mute(muted), on_error=self._on_usb_error)
+        self._device_async("set_mute", muted)
 
     def _wire_matrix_cells(self):
         """Bind each per-cell slider/mute to the mixer + restore persisted levels."""
@@ -865,10 +962,7 @@ class WaveXLRApp(Adw.Application):
     def _toggle_mute(self):
         if self._window and self._window.dev.connected:
             current = self._window._last_state and self._window._last_state.get("mute", False)
-            self._window._usb_async(
-                lambda: self._window.dev.set_mute(not current),
-                on_error=self._window._on_usb_error,
-            )
+            self._window._device_async("set_mute", not current)
 
     def _quit_app(self):
         self.release()

--- a/wavexlr/audio.py
+++ b/wavexlr/audio.py
@@ -44,7 +44,14 @@ import logging
 
 log = logging.getLogger("wavexlr.audio")
 
-SOURCE_MATCH = "alsa_input.usb-Elgato_Systems_Elgato_Wave_"
+# Every Wave family capture node. Two stems, not one "Elgato_" prefix,
+# because Elgato also ships capture cards with audio inputs that must not
+# be pinned; and not "Wave_" alone, because the XLR Dock (MK.2) enumerates
+# as "Elgato_XLR_Dock_..." — the old single-stem match silently skipped it.
+SOURCE_MATCHES = (
+    "alsa_input.usb-Elgato_Systems_Elgato_Wave_",
+    "alsa_input.usb-Elgato_Systems_Elgato_XLR_Dock_",
+)
 
 # Seconds without byte flow before we consider the keepalive wedged. At
 # 48 kHz mono s16 the healthy rate is ~96 kB/s, so even 1s of silence is
@@ -81,9 +88,6 @@ MAX_SILENCE_RECYCLES = 1
 # to attach, negotiate, and start emitting samples.
 STARTUP_GRACE = 1.0
 
-# Retry quickly while PipeWire is publishing the device, then back off when a
-# Wave device is genuinely absent. This keeps capture ahead of playback during
-# login without polling an unplugged setup several times per second forever.
 ABSENT_RETRY_INITIAL = 0.1
 ABSENT_RETRY_MAX = 5.0
 
@@ -95,16 +99,16 @@ SIGTERM_GRACE = 0.5
 
 
 def _pw_dump():
-    """Get PipeWire object dump as JSON."""
+    """Return the graph, or None when observation failed."""
     try:
-        r = subprocess.run(
+        result = subprocess.run(
             ["pw-dump", "--no-colors"], capture_output=True, text=True, timeout=5
         )
-        if r.returncode == 0:
-            return json.loads(r.stdout)
-    except Exception:
+        if result.returncode == 0:
+            return json.loads(result.stdout)
+    except (OSError, subprocess.SubprocessError, ValueError):
         pass
-    return []
+    return None
 
 
 def _source_is_muted(node_name):
@@ -118,6 +122,8 @@ def _source_is_muted(node_name):
     if not node_name:
         return False
     dump = _pw_dump()
+    if dump is None:
+        return None
     device_id = None
     for obj in dump:
         if obj.get("type") != "PipeWire:Interface:Node":
@@ -142,74 +148,94 @@ def _source_is_muted(node_name):
     return False
 
 
-def _get_source_node_name():
-    """Get the full node name of the Elgato Wave source."""
-    for obj in _pw_dump():
+def _get_source_node_names():
+    """Every Elgato Wave capture node currently present, in dump order."""
+    dump = _pw_dump()
+    if dump is None:
+        return None
+    names = []
+    for obj in dump:
         if obj.get("type") != "PipeWire:Interface:Node":
             continue
         props = obj.get("info", {}).get("props", {})
         name = props.get("node.name", "")
-        if name.startswith(SOURCE_MATCH):
-            return name
-    return None
+        if name.startswith(SOURCE_MATCHES) and name not in names:
+            names.append(name)
+    return names
 
 
-class AudioManager:
-    """Keeps the Wave XLR capture stream active via a watched pw-cat subprocess.
+def _aggregate(states):
+    """One (present, healthy, state) for many pins.
 
-    The subprocess's stdout is drained by a reader thread; the main loop
-    detects wedge ("alive but no data") and recycles the subprocess.
+    The worst pin wins the state — a wedged device must not hide behind a
+    healthy one — and the manager is healthy only when every pin is.
     """
+    if not states:
+        return False, False, "absent"
+    for worst in ("wedged", "silent"):
+        if worst in states:
+            return True, False, worst
+    return True, all(s == "ok" for s in states), "ok"
 
-    def __init__(self, on_status_change=None):
-        self._running = False
-        self._loop_thread = None
-        self._cat_proc = None
-        self._reader_thread = None
+
+class _Pin:
+    """One watched pw-cat keepalive against one Wave capture node."""
+
+    def __init__(self, source_name):
+        self.source_name = source_name
+        self.state = "ok"
+        self._proc = None
+        self._reader = None
         self._last_data_at = 0.0
         self._last_signal_at = 0.0
-        self._source_name = None
+        self._started_at = 0.0
         self._silence_recycles = 0
         self._muted = False
         self._mute_checked_at = 0.0
-        self._absent_retry = ABSENT_RETRY_INITIAL
-        self._healthy = False
-        self._state = "absent"
-        self._device_present = False
-        self._status_reported = False
-        self.on_status_change = on_status_change
 
-    @property
-    def healthy(self):
-        return self._healthy
-
-    @property
-    def state(self):
-        """One of "ok", "wedged", "silent", "absent"."""
-        return self._state
-
-    @property
-    def device_present(self):
-        return self._device_present
+    # --- lifecycle ---
 
     def start(self):
-        if self._running:
-            return
-        self._running = True
-        self._loop_thread = threading.Thread(target=self._run, daemon=True)
-        self._loop_thread.start()
+        self.kill()
+        now = time.monotonic()
+        self._last_data_at = now
+        self._last_signal_at = now
+        self._started_at = now
+        self._proc = subprocess.Popen(
+            [
+                "pw-cat", "--record",
+                "--target", self.source_name,
+                "--channels", "1",
+                "--format", "s16",
+                "--rate", "48000",
+                "--latency", "200ms",
+                "--properties", json.dumps({
+                    "node.name": f"openwave_keepalive_{self.source_name}",
+                    "node.description": "OpenWave capture keepalive",
+                    "media.name": f"OpenWave keepalive: {self.source_name}",
+                    "application.name": "OpenWave",
+                }),
+                "-",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            # New process group so SIGKILL on the leader cleans up any
+            # children too. start_new_session=True is the portable spelling.
+            start_new_session=True,
+        )
+        self._reader = threading.Thread(
+            target=self._drain, args=(self._proc,), daemon=True
+        )
+        self._reader.start()
+        log.info(
+            f"Started capture keepalive for {self.source_name} "
+            f"(PID {self._proc.pid})"
+        )
 
-    def stop(self):
-        self._running = False
-        self._kill_cat()
-        if self._loop_thread:
-            self._loop_thread.join(timeout=3)
-
-    def _kill_cat(self):
-        proc = self._cat_proc
-        reader = self._reader_thread
-        self._cat_proc = None
-        self._reader_thread = None
+    def kill(self):
+        proc, reader = self._proc, self._reader
+        self._proc = None
+        self._reader = None
         if proc and proc.poll() is None:
             try:
                 proc.terminate()
@@ -225,39 +251,10 @@ class AudioManager:
                     proc.wait(timeout=1)
                 except subprocess.TimeoutExpired:
                     pass
-            log.info("Stopped capture keepalive")
+            log.info(f"Stopped capture keepalive for {self.source_name}")
         # Reader thread exits when the pipe closes.
         if reader and reader.is_alive():
             reader.join(timeout=2)
-
-    def _start_cat(self, source_name):
-        """Spawn pw-cat with stdout piped so we can monitor byte flow."""
-        self._kill_cat()
-        now = time.monotonic()
-        self._last_data_at = now
-        self._last_signal_at = now
-        self._source_name = source_name
-        self._cat_proc = subprocess.Popen(
-            [
-                "pw-cat", "--record",
-                "--target", source_name,
-                "--channels", "1",
-                "--format", "s16",
-                "--rate", "48000",
-                "--latency", "200ms",
-                "-",
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            # New process group so SIGKILL on the leader cleans up any
-            # children too. start_new_session=True is the portable spelling.
-            start_new_session=True,
-        )
-        self._reader_thread = threading.Thread(
-            target=self._drain, args=(self._cat_proc,), daemon=True
-        )
-        self._reader_thread.start()
-        log.info(f"Started capture keepalive (PID {self._cat_proc.pid})")
 
     def _drain(self, proc):
         """Drain pw-cat's stdout, updating the last-data-received timestamp.
@@ -271,12 +268,11 @@ class AudioManager:
                 chunk = proc.stdout.read(DRAIN_CHUNK)
                 if not chunk:
                     return
-                now = time.monotonic()
-                self._last_data_at = now
-                # count(0) is a C-level scan; `any(chunk)` would be a
-                # Python loop over every byte of a 96 kB/s stream.
-                if chunk.count(0) != len(chunk):
-                    self._last_signal_at = now
+                if self._proc is proc:
+                    now = time.monotonic()
+                    self._last_data_at = now
+                    if chunk.count(0) != len(chunk):
+                        self._last_signal_at = now
         except Exception:
             return
         finally:
@@ -285,8 +281,10 @@ class AudioManager:
             except Exception:
                 pass
 
-    def _cat_alive(self):
-        return self._cat_proc is not None and self._cat_proc.poll() is None
+    # --- health ---
+
+    def _alive(self):
+        return self._proc is not None and self._proc.poll() is None
 
     def _data_flowing(self):
         return (time.monotonic() - self._last_data_at) < WEDGE_TIMEOUT
@@ -300,8 +298,114 @@ class AudioManager:
         if now - self._mute_checked_at < SILENCE_RECHECK:
             return self._muted
         self._mute_checked_at = now
-        self._muted = _source_is_muted(self._source_name)
+        self._muted = _source_is_muted(self.source_name)
         return self._muted
+
+    def step(self):
+        """Advance the watchdog one tick; returns the pin's state string."""
+        if not self._alive():
+            if self._proc is not None:
+                log.warning(
+                    f"Capture keepalive for {self.source_name} exited "
+                    f"unexpectedly (rc={self._proc.poll()}); restarting"
+                )
+            self.start()
+            self.state = "ok"
+            return self.state
+
+        if time.monotonic() - self._started_at < STARTUP_GRACE:
+            return self.state
+
+        if not self._data_flowing():
+            stalled_for = time.monotonic() - self._last_data_at
+            log.warning(
+                f"Capture keepalive for {self.source_name} wedged "
+                f"({stalled_for:.1f}s without data); recycling to release "
+                "the shared USB clock"
+            )
+            self.kill()
+            # Brief settle so PipeWire fully releases the device before
+            # the next tick's restart reattaches.
+            self.state = "wedged"
+            return self.state
+
+        if self._signal_flowing():
+            self._silence_recycles = 0
+            self.state = "ok"
+            return self.state
+
+        muted = self._source_muted()
+        if muted is None:
+            return self.state
+        if muted:
+            # Zeros are the correct output for a muted mic. Move the clock
+            # along so an unmute is what starts the silence window, not the
+            # mute that preceded it.
+            self._last_signal_at = time.monotonic()
+            self.state = "ok"
+            return self.state
+
+        silent_for = time.monotonic() - self._last_signal_at
+        if self._silence_recycles < MAX_SILENCE_RECYCLES:
+            self._silence_recycles += 1
+            log.warning(
+                f"Capture stream for {self.source_name} silent "
+                f"({silent_for:.0f}s of zero samples while unmuted); "
+                "recycling once"
+            )
+            self.kill()
+        self.state = "silent"
+        return self.state
+
+
+class AudioManager:
+    """One watched keepalive per connected Wave device.
+
+    Discovery reruns every tick, so a device plugged in later gets its pin
+    and an unplugged one loses it. Status is the aggregate: the worst pin's
+    state, healthy only when every pin is — two devices means two shared
+    USB clocks, either of which can wedge on its own.
+    """
+
+    def __init__(self, on_status_change=None):
+        self._running = False
+        self._loop_thread = None
+        self._pins = {}  # source node name -> _Pin
+        self._stop = threading.Event()
+        self._absent_retry = ABSENT_RETRY_INITIAL
+        self._status_reported = False
+        self._healthy = False
+        self._state = "absent"
+        self._device_present = False
+        self.on_status_change = on_status_change
+
+    @property
+    def healthy(self):
+        return self._healthy
+
+    @property
+    def state(self):
+        """One of "ok", "wedged", "silent", "absent" — the worst pin's."""
+        return self._state
+
+    @property
+    def device_present(self):
+        return self._device_present
+
+    def start(self):
+        if self._running:
+            return
+        self._running = True
+        self._stop.clear()
+        self._loop_thread = threading.Thread(target=self._run, daemon=True)
+        self._loop_thread.start()
+
+    def stop(self):
+        self._running = False
+        self._stop.set()
+        if self._loop_thread:
+            self._loop_thread.join()
+            self._loop_thread = None
 
     def _update_status(self, present, healthy, state):
         changed = (
@@ -318,77 +422,42 @@ class AudioManager:
             self.on_status_change(present, healthy, state)
 
     def _run(self):
-        while self._running:
-            try:
-                if self._cat_alive():
-                    if not self._data_flowing():
-                        stalled_for = time.monotonic() - self._last_data_at
-                        log.warning(
-                            f"Capture keepalive wedged ({stalled_for:.1f}s "
-                            "without data); recycling to release the shared "
-                            "USB clock"
+        try:
+            while not self._stop.is_set():
+                delay = WATCHDOG_INTERVAL
+                try:
+                    names = _get_source_node_names()
+                    if names is None:
+                        self._stop.wait(WATCHDOG_INTERVAL)
+                        continue
+                    if self._stop.is_set():
+                        break
+                    for name in list(self._pins):
+                        if name not in names:
+                            self._pins.pop(name).kill()
+                    for name in names:
+                        if self._stop.is_set():
+                            break
+                        if name not in self._pins:
+                            self._pins[name] = _Pin(name)
+                    states = []
+                    for pin in self._pins.values():
+                        if self._stop.is_set():
+                            break
+                        states.append(pin.step())
+                    self._update_status(*_aggregate(states))
+                    if states:
+                        self._absent_retry = ABSENT_RETRY_INITIAL
+                    else:
+                        delay = self._absent_retry
+                        self._absent_retry = min(
+                            ABSENT_RETRY_MAX, self._absent_retry * 2
                         )
-                        self._kill_cat()
-                        self._update_status(True, False, "wedged")
-                        # Brief settle so PipeWire fully releases the device
-                        # before the new pw-cat reattaches.
-                        time.sleep(0.5)
-                        continue
-
-                    if self._signal_flowing():
-                        self._silence_recycles = 0
-                        self._update_status(True, True, "ok")
-                        time.sleep(WATCHDOG_INTERVAL)
-                        continue
-
-                    if self._source_muted():
-                        # Zeros are the correct output for a muted mic.
-                        # Move the clock along so an unmute is what starts
-                        # the silence window, not the mute that preceded it.
-                        self._last_signal_at = time.monotonic()
-                        self._update_status(True, True, "ok")
-                        time.sleep(WATCHDOG_INTERVAL)
-                        continue
-
-                    silent_for = time.monotonic() - self._last_signal_at
-                    if self._silence_recycles < MAX_SILENCE_RECYCLES:
-                        self._silence_recycles += 1
-                        log.warning(
-                            f"Capture stream silent ({silent_for:.0f}s of zero "
-                            "samples while unmuted); recycling once"
-                        )
-                        self._kill_cat()
-                        self._update_status(True, False, "silent")
-                        time.sleep(0.5)
-                        continue
-
-                    self._update_status(True, False, "silent")
-                    time.sleep(SILENCE_RECHECK)
-                    continue
-
-                if self._cat_proc is not None:
-                    log.warning(
-                        f"Capture keepalive exited unexpectedly "
-                        f"(rc={self._cat_proc.poll()}); restarting"
-                    )
-                    self._cat_proc = None
-
-                source_name = _get_source_node_name()
-                if not source_name:
-                    self._update_status(False, False, "absent")
-                    time.sleep(self._absent_retry)
-                    self._absent_retry = min(
-                        ABSENT_RETRY_MAX, self._absent_retry * 2
-                    )
-                    continue
-
-                self._absent_retry = ABSENT_RETRY_INITIAL
-                self._start_cat(source_name)
-                time.sleep(STARTUP_GRACE)
-                started = self._cat_alive() and self._data_flowing()
-                self._update_status(True, started, "ok" if started else "wedged")
-
-            except Exception as e:
-                log.error(f"Audio manager error: {e}")
-                self._update_status(self._device_present, False, self._state)
-                time.sleep(2)
+                except Exception:
+                    log.exception("Audio manager error")
+                    delay = 2.0
+                self._stop.wait(delay)
+        finally:
+            for pin in self._pins.values():
+                pin.kill()
+            self._pins.clear()

--- a/wavexlr/device.py
+++ b/wavexlr/device.py
@@ -17,6 +17,7 @@ import re
 import struct
 import subprocess
 import threading
+import time
 
 from .profiles import PROFILES
 
@@ -43,8 +44,6 @@ _lib = ctypes.CDLL(_lib_path)
 
 _lib.libusb_init.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
 _lib.libusb_init.restype = ctypes.c_int
-_lib.libusb_open_device_with_vid_pid.argtypes = [ctypes.c_void_p, ctypes.c_uint16, ctypes.c_uint16]
-_lib.libusb_open_device_with_vid_pid.restype = ctypes.c_void_p
 _lib.libusb_close.argtypes = [ctypes.c_void_p]
 _lib.libusb_close.restype = None
 _lib.libusb_control_transfer.argtypes = [
@@ -53,9 +52,81 @@ _lib.libusb_control_transfer.argtypes = [
     ctypes.POINTER(ctypes.c_ubyte), ctypes.c_uint16, ctypes.c_uint,
 ]
 _lib.libusb_control_transfer.restype = ctypes.c_int
+_lib.libusb_get_device_list.argtypes = [
+    ctypes.c_void_p, ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p))
+]
+_lib.libusb_get_device_list.restype = ctypes.c_ssize_t
+_lib.libusb_free_device_list.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_int]
+_lib.libusb_free_device_list.restype = None
+_lib.libusb_get_bus_number.argtypes = [ctypes.c_void_p]
+_lib.libusb_get_bus_number.restype = ctypes.c_uint8
+_lib.libusb_get_device_address.argtypes = [ctypes.c_void_p]
+_lib.libusb_get_device_address.restype = ctypes.c_uint8
+_lib.libusb_open.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+_lib.libusb_open.restype = ctypes.c_int
+
+
+class _DeviceDescriptor(ctypes.Structure):
+    _fields_ = [
+        ("bLength", ctypes.c_uint8),
+        ("bDescriptorType", ctypes.c_uint8),
+        ("bcdUSB", ctypes.c_uint16),
+        ("bDeviceClass", ctypes.c_uint8),
+        ("bDeviceSubClass", ctypes.c_uint8),
+        ("bDeviceProtocol", ctypes.c_uint8),
+        ("bMaxPacketSize0", ctypes.c_uint8),
+        ("idVendor", ctypes.c_uint16),
+        ("idProduct", ctypes.c_uint16),
+        ("bcdDevice", ctypes.c_uint16),
+        ("iManufacturer", ctypes.c_uint8),
+        ("iProduct", ctypes.c_uint8),
+        ("iSerialNumber", ctypes.c_uint8),
+        ("bNumConfigurations", ctypes.c_uint8),
+    ]
+
+
+_lib.libusb_get_device_descriptor.argtypes = [
+    ctypes.c_void_p, ctypes.POINTER(_DeviceDescriptor)
+]
+_lib.libusb_get_device_descriptor.restype = ctypes.c_int
 
 _ctx = ctypes.c_void_p()
 _lib.libusb_init(ctypes.byref(_ctx))
+
+
+def _each_usb_device(visit):
+    """Visit devices while their enumeration references remain valid."""
+    devices = ctypes.POINTER(ctypes.c_void_p)()
+    count = _lib.libusb_get_device_list(_ctx, ctypes.byref(devices))
+    if count < 0:
+        raise RuntimeError(f"USB enumeration failed (err {count})")
+    try:
+        descriptor = _DeviceDescriptor()
+        for index in range(count):
+            dev = devices[index]
+            if _lib.libusb_get_device_descriptor(dev, ctypes.byref(descriptor)):
+                continue
+            visit(
+                descriptor.idVendor, descriptor.idProduct,
+                _lib.libusb_get_bus_number(dev),
+                _lib.libusb_get_device_address(dev), dev,
+            )
+    finally:
+        _lib.libusb_free_device_list(devices, 1)
+
+
+def scan():
+    """Return every supported (profile, bus, address), including duplicates."""
+    profiles = {(profile.vid, profile.pid): profile for profile in PROFILES}
+    found = []
+
+    def visit(vid, pid, bus, addr, _dev):
+        profile = profiles.get((vid, pid))
+        if profile is not None:
+            found.append((profile, bus, addr))
+
+    _each_usb_device(visit)
+    return sorted(found, key=lambda entry: (entry[1], entry[2]))
 
 
 def _find_card(matches, *, vid=None, pid=None, usbbus=None):
@@ -86,6 +157,8 @@ def _find_card(matches, *, vid=None, pid=None, usbbus=None):
                 return card_dir[4:]
         if readable:
             return None
+    if usbbus is not None:
+        return None
 
     # Older kernels may not expose /proc/asound/card*/usbid. Only that case
     # falls back to product-name matching, which cannot distinguish duplicates.
@@ -178,8 +251,9 @@ def _forget_alsa_card(card):
     if card is None:
         return
     _ALSA_NUMIDS.pop(card, None)
-    for key in [key for key in _ALSA_CTL_MAX if key[0] == card]:
-        del _ALSA_CTL_MAX[key]
+    for key in list(_ALSA_CTL_MAX):
+        if key[0] == card:
+            _ALSA_CTL_MAX.pop(key, None)
 
 
 def _alsa_get(card):
@@ -251,23 +325,35 @@ class WaveDevice:
         self._card = None
         self._last_fw = None  # last known firmware state for change detection
         self.profile = None
+        self.usbbus = None
+        self.info = {}
+        self._last_alsa_at = 0.0
 
     @property
     def connected(self):
         return self._handle is not None
 
-    def connect(self):
-        for profile in PROFILES:
-            handle = _lib.libusb_open_device_with_vid_pid(
-                _ctx, profile.vid, profile.pid
-            )
-            if not handle:
-                continue
-
-            # snd-usb-audio and OpenWave share endpoint 0. Do not start vendor
-            # transfers while ALSA is still probing the device at login.
+    def connect(self, profile=None, bus=None, addr=None):
+        """Open the exact scanned unit, only after its ALSA controls are ready."""
+        if profile is None:
+            found = scan()
+            if not found:
+                raise DeviceNotReadyError("No supported Elgato Wave device found")
+            profile, bus, addr = found[0]
+        if bus is None or addr is None:
+            raise ValueError("Opening a device requires both USB bus and address")
+        usbbus = f"{bus:03d}/{addr:03d}"
+        with self._lock:
+            if self._handle is not None:
+                raise RuntimeError("Device is already connected")
+            handle = self._open_at(profile, bus, addr)
+            if handle is None:
+                raise DeviceNotReadyError(
+                    f"Cannot open {profile.display_name} at {usbbus}"
+                )
             card = _find_card(
-                profile.card_match, vid=profile.vid, pid=profile.pid
+                profile.card_match, vid=profile.vid, pid=profile.pid,
+                usbbus=usbbus,
             )
             if card is None:
                 _lib.libusb_close(handle)
@@ -282,12 +368,24 @@ class WaveDevice:
                 raise DeviceUnresponsiveError(
                     f"{profile.display_name} control interface is not responding"
                 )
-
             self._handle = handle
             self.profile = profile
             self._card = card
-            return
-        raise DeviceNotReadyError("No supported Elgato Wave device found")
+            self.usbbus = usbbus
+
+    @staticmethod
+    def _open_at(profile, bus, addr):
+        handle = ctypes.c_void_p()
+
+        def visit(vid, pid, device_bus, device_addr, dev):
+            if handle.value or (vid, pid, device_bus, device_addr) != (
+                profile.vid, profile.pid, bus, addr
+            ):
+                return
+            _lib.libusb_open(dev, ctypes.byref(handle))
+
+        _each_usb_device(visit)
+        return handle.value
 
     def disconnect(self):
         card = self._card
@@ -297,12 +395,16 @@ class WaveDevice:
                 self._handle = None
             self._card = None
             self._last_fw = None
+            self.usbbus = None
+            self.info = {}
         _forget_alsa_card(card)
 
     def _ctrl_read(self, wValue, length):
         """USB control read — no detach needed."""
         buf = (ctypes.c_ubyte * length)()
         with self._lock:
+            if self._handle is None:
+                raise RuntimeError("Device disconnected")
             ret = _lib.libusb_control_transfer(
                 self._handle, RT_CLASS_IN, BREQUEST_READ, wValue, self.profile.windex,
                 buf, length, 1000,
@@ -312,6 +414,8 @@ class WaveDevice:
             if ret == LIBUSB_ERROR_TIMEOUT:
                 raise DeviceUnresponsiveError(error)
             raise RuntimeError(error)
+        if ret != length:
+            raise RuntimeError(f"Incomplete USB read ({ret}/{length} bytes)")
         return bytearray(buf[:ret])
 
     def _ctrl_write(self, wValue, data):
@@ -319,6 +423,8 @@ class WaveDevice:
         data = bytes(data)
         buf = (ctypes.c_ubyte * len(data))(*data)
         with self._lock:
+            if self._handle is None:
+                raise RuntimeError("Device disconnected")
             ret = _lib.libusb_control_transfer(
                 self._handle, RT_CLASS_OUT, BREQUEST_WRITE, wValue, self.profile.windex,
                 buf, len(data), 1000,
@@ -328,6 +434,8 @@ class WaveDevice:
             if ret == LIBUSB_ERROR_TIMEOUT:
                 raise DeviceUnresponsiveError(error)
             raise RuntimeError(error)
+        if ret != len(data):
+            raise RuntimeError(f"Incomplete USB write ({ret}/{len(data)} bytes)")
 
     def read_config(self):
         return self._ctrl_read(self.profile.wvalue_config, self.profile.config_len)
@@ -390,6 +498,11 @@ class WaveDevice:
         return struct.unpack_from('<H', self.read_config(), self.profile.off_monitor_mix)[0]
 
     def get_all(self):
+        """Read and synchronize one complete firmware transaction."""
+        with self._lock:
+            return self._get_all_locked()
+
+    def _get_all_locked(self):
         p = self.profile
         config = self.read_config()
         fw_gain = struct.unpack_from('<H', config, p.off_gain)[0]
@@ -400,7 +513,11 @@ class WaveDevice:
 
         # Sync firmware ↔ ALSA
         if self._card:
-            alsa = _alsa_get(self._card)
+            now = time.monotonic()
+            alsa = {}
+            if now - self._last_alsa_at >= 0.5:
+                alsa = _alsa_get(self._card)
+                self._last_alsa_at = now
             dirty = False  # whether we need to write config back
 
             if self._last_fw is not None:
@@ -523,4 +640,3 @@ class WaveDevice:
         self._write_config_value('<H', p.off_monitor_mix, value)
 
 
-WaveXLR = WaveDevice


### PR DESCRIPTION
## Scope
- Enumerate exact USB units, including multiple devices of the same model.
- Serialize each unit's transfers and firmware synchronization separately; preserve healthy handles during hotplug.
- Bind queued controls to their selected device, cancel delayed sliders on selection changes, and finish workers before disconnecting.
- Maintain one capture keepalive per Wave input; preserve pins when PipeWire observation fails.

## Verification
- 26 focused Python tests pass.
- Nix package builds.
- Isolated GTK/Xvfb scenario passes: two emulated units, serial selector, write ownership, stale drag cancellation, hotplug survivor, clean shutdown. Actual physical multi-device hardware was not exercised.

Draft while dynamic routing integration is verified. No change to unsupported 00c7 USB variant.