### PR TITLE
Integrate dynamic sources, mixes and bounded GTK metering

### DIFF
--- a/tests/test_device_scan.py
+++ b/tests/test_device_scan.py
@@ -6,6 +6,7 @@ each one with its (bus, addr) so callers can open them individually.
 """
 
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 from wavexlr import device
@@ -99,6 +100,59 @@ class DeviceReadiness(unittest.TestCase):
         with mock.patch.object(device._lib, "libusb_control_transfer", return_value=2):
             with self.assertRaises(RuntimeError):
                 dev.read_config()
+
+
+class CaptureIdentity(unittest.TestCase):
+    def _unit(self, serial, card="3", profile=WAVE_XLR_MK2):
+        return SimpleNamespace(
+            info={"serial": serial}, alsa_card=card, profile=profile, connected=True,
+        )
+
+    def test_reused_alsa_card_cannot_target_replacement_unit(self):
+        replacement = self._unit("UNIT_B")
+        stale_capture = {"alsa_card": "3", "serial": "UNIT_A"}
+        self.assertIsNone(device.device_for_capture(stale_capture, [replacement]))
+
+    def test_missing_capture_identity_leaves_pipewire_in_control(self):
+        unit = self._unit("UNIT_A")
+        self.assertIsNone(device.device_for_capture({"alsa_card": "3"}, [unit]))
+
+    def test_missing_hardware_identity_cannot_be_supplied_by_card(self):
+        unit = self._unit("")
+        capture = {"alsa_card": "3", "serial": "UNIT_A"}
+        self.assertIsNone(device.device_for_capture(capture, [unit]))
+
+    def test_exact_serial_follows_unit_not_recycled_card(self):
+        original = self._unit("UNIT_A", card="4")
+        replacement = self._unit("UNIT_B", card="3")
+        capture = {"alsa_card": "3", "serial": "UNIT_A"}
+        self.assertIs(device.device_for_capture(capture, [replacement, original]), original)
+
+    def test_complete_udev_identity_maps_same_unit(self):
+        unit = self._unit("A8A9A40411NOP9")
+        capture = {"serial": "Elgato_Systems_Elgato_XLR_Dock_A8A9A40411NOP9"}
+        self.assertIs(device.device_for_capture(capture, [unit]), unit)
+
+    def test_model_identity_cannot_be_replaced_by_serial_suffix(self):
+        unit = self._unit("UNIT_A", profile=WAVE3)
+        capture = {"alsa_card": "3", "serial": "Elgato_Systems_Elgato_XLR_Dock_UNIT_A"}
+        self.assertIsNone(device.device_for_capture(capture, [unit]))
+
+    def test_serial_substring_is_not_physical_identity(self):
+        unit = self._unit("UNIT_A")
+        capture = {"alsa_card": "3", "serial": "Elgato_Systems_Elgato_XLR_Dock_UNIT_AB"}
+        self.assertIsNone(device.device_for_capture(capture, [unit]))
+
+    def test_duplicate_identity_cannot_be_disambiguated_by_card(self):
+        first = self._unit("UNIT_A", card="3")
+        second = self._unit("UNIT_A", card="4")
+        capture = {"alsa_card": "3", "serial": "Elgato_Systems_Elgato_XLR_Dock_UNIT_A"}
+        self.assertIsNone(device.device_for_capture(capture, [first, second]))
+
+    def test_disconnected_unit_is_not_a_hardware_target(self):
+        unit = self._unit("UNIT_A")
+        unit.connected = False
+        self.assertIsNone(device.device_for_capture({"serial": "UNIT_A"}, [unit]))
 
 
 if __name__ == "__main__":

--- a/tests/test_meter_lifecycle.py
+++ b/tests/test_meter_lifecycle.py
@@ -1,0 +1,155 @@
+"""Real pipe/process regressions; no GTK display or PipeWire server required."""
+
+import importlib.util
+from pathlib import Path
+import queue
+import subprocess
+import sys
+import threading
+import time
+import types
+import unittest
+from unittest import mock
+
+
+_CHILD = """
+import os, signal
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+while True:
+    data = os.read(0, 4096)
+    if not data:
+        break
+    os.write(1, data)
+"""
+
+
+class MeterLifecycleTests(unittest.TestCase):
+    def setUp(self):
+        self.pending = queue.Queue()
+        glib = types.SimpleNamespace(idle_add=lambda fn, *args: self.pending.put((fn, args)))
+        gi = types.ModuleType("gi")
+        gi.require_version = lambda *_args: None
+        repository = types.ModuleType("gi.repository")
+        repository.GLib = glib
+        name = "_openwave_meter_regression"
+        spec = importlib.util.spec_from_file_location(
+            name, Path(__file__).parents[1] / "wavexlr" / "meter.py")
+        self.module = importlib.util.module_from_spec(spec)
+        with mock.patch.dict(sys.modules, {
+            "gi": gi, "gi.repository": repository, name: self.module,
+        }):
+            spec.loader.exec_module(self.module)
+        self.monitor = self.module.MeterMonitor()
+        self.processes = []
+        self.real_popen = subprocess.Popen
+        self.addCleanup(self.cleanup_processes)
+        self.spawn_patch = mock.patch.object(
+            self.module.subprocess, "Popen", side_effect=self.spawn)
+        self.spawn_patch.start()
+        self.addCleanup(self.spawn_patch.stop)
+
+    def spawn(self, _args, **_kwargs):
+        proc = self.real_popen(
+            [sys.executable, "-u", "-c", _CHILD],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL, bufsize=0)
+        self.processes.append(proc)
+        return proc
+
+    def cleanup_processes(self):
+        self.monitor.stop_all()
+        stopped = self.monitor.wait_stopped()
+        for proc in self.processes:
+            if proc.poll() is None:
+                proc.kill()
+            proc.wait(timeout=2)
+            proc.stdin.close()
+            proc.stdout.close()
+        self.assertTrue(stopped, "meter worker outlived bounded teardown")
+
+    def await_condition(self, predicate):
+        deadline = time.monotonic() + 3
+        while not predicate():
+            if time.monotonic() >= deadline:
+                self.fail("timed out waiting for meter event")
+            time.sleep(0.005)
+
+    def flush_ui(self):
+        while True:
+            try:
+                fn, args = self.pending.get_nowait()
+            except queue.Empty:
+                return
+            fn(*args)
+
+    def test_replacement_rejects_already_queued_old_peaks_and_final_zero(self):
+        old_levels, new_levels = [], []
+        self.monitor.start("mic", "old", old_levels.append)
+        self.await_condition(lambda: self.monitor.running("mic"))
+        old = self.processes[0]
+        old.stdin.write(b"\x00\x20" * 512)
+        self.await_condition(lambda: not self.pending.empty())
+
+        self.monitor.start("mic", "new", new_levels.append)
+        self.await_condition(lambda: len(self.processes) == 2 and self.monitor.running("mic"))
+        self.processes[1].stdin.write(b"\x00\x40" * 512)
+        self.await_condition(lambda: self.pending.qsize() >= 2)
+        self.await_condition(lambda: old.poll() is not None)
+        self.flush_ui()
+        self.assertEqual(old_levels, [])
+        self.assertEqual(new_levels, [0.5])
+        self.monitor.stop_all()
+        self.assertTrue(self.monitor.wait_stopped())
+        self.flush_ui()
+        self.assertEqual(new_levels, [0.5])
+        for proc in self.processes:
+            self.assertIsNotNone(proc.returncode)
+            self.assertTrue(proc.stdout.closed)
+
+    def test_suspended_visuals_still_refresh_byte_flow_on_silent_samples(self):
+        clock = [10.0]
+        self.module.time = types.SimpleNamespace(monotonic=lambda: clock[0])
+        levels = []
+        self.monitor.start("mic", "capture", levels.append)
+        self.await_condition(lambda: self.monitor.running("mic"))
+        self.monitor.ui_suspended = True
+        clock[0] = 20.0
+        self.assertEqual(self.monitor.silent_for("mic"), 10.0)
+        self.processes[0].stdin.write(b"\x00\x00" * 512)
+        self.await_condition(lambda: self.monitor.silent_for("mic") == 0.0)
+        self.flush_ui()
+        self.assertEqual(levels, [])
+        self.monitor.ui_suspended = False
+        self.processes[0].stdin.write(b"\x00\x20" * 512)
+        self.await_condition(lambda: not self.pending.empty())
+        self.flush_ui()
+        self.assertEqual(levels, [0.25])
+        self.monitor.stop_all()
+        self.assertIsNone(self.monitor.silent_for("mic"))
+
+    def test_cancel_during_spawn_still_closes_pipe_and_reaps_child(self):
+        entered, release = threading.Event(), threading.Event()
+        original_spawn = self.spawn
+
+        def held_spawn(*args, **kwargs):
+            entered.set()
+            if not release.wait(3):
+                raise OSError("test failed to release spawn")
+            return original_spawn(*args, **kwargs)
+
+        self.spawn_patch.stop()
+        with mock.patch.object(self.module.subprocess, "Popen", side_effect=held_spawn):
+            self.monitor.start("mic", "capture", lambda _peak: self.fail("late callback"))
+            self.assertTrue(entered.wait(3))
+            self.monitor.stop_all()
+            release.set()
+            self.assertTrue(self.monitor.wait_stopped())
+        self.flush_ui()
+        self.assertFalse(self.monitor.running("mic"))
+        proc = self.processes[0]
+        self.assertIsNotNone(proc.returncode)
+        self.assertTrue(proc.stdout.closed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_meter_lifecycle.py
+++ b/tests/test_meter_lifecycle.py
@@ -31,7 +31,7 @@ class MeterLifecycleTests(unittest.TestCase):
         gi.require_version = lambda *_args: None
         repository = types.ModuleType("gi.repository")
         repository.GLib = glib
-        name = "_openwave_meter_regression"
+        name = "wavexlr._meter_regression"
         spec = importlib.util.spec_from_file_location(
             name, Path(__file__).parents[1] / "wavexlr" / "meter.py")
         self.module = importlib.util.module_from_spec(spec)
@@ -66,6 +66,17 @@ class MeterLifecycleTests(unittest.TestCase):
             proc.stdin.close()
             proc.stdout.close()
         self.assertTrue(stopped, "meter worker outlived bounded teardown")
+
+    def test_capture_readiness_requires_bytes_from_exact_generation(self):
+        self.monitor.start("mic", "capture", lambda _: None, identity=("server", 1))
+        self.await_condition(lambda: self.monitor.running("mic"))
+        self.assertFalse(self.monitor.ready("capture", ("server", 1)))
+        self.processes[-1].stdin.write(bytes(128))
+        self.processes[-1].stdin.flush()
+        self.await_condition(lambda: self.monitor.ready("capture", ("server", 1)))
+        self.monitor.start("mic", "capture", lambda _: None, identity=("server", 2))
+        self.assertFalse(self.monitor.ready("capture", ("server", 1)))
+        self.assertFalse(self.monitor.ready("capture", ("server", 2)))
 
     def await_condition(self, predicate):
         deadline = time.monotonic() + 3

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -39,6 +39,7 @@ class PipeWire:
         self.fail_links = 0
         self.fail_moves = 0
         self.fail_levels = 0
+        self.fail_capture_mutes = 0
         self.operations = []
         self.sink("headphones")
         for mid in ("personal", "chat", "record"):
@@ -100,6 +101,20 @@ class PipeWire:
                 sink.update(volume=volume, muted=muted)
         return True
 
+    def capture(self, name):
+        ident = self.node(name)
+        self.graph["captures"] = [item for item in self.graph["captures"] if item["name"] != name]
+        self.graph["captures"].append({"name": name, "identity": (None, str(ident)),
+                                       "description": name, "priority": 0})
+        self.graph["capture_mutes"][name] = False
+
+    def set_capture_mute(self, name, muted):
+        if self.fail_capture_mutes:
+            self.fail_capture_mutes -= 1
+            return False
+        self.graph["capture_mutes"][name] = muted
+        return True
+
     def move_stream(self, stream, sink):
         if self.fail_moves:
             self.fail_moves -= 1
@@ -138,6 +153,12 @@ def eventually(predicate):
 
 
 class RoutingTests(unittest.TestCase):
+    @staticmethod
+    def reconcile(mixer, pw):
+        graph = pw.snapshot()
+        mixer._discover(graph)
+        mixer._reconcile(graph)
+
     def test_claims_are_exclusive_and_order_independent(self):
         streams = {7: {"app_name": " Music ", "binary": "/usr/bin/player"}}
         rows = {"z": {"match_app_names": ["Music"]}, "a": {"match_app_names": ["player"]},
@@ -209,6 +230,218 @@ class RoutingTests(unittest.TestCase):
                 mixer.stop()
             self.assertEqual(json.loads(path.read_text())["volumes"]["chat"], {"volume": 0.25, "muted": True})
 
+    def test_successful_master_change_preserves_publication_and_route_identity(self):
+        pw = PipeWire()
+        pw.stream()
+        with tempfile.TemporaryDirectory() as directory:
+            mixer = Mixer(pw, config_path=str(Path(directory) / "mixes.json"))
+            try:
+                mixer.set_sources({"music": {"name": "Music", "match_app_names": ["Music"]}})
+                mixer.set_cell("music", "personal", 0.6, False)
+                for _ in range(3):
+                    self.reconcile(mixer, pw)
+                self.assertTrue(pw.has_route("openwave_src_music", "openwave_personal_mix"))
+                self.assertTrue(pw.has_route("openwave_personal_mix", "headphones"))
+                self.assertIn(mix_capture_name("personal"), pw.graph["nodes"])
+                identities = {name: node["serial"] for name, node in pw.graph["nodes"].items()}
+
+                mixer.set_mix_volume("personal", 0.4, True)
+                for _ in range(2):
+                    self.reconcile(mixer, pw)
+                    self.assertEqual({name: node["serial"] for name, node in pw.graph["nodes"].items()},
+                                     identities)
+                    self.assertTrue(pw.has_route("openwave_src_music", "openwave_personal_mix"))
+                    self.assertTrue(pw.has_route("openwave_personal_mix", "headphones"))
+                self.assertEqual(pw.graph["sinks"]["openwave_personal_mix"]["volume"], 0.4)
+                self.assertTrue(pw.graph["sinks"]["openwave_personal_mix"]["muted"])
+            finally:
+                mixer._teardown()
+                mixer.stop()
+
+    def test_failed_restore_retains_intake_until_original_destination_recovers(self):
+        pw = PipeWire()
+        pw.sink("speakers")
+        stream = pw.stream()
+        pw.graph["streams"][stream]["sink"] = "speakers"
+        with tempfile.TemporaryDirectory() as directory:
+            mixer = Mixer(pw, config_path=str(Path(directory) / "mixes.json"))
+            try:
+                mixer.set_sources({"music": {"name": "Music", "match_app_names": ["Music"]}})
+                for _ in range(3):
+                    self.reconcile(mixer, pw)
+                self.assertEqual(pw.graph["streams"][stream]["sink"], "openwave_src_music")
+
+                mixer.remove_source("music")
+                pw.fail_moves = 1
+                self.reconcile(mixer, pw)
+                self.assertEqual(pw.graph["streams"][stream]["sink"], "openwave_src_music")
+                self.assertIn("openwave_src_music", pw.graph["sinks"])
+
+                self.reconcile(mixer, pw)
+                self.assertEqual(pw.graph["streams"][stream]["sink"], "speakers")
+                self.assertNotIn("openwave_src_music", pw.graph["sinks"])
+            finally:
+                mixer._teardown()
+                mixer.stop()
+
+    def test_teardown_retries_restore_and_retains_unresolved_intake(self):
+        for persistent_failure in (False, True):
+            with self.subTest(persistent_failure=persistent_failure), tempfile.TemporaryDirectory() as directory:
+                pw = PipeWire()
+                pw.sink("speakers")
+                stream = pw.stream()
+                pw.graph["streams"][stream]["sink"] = "speakers"
+                mixer = Mixer(pw, config_path=str(Path(directory) / "mixes.json"))
+                try:
+                    mixer.set_sources({"music": {"name": "Music", "match_app_names": ["Music"]}})
+                    for _ in range(3):
+                        self.reconcile(mixer, pw)
+                    self.assertEqual(pw.graph["streams"][stream]["sink"], "openwave_src_music")
+
+                    pw.fail_moves = 100 if persistent_failure else 1
+                    mixer._teardown()
+                    if persistent_failure:
+                        self.assertEqual(pw.graph["streams"][stream]["sink"], "openwave_src_music")
+                        self.assertIn("openwave_src_music", pw.graph["sinks"])
+                    else:
+                        self.assertEqual(pw.graph["streams"][stream]["sink"], "speakers")
+                        self.assertNotIn("openwave_src_music", pw.graph["sinks"])
+                finally:
+                    pw.fail_moves = 0
+                    mixer._teardown()
+                    mixer.stop()
+
+    def test_offline_configured_capture_queues_mute_until_connected(self):
+        pw = PipeWire()
+        with tempfile.TemporaryDirectory() as directory:
+            mixer = Mixer(pw, config_path=str(Path(directory) / "mixes.json"))
+            try:
+                mixer.set_sources({"mic": {"kind": "device", "node_name": "microphone"}})
+                mixer.set_capture_mute("microphone", True)
+                self.reconcile(mixer, pw)
+                self.assertEqual(pw.graph["capture_mutes"], {})
+
+                pw.capture("microphone")
+                self.reconcile(mixer, pw)
+                self.assertTrue(pw.graph["capture_mutes"]["microphone"])
+            finally:
+                mixer._teardown()
+                mixer.stop()
+
+    def test_capture_mute_rejects_unowned_capture_before_later_binding(self):
+        pw = PipeWire()
+        pw.capture("microphone")
+        with tempfile.TemporaryDirectory() as directory:
+            mixer = Mixer(pw, config_path=str(Path(directory) / "mixes.json"))
+            try:
+                self.reconcile(mixer, pw)
+                mixer.set_capture_mute("microphone", True)
+                mixer.set_sources({"mic": {"kind": "device", "node_name": "microphone"}})
+                self.reconcile(mixer, pw)
+                self.assertFalse(pw.graph["capture_mutes"]["microphone"])
+
+                mixer.set_capture_mute("microphone", True)
+                self.reconcile(mixer, pw)
+                self.assertTrue(pw.graph["capture_mutes"]["microphone"])
+            finally:
+                mixer._teardown()
+                mixer.stop()
+
+    def test_removed_source_drops_capture_mute_before_same_binding_returns(self):
+        pw = PipeWire()
+        pw.capture("microphone")
+        records = {"mic": {"kind": "device", "node_name": "microphone"}}
+        with tempfile.TemporaryDirectory() as directory:
+            mixer = Mixer(pw, config_path=str(Path(directory) / "mixes.json"))
+            try:
+                mixer.set_sources(records)
+                self.reconcile(mixer, pw)
+                mixer.set_capture_mute("microphone", True)
+                pw.fail_capture_mutes = 1
+                self.reconcile(mixer, pw)
+                self.assertFalse(pw.graph["capture_mutes"]["microphone"])
+
+                mixer.remove_source("mic")
+                mixer.set_sources(records)
+                self.reconcile(mixer, pw)
+                self.assertFalse(pw.graph["capture_mutes"]["microphone"])
+            finally:
+                mixer._teardown()
+                mixer.stop()
+
+    def test_capture_mute_dispatch_rechecks_ownership_after_earlier_command(self):
+        class RemovingCapture(PipeWire):
+            def set_capture_mute(self, name, muted):
+                applied = super().set_capture_mute(name, muted)
+                mixer.remove_source("other")
+                return applied
+
+        pw = RemovingCapture()
+        pw.capture("microphone")
+        pw.capture("other_microphone")
+        with tempfile.TemporaryDirectory() as directory:
+            mixer = Mixer(pw, config_path=str(Path(directory) / "mixes.json"))
+            try:
+                mixer.set_sources({"mic": {"kind": "device", "node_name": "microphone"},
+                                   "other": {"kind": "device", "node_name": "other_microphone"}})
+                self.reconcile(mixer, pw)
+                mixer.set_capture_mute("microphone", True)
+                mixer.set_capture_mute("other_microphone", True)
+                self.reconcile(mixer, pw)
+                self.assertTrue(pw.graph["capture_mutes"]["microphone"])
+                self.assertFalse(pw.graph["capture_mutes"]["other_microphone"])
+            finally:
+                mixer._teardown()
+                mixer.stop()
+
+    def test_rebound_source_drops_capture_mute_before_old_binding_returns(self):
+        pw = PipeWire()
+        pw.capture("microphone")
+        pw.capture("other_microphone")
+        records = {"mic": {"kind": "device", "node_name": "microphone"}}
+        with tempfile.TemporaryDirectory() as directory:
+            mixer = Mixer(pw, config_path=str(Path(directory) / "mixes.json"))
+            try:
+                mixer.set_sources(records)
+                self.reconcile(mixer, pw)
+                mixer.set_capture_mute("microphone", True)
+                pw.fail_capture_mutes = 1
+                self.reconcile(mixer, pw)
+
+                mixer.set_sources({"mic": {"kind": "device", "node_name": "other_microphone"}})
+                mixer.set_sources(records)
+                self.reconcile(mixer, pw)
+                self.assertFalse(pw.graph["capture_mutes"]["microphone"])
+                self.assertFalse(pw.graph["capture_mutes"]["other_microphone"])
+            finally:
+                mixer._teardown()
+                mixer.stop()
+
+    def test_owned_capture_retains_pending_mute_across_reconnect(self):
+        for observe_unplug in (True, False):
+            with self.subTest(observe_unplug=observe_unplug), tempfile.TemporaryDirectory() as directory:
+                pw = PipeWire()
+                pw.capture("microphone")
+                mixer = Mixer(pw, config_path=str(Path(directory) / "mixes.json"))
+                try:
+                    mixer.set_sources({"mic": {"kind": "device", "node_name": "microphone"}})
+                    self.reconcile(mixer, pw)
+                    mixer.set_capture_mute("microphone", True)
+                    pw.fail_capture_mutes = 1
+                    self.reconcile(mixer, pw)
+
+                    if observe_unplug:
+                        pw.graph["captures"].clear()
+                        pw.graph["nodes"].pop("microphone")
+                        pw.graph["capture_mutes"].pop("microphone")
+                        self.reconcile(mixer, pw)
+                    pw.capture("microphone")
+                    self.reconcile(mixer, pw)
+                    self.assertTrue(pw.graph["capture_mutes"]["microphone"])
+                finally:
+                    mixer._teardown()
+                    mixer.stop()
+
     def test_dynamic_outputs_publish_capture_and_stop_owned_children(self):
         pw = PipeWire()
         with tempfile.TemporaryDirectory() as directory:
@@ -274,90 +507,3 @@ class RoutingTests(unittest.TestCase):
         graph = DuplicateStreams().snapshot()
         self.assertEqual(claim_streams({"player": {"match_app_names": ["Player"]}}, graph["streams"]),
                          {"player": {11, 12}})
-
-    @staticmethod
-    def reconcile(mixer, pw):
-        graph = pw.snapshot()
-        mixer._discover(graph)
-        mixer._reconcile(graph)
-
-    def test_failed_restore_retains_intake_until_original_destination_recovers(self):
-        pw = PipeWire()
-        pw.sink("speakers")
-        stream = pw.stream()
-        pw.graph["streams"][stream]["sink"] = "speakers"
-        with tempfile.TemporaryDirectory() as directory:
-            mixer = Mixer(pw, config_path=str(Path(directory) / "mixes.json"))
-            try:
-                mixer.set_sources({"music": {"name": "Music", "match_app_names": ["Music"]}})
-                for _ in range(3):
-                    self.reconcile(mixer, pw)
-                self.assertEqual(pw.graph["streams"][stream]["sink"], "openwave_src_music")
-
-                mixer.remove_source("music")
-                pw.fail_moves = 1
-                self.reconcile(mixer, pw)
-                self.assertEqual(pw.graph["streams"][stream]["sink"], "openwave_src_music")
-                self.assertIn("openwave_src_music", pw.graph["sinks"])
-
-                self.reconcile(mixer, pw)
-                self.assertEqual(pw.graph["streams"][stream]["sink"], "speakers")
-                self.assertNotIn("openwave_src_music", pw.graph["sinks"])
-            finally:
-                mixer._teardown()
-                mixer.stop()
-
-    def test_teardown_retries_restore_and_retains_unresolved_intake(self):
-        for persistent_failure in (False, True):
-            with self.subTest(persistent_failure=persistent_failure), tempfile.TemporaryDirectory() as directory:
-                pw = PipeWire()
-                pw.sink("speakers")
-                stream = pw.stream()
-                pw.graph["streams"][stream]["sink"] = "speakers"
-                mixer = Mixer(pw, config_path=str(Path(directory) / "mixes.json"))
-                try:
-                    mixer.set_sources({"music": {"name": "Music", "match_app_names": ["Music"]}})
-                    for _ in range(3):
-                        self.reconcile(mixer, pw)
-                    self.assertEqual(pw.graph["streams"][stream]["sink"], "openwave_src_music")
-
-                    pw.fail_moves = 100 if persistent_failure else 1
-                    mixer._teardown()
-                    if persistent_failure:
-                        self.assertEqual(pw.graph["streams"][stream]["sink"], "openwave_src_music")
-                        self.assertIn("openwave_src_music", pw.graph["sinks"])
-                    else:
-                        self.assertEqual(pw.graph["streams"][stream]["sink"], "speakers")
-                        self.assertNotIn("openwave_src_music", pw.graph["sinks"])
-                finally:
-                    pw.fail_moves = 0
-                    mixer._teardown()
-                    mixer.stop()
-
-    def test_successful_master_change_preserves_publication_and_route_identity(self):
-        pw = PipeWire()
-        pw.stream()
-        with tempfile.TemporaryDirectory() as directory:
-            mixer = Mixer(pw, config_path=str(Path(directory) / "mixes.json"))
-            try:
-                mixer.set_sources({"music": {"name": "Music", "match_app_names": ["Music"]}})
-                mixer.set_cell("music", "personal", 0.6, False)
-                for _ in range(3):
-                    self.reconcile(mixer, pw)
-                self.assertTrue(pw.has_route("openwave_src_music", "openwave_personal_mix"))
-                self.assertTrue(pw.has_route("openwave_personal_mix", "headphones"))
-                self.assertIn(mix_capture_name("personal"), pw.graph["nodes"])
-                identities = {name: node["serial"] for name, node in pw.graph["nodes"].items()}
-
-                mixer.set_mix_volume("personal", 0.4, True)
-                for _ in range(2):
-                    self.reconcile(mixer, pw)
-                    self.assertEqual({name: node["serial"] for name, node in pw.graph["nodes"].items()},
-                                     identities)
-                    self.assertTrue(pw.has_route("openwave_src_music", "openwave_personal_mix"))
-                    self.assertTrue(pw.has_route("openwave_personal_mix", "headphones"))
-                self.assertEqual(pw.graph["sinks"]["openwave_personal_mix"]["volume"], 0.4)
-                self.assertTrue(pw.graph["sinks"]["openwave_personal_mix"]["muted"])
-            finally:
-                mixer._teardown()
-                mixer.stop()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -179,7 +179,7 @@ class RoutingTests(unittest.TestCase):
                 cell["volume"] = 0
                 self.assertEqual(mixer.get_cell("music", "chat")["volume"], 0.5)
                 self.assertEqual(mixer.streams(), {})
-                mixer.poll_streams()
+                mixer.request_stream_poll()
             finally:
                 mixer.stop()
 
@@ -235,9 +235,24 @@ class RoutingTests(unittest.TestCase):
     def test_reused_module_id_does_not_authorize_deletion(self):
         from unittest.mock import patch
         pw = SubprocessPipeWire()
-        graph = {"modules": [{"index": 8, "argument": "openwave.owner=someone-else"}]}
+        graph = {"nodes": {"unrelated": {"props": {
+            "pulse.module.id": 8, "openwave.owner": "someone-else",
+        }}}}
         with patch("wavexlr.mixer.subprocess.run", side_effect=AssertionError("Unrelated resource touched")):
             self.assertTrue(pw.destroy_sink((8, "our-token"), graph))
+
+    def test_owned_sink_removal_uses_native_module_identity(self):
+        from unittest.mock import patch
+        pw = SubprocessPipeWire()
+        nodes = {"owned": {"props": {"pulse.module.id": 8, "openwave.owner": "our-token"}}}
+        def unload(argv, **kwargs):
+            if argv == ["pactl", "unload-module", "8"]:
+                nodes.pop("owned")
+            return subprocess.CompletedProcess(argv, 0, "", "")
+        # pactl's JSON module list does not expose module indices.
+        with patch("wavexlr.mixer.subprocess.run", side_effect=unload):
+            pw.destroy_sink((8, "our-token"), {"nodes": nodes, "modules": []})
+        self.assertFalse(nodes)
 
     def test_duplicate_stream_names_remain_independently_claimable(self):
         objects = [{"id": index, "type": "PipeWire:Interface:Node",

--- a/tests/test_routing_stores.py
+++ b/tests/test_routing_stores.py
@@ -44,6 +44,20 @@ class StoreTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             mixes.normalize({"a": {"sink": "openwave_shared"}, "b": {"sink": "openwave_shared"}})
 
+    def test_joined_group_is_exclusive_after_reload(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with patch.object(sources, "CONFIG_PATH", str(Path(directory) / "sources.json")):
+                records = sources.normalize({"voice": {"group": "Live"}})
+                sources.add(records, {"id": "backup", "group": "Live"})
+                reloaded = sources.load()
+                self.assertFalse(reloaded["voice"]["muted"])
+                self.assertTrue(reloaded["backup"]["muted"])
+                sources.update(reloaded, "voice", muted=True)
+                sources.update(reloaded, "backup", muted=False)
+                recalled = sources.load()
+                self.assertTrue(recalled["voice"]["muted"])
+                self.assertFalse(recalled["backup"]["muted"])
+
     def test_mix_rename_preserves_external_sink_and_cell_identity(self):
         with tempfile.TemporaryDirectory() as directory:
             with patch.object(mixes, "CONFIG_PATH", str(Path(directory) / "mixdefs.json")):

--- a/wavexlr/__main__.py
+++ b/wavexlr/__main__.py
@@ -1,2 +1,25 @@
-from .app import main
-main()
+"""Headless informational options, before GTK or USB imports."""
+
+import argparse
+from pathlib import Path
+
+from . import paths
+
+
+def main():
+    parser = argparse.ArgumentParser(prog="openwave", description="Wave hardware controls and PipeWire audio mixes")
+    parser.add_argument("--hide", action="store_true", help="Start hidden when a system tray host is available")
+    parser.add_argument("--version", action="store_true", help="Print the installed version without opening audio or USB")
+    options, _ = parser.parse_known_args()
+    if options.version:
+        version_file = paths.data_file("VERSION")
+        if version_file is None:
+            parser.error("Installed VERSION file is missing")
+        print("OpenWave " + Path(version_file).read_text().strip())
+        return 0
+    from .app import main as run
+    return run()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/wavexlr/app.py
+++ b/wavexlr/app.py
@@ -10,7 +10,7 @@ import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
 
-from .device import WaveDevice, DeviceUnresponsiveError, scan
+from .device import WaveDevice, DeviceUnresponsiveError, device_for_capture, scan
 from .audio import SOURCE_MATCHES
 from .meter import MeterMonitor
 from .mixer import Mixer, claim_streams, stream_matches, source_sink_name, OUTPUT_AUTO, OUTPUT_NONE
@@ -1307,10 +1307,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
                         if item["name"] == source.get("node_name")), None)
         if capture is None:
             return None
-        candidates = [dev for dev in self._devs if
-            (capture.get("alsa_card") is not None and str(capture["alsa_card"]) == str(dev.alsa_card))
-            or (capture.get("serial") and capture["serial"] == dev.info.get("serial"))]
-        return candidates[0] if len(candidates) == 1 else None
+        return device_for_capture(capture, self._devs)
 
     def _sync_hw_mute(self, source, muted):
         if sources_module.kind(source) != sources_module.KIND_DEVICE:

--- a/wavexlr/app.py
+++ b/wavexlr/app.py
@@ -1,31 +1,45 @@
-"""OpenWave — GTK4 + Adwaita control application for Elgato Wave devices."""
+"""GTK4 control surface for independently owned Wave devices and audio mixes."""
 
 import gi
-gi.require_version('Gtk', '4.0')
-gi.require_version('Adw', '1')
-
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
 from gi.repository import Gtk, Adw, GLib, GObject, Gio, Gdk
+import json
 import logging
 import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
 
-from .device import DeviceNotReadyError, DeviceUnresponsiveError, WaveDevice, scan
+from .device import WaveDevice, DeviceUnresponsiveError, scan
+from .audio import SOURCE_MATCHES
 from .meter import MeterMonitor
-from .mixer import Mixer
+from .mixer import Mixer, claim_streams, stream_matches, source_sink_name, OUTPUT_AUTO, OUTPUT_NONE
 from .mixmatrix import MixMatrix
+from .mixdialog import MixDialog
 from .sourcedialog import AddSourceDialog
-from . import paths, setup, service, sources as sources_module
+from . import paths, setup, service, sources as sources_module, mixes as mixes_module, desktop as desktop_module
 
 logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
-
 KNOB_LABELS = {"gain": "Gain", "hp": "Headphones", "mix": "Monitor Mix"}
+
+def _slider_row(scale):
+    row = Adw.PreferencesRow(activatable=False, selectable=False)
+    scale.set_margin_start(12)
+    scale.set_margin_end(12)
+    scale.set_margin_top(2)
+    scale.set_margin_bottom(6)
+    row.set_child(scale)
+    return row
 
 
 class WaveXLRWindow(Adw.ApplicationWindow):
+    _UI_STATE = os.path.join(os.path.dirname(sources_module.CONFIG_PATH), "ui-state.json")
+    _CELL_DEBOUNCE_MS = 150
+
     def __init__(self, **kwargs):
-        super().__init__(**kwargs, title="OpenWave", default_width=1100, default_height=620)
-        self.set_size_request(900, 520)
+        super().__init__(**kwargs, title="OpenWave", default_width=1280, default_height=720)
+        self.set_size_request(820, 480)
+        self._restore_window_size()
         self._empty_device = WaveDevice()
         self.dev = self._empty_device
         self._devs = []
@@ -37,32 +51,33 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self._failed_units = set()
         self._closing_units = set()
         self._selector_updating = False
-        self._usb_executor = ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="openwave-discovery"
-        )
+        self._usb_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="openwave-discovery")
         self._shutting_down = False
         self._connect_pending = False
-        self._reconnect_id = None
+        self._reconnect_id = self._poll_id = self._stream_poll_id = None
+        self._gain_timeout = self._hp_timeout = self._mix_timeout = None
         self._gain_max = 0x5000
         self._updating_ui = False
         self._last_state = None
-        self._poll_id = None
-        self._stream_poll_id = None
-        self._gain_timeout = None
-        self._hp_timeout = None
-        self._mix_timeout = None
-        # Debounce slider events to coalesce a flurry of value-changed signals
-        # during a drag into one set_cell. {(source_id, mix_id): timeout_id}.
         self._cell_debounce_ids = {}
+        self._remote_levels = {}
+        self._capture_mute_seen = {}
+        self._service_problem = False
         self._sources = sources_module.load()
-
-        self._build_ui()
-        self._update_service_status()
-        self.mixer = Mixer()
-        self.mixer.set_sources(self._sources)
+        self._mixes = mixes_module.load_seeded()
+        self._offered_nodes = set(self._load_ui_state().get("offered_capture_nodes", []))
         self.meter = MeterMonitor()
         self._meter_targets = {}
+        self.mixer = Mixer(capture_ready=lambda capture: self.meter.ready(
+            capture["name"], capture["identity"]))
+        self.mixer.set_mixes(self._mixes)
+        self.mixer.set_sources(self._sources)
+        self._build_ui()
+        self._restore_gain_lock()
         self._wire_matrix_cells()
+        self.connect("map", lambda *_: setattr(self.meter, "ui_suspended", False))
+        self.connect("unmap", lambda *_: setattr(self.meter, "ui_suspended", True))
+        self._update_service_status()
         self._start_meters()
         self.mixer.start()
         self._start_stream_poll()
@@ -72,130 +87,79 @@ class WaveXLRWindow(Adw.ApplicationWindow):
     def _build_ui(self):
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.set_content(box)
-
-        # Header bar
         header = Adw.HeaderBar()
-        self.status_label = Gtk.Label(label="Disconnected")
-        self.status_label.add_css_class("dim-label")
-        header.set_title_widget(self.status_label)
-
-        refresh_btn = Gtk.Button(icon_name="view-refresh-symbolic", tooltip_text="Reconnect")
-        refresh_btn.connect("clicked", lambda _: self._try_connect())
-        header.pack_end(refresh_btn)
-
-        # Sidebar toggle (placed at the end so it sits next to the close button)
-        self.sidebar_toggle = Gtk.ToggleButton(
-            icon_name="sidebar-show-symbolic",
-            tooltip_text="Toggle device panel",
-            active=True,
-        )
+        self._window_title = Adw.WindowTitle(title="OpenWave", subtitle="Disconnected")
+        header.set_title_widget(self._window_title)
+        self.service_btn = Gtk.MenuButton(icon_name="dialog-warning-symbolic", visible=False)
+        service_pop = Gtk.Popover()
+        service_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8,
+                              margin_top=12, margin_bottom=12, margin_start=12, margin_end=12)
+        self.service_label = Gtk.Label(xalign=0, wrap=True, max_width_chars=38)
+        self.routing_label = Gtk.Label(xalign=0, wrap=True, max_width_chars=38)
+        service_box.append(self.service_label)
+        service_box.append(self.routing_label)
+        self.uninstall_btn = Gtk.Button(label="Uninstall capture fix")
+        self.uninstall_btn.connect("clicked", self._on_uninstall_clicked)
+        service_box.append(self.uninstall_btn)
+        service_pop.set_child(service_box)
+        self.service_btn.set_popover(service_pop)
+        header.pack_start(self.service_btn)
+        refresh = Gtk.Button(icon_name="view-refresh-symbolic", tooltip_text="Reconnect")
+        refresh.connect("clicked", lambda _: self._try_connect())
+        header.pack_end(refresh)
+        self.sidebar_toggle = Gtk.ToggleButton(icon_name="sidebar-show-symbolic",
+                                               tooltip_text="Toggle device panel", active=False)
         header.pack_end(self.sidebar_toggle)
         box.append(header)
-
-        # --- Split view: matrix (content) | device controls (sidebar) ---------
-        self.split = Adw.OverlaySplitView(
-            sidebar_position=Gtk.PackType.END,
-            min_sidebar_width=320,
-            max_sidebar_width=420,
-            sidebar_width_fraction=0.30,
-            vexpand=True,
-        )
+        self.split = Adw.OverlaySplitView(sidebar_position=Gtk.PackType.END,
+            min_sidebar_width=320, max_sidebar_width=420, sidebar_width_fraction=0.30, vexpand=True)
         box.append(self.split)
-
-        self.sidebar_toggle.bind_property(
-            "active", self.split, "show-sidebar",
-            GObject.BindingFlags.BIDIRECTIONAL | GObject.BindingFlags.SYNC_CREATE,
-        )
-
-        # Auto-collapse the sidebar into an overlay on narrow windows.
-        bp = Adw.Breakpoint.new(Adw.BreakpointCondition.parse("max-width: 900sp"))
-        bp.add_setter(self.split, "collapsed", True)
-        self.add_breakpoint(bp)
-
-        # --- Content: mix matrix ---------------------------------------------
+        self.sidebar_toggle.bind_property("active", self.split, "show-sidebar",
+            GObject.BindingFlags.BIDIRECTIONAL | GObject.BindingFlags.SYNC_CREATE)
+        breakpoint = Adw.Breakpoint.new(Adw.BreakpointCondition.parse("max-width: 900sp"))
+        breakpoint.add_setter(self.split, "collapsed", True)
+        self.add_breakpoint(breakpoint)
         self.matrix = MixMatrix()
         self.split.set_content(self.matrix)
-
-        self.matrix.add_mix(
-            "personal", title="Personal Mix",
-            subtitle="What you hear",
-            icon_name="audio-headphones-symbolic",
-        )
-        self.matrix.add_mix(
-            "chat", title="Chat Mix",
-            subtitle="To voice apps (v0.3.0)",
-            icon_name="system-users-symbolic",
-        )
-        self.matrix.add_mix(
-            "record", title="Record Mix",
-            subtitle="To OBS / recording (v0.3.0)",
-            icon_name="media-record-symbolic",
-        )
-
-        self.mic_source = self.matrix.add_source(
-            "mic", name="Microphone",
-            icon_name="audio-input-microphone-symbolic",
-            has_level=True,
-        )
-        self.mic_source.connect("volume-changed", self._on_mic_matrix_volume_changed)
-        self.mic_source.connect("mute-toggled", self._on_mic_matrix_mute_toggled)
-
-        # User-defined app sources (persisted)
-        for source_id, source in self._sources.items():
-            self.matrix.add_source(
-                source_id,
-                name=source.get("name", source_id),
-                icon_name=source.get("icon_name", "applications-multimedia-symbolic"),
-                has_level=True,
-                removable=True,
-            )
-
-        self.matrix.connect("add-source-clicked", self._on_add_source_clicked)
-        self.matrix.connect("remove-source-clicked", self._on_remove_source_clicked)
-
-        # --- Sidebar: device controls -----------------------------------------
-        sidebar_scroll = Gtk.ScrolledWindow(
-            vexpand=True,
-            hscrollbar_policy=Gtk.PolicyType.NEVER,
-            vscrollbar_policy=Gtk.PolicyType.AUTOMATIC,
-        )
-        sidebar_clamp = Adw.Clamp(
-            maximum_size=380,
-            margin_start=12, margin_end=12, margin_top=12, margin_bottom=12,
-        )
-        sidebar_scroll.set_child(sidebar_clamp)
-
-        sidebar_content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
-        sidebar_clamp.set_child(sidebar_content)
-        self._build_device_pane(sidebar_content)
-
-        self.split.set_sidebar(sidebar_scroll)
+        for mid, mix in self._mixes.items():
+            self.matrix.add_mix(mid, title=mix["name"], subtitle=mix["subtitle"], icon_name=mix["icon_name"])
+        for source in self._sources.values():
+            self._add_source_widget(source)
+        for signal, handler in (
+            ("add-source-clicked", self._on_add_source_clicked),
+            ("remove-source-clicked", self._on_remove_source_clicked),
+            ("edit-source-clicked", self._on_edit_source_clicked),
+            ("move-source-clicked", self._on_move_source_clicked),
+            ("switch-source-clicked", self._on_switch_source_clicked),
+            ("group-sources-clicked", self._on_group_sources_clicked),
+            ("add-mix-clicked", self._on_add_mix_clicked),
+            ("rename-mix-clicked", self._on_rename_mix_clicked),
+            ("remove-mix-clicked", self._on_remove_mix_clicked),
+            ("mix-output-changed", self._on_mix_output_changed),
+            ("mix-volume-changed", self._on_mix_volume_changed),
+        ):
+            self.matrix.connect(signal, handler)
+        scroll = Gtk.ScrolledWindow(vexpand=True, hscrollbar_policy=Gtk.PolicyType.NEVER)
+        clamp = Adw.Clamp(maximum_size=380, margin_start=12, margin_end=12,
+                          margin_top=12, margin_bottom=12)
+        scroll.set_child(clamp)
+        sidebar = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        clamp.set_child(sidebar)
+        self._build_device_pane(sidebar)
+        self.split.set_sidebar(scroll)
 
     def _build_device_pane(self, parent):
-        """Populate the right-hand column with Audio / Mic / HP / Device Info groups."""
-        # --- Audio fix status ---
-        status_group = Adw.PreferencesGroup(title="Audio")
-        parent.append(status_group)
-
-        self.audio_status_row = Adw.ActionRow(
-            title="Capture Fix",
-            subtitle="Keeps mic capture active to prevent the race condition"
-        )
-        self.audio_status_icon = Gtk.Image(icon_name="emblem-ok-symbolic")
-        self.audio_status_icon.add_css_class("dim-label")
-        self.audio_status_row.add_suffix(self.audio_status_icon)
-
-        self.uninstall_btn = Gtk.Button(icon_name="user-trash-symbolic", valign=Gtk.Align.CENTER, tooltip_text="Uninstall capture fix")
-        self.uninstall_btn.add_css_class("flat")
-        self.uninstall_btn.connect("clicked", self._on_uninstall_clicked)
-        self.audio_status_row.add_suffix(self.uninstall_btn)
-
-        status_group.add(self.audio_status_row)
-
+        """Populate the sidebar: Microphone, Headphones, and device info."""
+        # --- Device selector ---
+        # Hidden with a single device: a dropdown with one entry is a
+        # question with no answer. With two or more, the controls below
+        # bind to whichever unit is chosen here; every unit keeps polling
+        # and syncing regardless.
         self._selector_group = Adw.PreferencesGroup(visible=False)
         parent.append(self._selector_group)
         self.device_combo = Adw.ComboRow(title="Device")
-        self.device_combo.connect("notify::selected", self._on_device_selected)
+        self.device_combo.connect("notify::selected",
+                                  self._on_device_selected)
         self._selector_group.add(self.device_combo)
 
         # --- Mic controls ---
@@ -208,9 +172,20 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         mic_group.add(mute_row)
 
         gain_row = Adw.ActionRow(title="Gain")
-        self.gain_label = Gtk.Label(label="0 dB", width_chars=8, xalign=1)
+        self.gain_label = Gtk.Label(label="—", width_chars=8, xalign=1)
         self.gain_label.add_css_class("monospace")
         gain_row.add_suffix(self.gain_label)
+
+        # Preamp gain is set once and then wants leaving alone: a stray scroll
+        # over the slider silently changes how loud you are to everyone else,
+        # and nothing on screen makes that obvious afterwards.
+        self.gain_lock = Gtk.ToggleButton(
+            icon_name="changes-allow-symbolic", valign=Gtk.Align.CENTER,
+            tooltip_text="Lock gain",
+        )
+        self.gain_lock.add_css_class("flat")
+        self.gain_lock.connect("toggled", self._on_gain_lock_toggled)
+        gain_row.add_suffix(self.gain_lock)
         mic_group.add(gain_row)
 
         self.gain_scale = Gtk.Scale(
@@ -219,19 +194,16 @@ class WaveXLRWindow(Adw.ApplicationWindow):
             draw_value=False,
             adjustment=Gtk.Adjustment(lower=0x0000, upper=0x5000, step_increment=0x40, page_increment=0x200),
         )
-        self.gain_scale.set_margin_start(12)
-        self.gain_scale.set_margin_end(12)
         self.gain_scale.connect("value-changed", self._on_gain_changed)
-        parent.append(self.gain_scale)
+        mic_group.add(_slider_row(self.gain_scale))
 
         phantom_row = Adw.SwitchRow(
             title="48V Phantom Power",
-            subtitle="For condenser microphones; turn off before unplugging",
+            subtitle="For condenser microphones. Leave off for dynamic mics.",
         )
         phantom_row.connect("notify::active", self._on_phantom_changed)
         self.phantom_row = phantom_row
         mic_group.add(phantom_row)
-
 
         knob_row = Adw.ActionRow(title="Knob Controls", subtitle="What the physical knob adjusts")
         self.knob_label = Gtk.Label(label="Gain")
@@ -256,10 +228,8 @@ class WaveXLRWindow(Adw.ApplicationWindow):
             draw_value=False,
             adjustment=Gtk.Adjustment(lower=-60.0, upper=0.0, step_increment=0.5, page_increment=2.0),
         )
-        self.hp_scale.set_margin_start(12)
-        self.hp_scale.set_margin_end(12)
         self.hp_scale.connect("value-changed", self._on_hp_changed)
-        parent.append(self.hp_scale)
+        hp_group.add(_slider_row(self.hp_scale))
 
         lowz_row = Adw.SwitchRow(title="Low Impedance", subtitle="For low impedance headphones")
         lowz_row.connect("notify::active", self._on_lowz_changed)
@@ -282,58 +252,83 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         )
         self.mix_scale.set_margin_start(12)
         self.mix_scale.set_margin_end(12)
-        self.mix_scale.set_visible(False)
         self.mix_scale.connect("value-changed", self._on_mix_changed)
-        parent.append(self.mix_scale)
+        self.mix_scale_row = _slider_row(self.mix_scale)
+        self.mix_scale_row.set_visible(False)
+        hp_group.add(self.mix_scale_row)
+
+        # Output routing is per mix and lives in each mix column's header
+        # menu, not here — one device combo could only ever speak for one mix.
+
+        # --- Startup ---
+        startup_group = Adw.PreferencesGroup(title="Startup")
+        parent.append(startup_group)
+
+        enabled, hidden = desktop_module.autostart_state()
+        self.autostart_row = Adw.SwitchRow(
+            title="Start at login",
+            subtitle="Keeps mixes routed before you open anything",
+        )
+        self.autostart_row.set_active(enabled)
+        self._autostart_handler = self.autostart_row.connect(
+            "notify::active", self._on_autostart_toggled)
+        startup_group.add(self.autostart_row)
+
+        self.tray_row = Adw.SwitchRow(
+            title="Start in the tray",
+            subtitle="No window on login; open it from the tray icon",
+        )
+        self.tray_row.set_active(hidden)
+        # Only meaningful when something is starting it for you.
+        self.tray_row.set_sensitive(enabled)
+        self.tray_row.connect("notify::active", self._on_start_hidden_toggled)
+        startup_group.add(self.tray_row)
 
         # --- Device info ---
-        info_group = Adw.PreferencesGroup(title="Device Info")
+        # Titleless group so the expander reads as a single collapsed line: it
+        # is reference material, looked at once, and does not deserve a
+        # permanent three-row card in a narrow sidebar.
+        info_group = Adw.PreferencesGroup()
         parent.append(info_group)
+
+        info_expander = Adw.ExpanderRow(title="Device Info")
+        info_group.add(info_expander)
 
         self.fw_row = Adw.ActionRow(title="Firmware")
         self.fw_label = Gtk.Label(label="—")
         self.fw_label.add_css_class("dim-label")
         self.fw_row.add_suffix(self.fw_label)
-        info_group.add(self.fw_row)
+        info_expander.add_row(self.fw_row)
 
-        self.api_row = Adw.ActionRow(title="API Version")
+        self.api_row = Adw.ActionRow(title="API")
         self.api_label = Gtk.Label(label="—")
         self.api_label.add_css_class("dim-label")
         self.api_row.add_suffix(self.api_label)
-        info_group.add(self.api_row)
+        info_expander.add_row(self.api_row)
 
         self.serial_row = Adw.ActionRow(title="Serial")
         self.serial_label = Gtk.Label(label="—")
         self.serial_label.add_css_class("dim-label")
         self.serial_row.add_suffix(self.serial_label)
-        info_group.add(self.serial_row)
+        info_expander.add_row(self.serial_row)
 
     def _update_service_status(self):
-        """Check if the audio service is running."""
-        active = service.is_running()
-
-        if active:
-            self.audio_status_icon.set_from_icon_name("emblem-ok-symbolic")
-            self.audio_status_icon.remove_css_class("dim-label")
-            self.audio_status_row.set_subtitle("Audio service running")
-        else:
-            self.audio_status_icon.set_from_icon_name("dialog-warning-symbolic")
-            # Distinguish a service that never came up from one that is not
-            # installed at all: both leave the capture fix off, but only the
-            # first has anything to read in `journalctl --user -u openwave`.
-            if service.is_failed():
-                subtitle = "Audio service failed to start"
-            elif service.is_installed():
-                subtitle = "Audio service installed but not running"
-            else:
-                subtitle = "Audio service not running"
-            self.audio_status_row.set_subtitle(subtitle)
-
-        # Shown whenever there is something to remove, rather than only while
-        # the service runs. A stopped or failed service is when removing it
-        # matters most, and the udev rule and the config drop-ins outlive it
-        # either way.
-        self.uninstall_btn.set_visible(setup.anything_installed())
+        if setup.is_sandboxed():
+            self._service_problem = True
+            self.service_label.set_label("Sandbox: install USB permissions and the capture service on the host. Native setup is unavailable here.")
+            self.uninstall_btn.set_visible(False)
+            self.service_btn.set_visible(True)
+            return
+        def query():
+            return service.is_running(), service.is_failed(), setup.anything_installed()
+        def apply(result):
+            active, failed, installed = result
+            self._service_problem = not active
+            self.service_label.set_label("Capture service running" if active else
+                "Capture service failed; inspect its user journal" if failed else "Capture service not running")
+            self.uninstall_btn.set_visible(installed)
+            self.service_btn.set_visible(self._service_problem or bool(self.mixer.last_error()))
+        self._usb_async(query, apply, lambda error: self._show_error("Service status unavailable", error))
 
     def _on_uninstall_clicked(self, btn):
         dialog = Adw.AlertDialog(
@@ -349,15 +344,19 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         dialog.choose(self, None, self._on_uninstall_response)
 
     def _on_uninstall_response(self, dialog, result):
-        response = dialog.choose_finish(result)
-        if response != "uninstall":
+        if dialog.choose_finish(result) != "uninstall":
             return
-        success, message = setup.run_uninstall()
-        self._update_service_status()
-        if not success:
-            err = Adw.AlertDialog(heading="Uninstall Failed", body=message)
-            err.add_response("ok", "OK")
-            err.choose(self, None, lambda d, r: d.choose_finish(r))
+        self.matrix.set_sensitive(False)
+        def uninstall():
+            self.mixer.stop()
+            return setup.run_uninstall()
+        def done(result):
+            success, message = result
+            if success:
+                self.get_application().quit()
+            else:
+                self._show_error("Uninstall failed", message + "\nReopen OpenWave to resume routing.")
+        self._usb_async(uninstall, done, lambda error: self._show_error("Uninstall failed", error))
 
     def _usb_async(self, fn, on_done=None, on_error=None, *, device=None):
         """Dispatch discovery or one device's serialized operations."""
@@ -485,8 +484,8 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self.dev = device
         self._last_state = None
         if device is self._empty_device:
-            self.status_label.set_label("Disconnected")
-            self.status_label.add_css_class("dim-label")
+            self._window_title.set_subtitle("Disconnected")
+            self._window_title.add_css_class("dim-label")
             return
         self._updating_ui = True
         try:
@@ -497,7 +496,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
             f"USB {device.usbbus} · {device.info.get('serial', 'No serial')}"
         )
         self._apply_state(self._device_states[device])
-        self.status_label.remove_css_class("dim-label")
+        self._window_title.remove_css_class("dim-label")
         self.fw_label.set_label(device.info.get("fw_version", "—"))
         self.api_label.set_label(device.info.get("api_version", "—"))
         self.serial_label.set_label(device.info.get("serial", "—"))
@@ -530,7 +529,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
             self._failed_units.add(key)
         self._retire_device(device)
         if not self._devs and isinstance(error, DeviceUnresponsiveError):
-            self.status_label.set_label("Power-cycle Wave device")
+            self._window_title.set_subtitle("Power-cycle Wave device")
 
     def _schedule_reconnect(self):
         if self._reconnect_id or self._shutting_down:
@@ -567,9 +566,15 @@ class WaveXLRWindow(Adw.ApplicationWindow):
     def _on_poll_result(self, device, state):
         self._polling_devices.discard(device)
         self._device_failures[device] = 0
+        previous = self._device_states.get(device)
         self._device_states[device] = state
+        if previous is not None and previous["mute"] != state["mute"]:
+            for sid, source in list(self._sources.items()):
+                if self._device_for_source(source) is device:
+                    self._set_source_muted(sid, state["mute"], hardware=False)
         if device is self.dev and state != self._last_state:
             self._apply_state(state)
+        self._notify_tray()
 
     def _on_poll_error(self, device, error):
         self._polling_devices.discard(device)
@@ -607,11 +612,10 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self.lowz_row.set_visible(profile.has_low_z)
         self.phantom_row.set_visible(profile.has_phantom)
         self.mix_row.set_visible(profile.has_monitor_mix)
-        self.mix_scale.set_visible(profile.has_monitor_mix)
+        self.mix_scale_row.set_visible(profile.has_monitor_mix)
         if profile.has_monitor_mix:
             self.mix_scale.get_adjustment().set_upper(profile.mix_max)
-        self.mic_source.set_name(profile.display_name)
-        self.status_label.set_label(f"OpenWave — {profile.display_name}")
+        self._window_title.set_subtitle(profile.display_name)
 
     def _format_gain(self, raw):
         scale = self.dev.profile.gain_scale if self.dev.profile else None
@@ -637,10 +641,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         if "monitor_mix" in state:
             self.mix_scale.set_value(state["monitor_mix"])
             self.mix_label.set_label(f"{state['monitor_mix'] / 256:.0f}%")
-        self.mic_source.set_volume(state["gain_raw"] / self._gain_max)
-        self.mic_source.set_muted(state["mute"])
         self._updating_ui = False
-
 
     def _on_mute_changed(self, row, _pspec):
         if self._updating_ui or not self.dev.connected:
@@ -689,7 +690,6 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         enabled = row.get_active()
         self._device_async("set_phantom", enabled)
 
-
     def _on_mix_changed(self, scale):
         if self._updating_ui or not self.dev.connected:
             return
@@ -704,31 +704,11 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self._device_async("set_monitor_mix", val)
         return False
 
-    def _on_mic_matrix_volume_changed(self, _source, value):
-        if self._updating_ui or not self.dev.connected:
-            return
-        raw = int(value * self._gain_max)
-        self.gain_label.set_label(self._format_gain(raw))
-        self._updating_ui = True
-        self.gain_scale.set_value(raw)
-        self._updating_ui = False
-        if self._gain_timeout:
-            GLib.source_remove(self._gain_timeout)
-        self._gain_timeout = GLib.timeout_add(200, self._send_gain, raw)
-
-    def _on_mic_matrix_mute_toggled(self, _source, muted):
-        if self._updating_ui or not self.dev.connected:
-            return
-        self._updating_ui = True
-        self.mute_row.set_active(muted)
-        self._updating_ui = False
-        self._device_async("set_mute", muted)
-
     def _wire_matrix_cells(self):
         """Bind each per-cell slider/mute to the mixer + restore persisted levels."""
-        source_ids = ["mic"] + list(self._sources.keys())
+        source_ids = list(self._sources.keys())
         for source_id in source_ids:
-            for mix_id in ("personal", "chat", "record"):
+            for mix_id in self._mixes:
                 self._wire_cell(source_id, mix_id)
 
     def _wire_cell(self, source_id, mix_id):
@@ -748,83 +728,83 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self._stream_poll_id = GLib.timeout_add_seconds(2, self._stream_poll_tick)
 
     def _stream_poll_tick(self):
-        self.mixer.poll_streams()
-        for source_id in list(self._sources.keys()):
-            self._refresh_app_meter(source_id)
-        return True
+        self.mixer.request_stream_poll()
+        captures = self.mixer.capture_sources()
+        self._add_discovered_inputs(captures)
+        self._follow_capture_mutes()
+        for sid in list(self._sources):
+            self._refresh_source_meter(sid)
+        for mid, mix in self._mixes.items():
+            self._refresh_mix_meter(mid, mix)
+            master = self.mixer.mix_volume(mid)
+            if master is not None:
+                self.matrix.set_mix_volume(mid, master[0])
+        self._refresh_outputs()
+        self._refresh_mix_emptiness()
+        error = self.mixer.last_error()
+        self.routing_label.set_label("Routing: " + error if error else "")
+        self.routing_label.set_visible(bool(error))
+        self.service_btn.set_visible(self._service_problem or bool(error))
+        return not self._shutting_down
 
     def _start_meters(self):
-        """Begin metering the mic + any app source that already has a matching stream."""
-        if self.mixer.mic:
-            self.meter.start(
-                "mic", self.mixer.mic,
-                lambda level: self._set_source_level("mic", level),
-            )
+        """Meter every source that has something to meter."""
         for source_id in self._sources.keys():
-            self._refresh_app_meter(source_id)
+            self._refresh_source_meter(source_id)
 
     def _refresh_app_meter(self, source_id):
-        """Re-point the meter at the first currently-matching stream, or stop it
-        if none match. Called on stream-poll changes and source add."""
-        source = self._sources.get(source_id)
-        if not source:
-            return
-        match = source.get("match_app_name")
+        source = self._sources[source_id]
         streams = self.mixer.streams()
-        candidate = next(
-            (s for s in streams.values() if s.get("app_name") == match), None,
-        )
-        current = self._meter_targets.get(source_id)
-        if candidate is None:
-            if current is not None:
-                self.meter.stop(source_id)
-                self._meter_targets.pop(source_id, None)
-                self._set_source_level(source_id, 0.0)
+        claimed = claim_streams(self._sources, streams).get(source_id, set())
+        row = self.matrix.source(source_id)
+        row.set_waiting(not claimed, "Routed by another source" if any(
+            stream_matches(source, stream) for stream in streams.values()) else "Waiting for audio")
+        if not claimed:
+            self.meter.stop(source_id)
+            self._meter_targets.pop(source_id, None)
+            self._set_source_level(source_id, 0.0)
             return
-        if current == candidate["id"]:
-            return  # already metering this stream
-        self.meter.start(
-            source_id, candidate["node_name"],
-            lambda level, sid=source_id: self._set_source_level(sid, level),
-        )
-        self._meter_targets[source_id] = candidate["id"]
+        target = source_sink_name(source_id)
+        if self._meter_targets.get(source_id) == target and self.meter.active(source_id):
+            return
+        self._meter_targets[source_id] = target
+        self.meter.start(source_id, target, lambda level, sid=source_id: self._set_source_level(sid, level), capture_sink=True)
 
     def _set_source_level(self, source_id, level):
+        self._remote_levels[f"src:{source_id}"] = round(float(level), 4)
         cell = self.matrix.source(source_id)
         if cell is not None:
             cell.set_level(level)
 
     def _on_add_source_clicked(self, _matrix):
-        dialog = AddSourceDialog()
+        dialog = AddSourceDialog(exclude_nodes=self._bound_capture_nodes(),
+            exclude_apps=self._bound_app_names(), streams=self.mixer.streams().values(),
+            captures=self.mixer.capture_sources())
         dialog.connect("source-confirmed", self._on_source_confirmed)
+        dialog.connect("device-source-confirmed", self._on_device_source_confirmed)
         dialog.present(self)
 
-    def _on_source_confirmed(self, _dialog, name, match_app_name, icon_name):
+    def _on_source_confirmed(self, _dialog, name, match_app_name, icon_name,
+                             group=""):
         source = sources_module.new_source(
             name=name, match_app_name=match_app_name, icon_name=icon_name,
         )
-        self._sources = sources_module.add(self._sources, source)
-        self.matrix.add_source(
-            source["id"],
-            name=source["name"],
-            icon_name=source["icon_name"],
-            has_level=True,
-            removable=True,
-        )
-        self._wire_cell(source["id"], "personal")
-        self._wire_cell(source["id"], "chat")
-        self._wire_cell(source["id"], "record")
-        self.mixer.set_sources(self._sources)
-        self.mixer.poll_streams()
-        self._refresh_app_meter(source["id"])
+        if group:
+            source["group"] = group
+        self._install_source(source)
 
     def _on_remove_source_clicked(self, _matrix, source_id):
         source = self._sources.get(source_id, {})
         name = source.get("name", "this source")
+        if sources_module.is_protected(source):
+            body = (f"This deletes “{name}” and its mix levels. If the device "
+                    f"is plugged back in, the row is offered again.")
+        else:
+            body = (f"This deletes “{name}” and its mix levels. The bound "
+                    f"application itself is not affected.")
         dialog = Adw.AlertDialog(
             heading="Remove source?",
-            body=f"This deletes “{name}” and its mix levels. The bound application "
-                 f"itself is not affected.",
+            body=body,
         )
         dialog.add_response("cancel", "Cancel")
         dialog.add_response("remove", "Remove")
@@ -833,15 +813,23 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         dialog.choose(self, None, lambda d, r: self._on_remove_response(d, r, source_id))
 
     def _on_remove_response(self, dialog, result, source_id):
-        if dialog.choose_finish(result) != "remove":
+        if dialog.choose_finish(result) != "remove" or source_id not in self._sources:
             return
+        source = self._sources[source_id]
+        if source.get("protected") and self.mixer.capture_device_present(source["node_name"]):
+            return
+        self._cancel_cell_edits(source_id=source_id)
+        candidate = {sid: record for sid, record in self._sources.items() if sid != source_id}
+        sources_module.save(candidate)
+        self._sources = candidate
+        self.mixer.set_sources(candidate)
+        self.mixer.remove_source(source_id)
         self.meter.stop(source_id)
         self._meter_targets.pop(source_id, None)
+        self._remote_levels.pop("src:" + source_id, None)
         self.matrix.remove_source(source_id)
-        self._sources = sources_module.remove(self._sources, source_id)
-        self.mixer.remove_source(source_id)
-
-    _CELL_DEBOUNCE_MS = 150
+        self._offered_nodes.discard(source.get("node_name"))
+        self._save_ui_state()
 
     def _on_cell_volume_changed(self, _cell, value, source_id, mix_id):
         # During a drag, value-changed fires continuously; coalesce into a
@@ -857,13 +845,556 @@ class WaveXLRWindow(Adw.ApplicationWindow):
 
     def _flush_cell_volume(self, source_id, mix_id, value):
         self._cell_debounce_ids.pop((source_id, mix_id), None)
-        cur = self.mixer.get_cell(source_id, mix_id)
-        self.mixer.set_cell(source_id, mix_id, value, cur["muted"])
-        return False  # one-shot
+        self.set_cell_volume(source_id, mix_id, value)
+        return False
 
     def _on_cell_mute_toggled(self, _cell, muted, source_id, mix_id):
-        cur = self.mixer.get_cell(source_id, mix_id)
-        self.mixer.set_cell(source_id, mix_id, cur["volume"], muted)
+        if source_id not in self._sources or mix_id not in self._mixes:
+            return
+        state = self.mixer.get_cell(source_id, mix_id)
+        self.mixer.set_cell(source_id, mix_id, state["volume"], muted)
+        self._refresh_mix_emptiness()
+
+    def _on_gain_lock_toggled(self, btn):
+        locked = btn.get_active()
+        self.gain_scale.set_sensitive(not locked)
+        btn.set_icon_name(
+            "changes-prevent-symbolic" if locked else "changes-allow-symbolic"
+        )
+        btn.set_tooltip_text("Gain locked \u2014 click to unlock" if locked
+                             else "Lock gain")
+        self._save_ui_state()
+
+    def _restore_gain_lock(self):
+        state = self._load_ui_state()
+        if state.get("gain_locked"):
+            self.gain_lock.set_active(True)   # toggled fires and applies it
+
+    def _load_ui_state(self):
+        try:
+            with open(self._UI_STATE) as f:
+                state = json.load(f)
+        except (OSError, ValueError):
+            return {}
+        return state if isinstance(state, dict) else {}
+
+    def _restore_window_size(self):
+        state = self._load_ui_state()
+        width, height = state.get("width"), state.get("height")
+        if isinstance(width, int) and isinstance(height, int) \
+                and width >= 820 and height >= 480:
+            self.set_default_size(width, height)
+        else:
+            # First run: without this the window opens at the 820x480
+            # MINIMUM, which clips the matrix on every axis. Sized to show
+            # the seeded rows and three mix columns with room to breathe,
+            # while still fitting a 1366x768 laptop panel.
+            self.set_default_size(1280, 720)
+        if state.get("maximized"):
+            self.maximize()
+
+    def _save_ui_state(self):
+        previous = self._load_ui_state()
+        size = (self.get_width(), self.get_height())
+        if self.is_maximized() or min(size) <= 0:
+            size = (previous.get("width", 1280), previous.get("height", 720))
+        try:
+            sources_module._atomic_write(self._UI_STATE, {
+                "width": size[0], "height": size[1], "maximized": self.is_maximized(),
+                "offered_capture_nodes": sorted(self._offered_nodes),
+                "gain_locked": self.gain_lock.get_active(),
+            })
+        except OSError as error:
+            logging.warning("Cannot save interface preferences: %s", error)
+
+    def _on_autostart_toggled(self, row, _param):
+        enabled, _hidden = desktop_module.set_autostart(
+            row.get_active(), self.tray_row.get_active())
+        self.tray_row.set_sensitive(enabled)
+        if enabled != row.get_active():
+            # The file could not be written; show what is actually true
+            # rather than a switch that lies about the next login.
+            with GObject.signal_handler_block(row, self._autostart_handler):
+                row.set_active(enabled)
+
+    def _on_start_hidden_toggled(self, row, _param):
+        if self.autostart_row.get_active():
+            desktop_module.set_autostart(True, row.get_active())
+
+    def _output_entries(self, mix_id, sinks, default_sink):
+        """(entries, current, summary, monitored) for one mix's header menu."""
+        current = self.mixer.get_output(mix_id)
+        resolved = self.mixer.resolve_output(
+            mix_id, sinks=sinks, default_sink=default_sink,
+        )
+        descriptions = {sink["name"]: sink["description"] for sink in sinks}
+
+        auto_label = "Automatic"
+        if current == OUTPUT_AUTO and resolved in descriptions:
+            # Only name the device when Automatic is what is actually in force:
+            # with an explicit sink chosen, resolve_output returns that sink,
+            # and labelling Automatic with it would claim a resolution that is
+            # not the one Automatic would pick.
+            auto_label = f"Automatic — {descriptions[resolved]}"
+
+        # Automatic stays first: it is the entry that describes the default
+        # behaviour, and a mix with no stored choice lands on it.
+        entries = [(OUTPUT_AUTO, auto_label), (OUTPUT_NONE, "Not monitored")]
+        entries += [(sink["name"], sink["description"]) for sink in sinks]
+        if current not in [name for name, _ in entries]:
+            # A remembered device that is currently absent: show it rather than
+            # silently substituting a sentinel.
+            entries.append((current, f"{current} (unavailable)"))
+
+        if current == OUTPUT_NONE:
+            summary, monitored = "Not monitored", False
+        elif resolved is None:
+            summary, monitored = "No output", False
+        else:
+            summary, monitored = descriptions.get(resolved, resolved), True
+        return entries, current, summary, monitored
+
+    def _refresh_mix_meter(self, mix_id, mix):
+        """Point a meter at the mix's sink (its monitor carries the audio).
+
+        Re-pointed idempotently from the stream tick: installing mixes
+        destroys and recreates their sinks, which kills the pw-cat under
+        the meter — running() going false is how that is noticed.
+        """
+        key = f"mix:{mix_id}"
+        sink = mix.get("sink")
+        if not sink:
+            return
+        if self._meter_targets.get(key) == sink and self.meter.active(key):
+            return
+        self._meter_targets[key] = sink
+        def _on_mix_level(level, mid=mix_id):
+            self._remote_levels[f"mix:{mid}"] = round(float(level), 4)
+            self.matrix.set_mix_level(mid, level)
+
+        self.meter.start(key, sink, _on_mix_level, capture_sink=True)
+
+    def _stop_mix_meter(self, mix_id):
+        key = f"mix:{mix_id}"
+        if self._meter_targets.pop(key, None) is not None:
+            self.meter.stop(key)
+
+    def _on_add_mix_clicked(self, _matrix):
+        dialog = MixDialog(
+            heading="Add Mix", confirm_label="Add Mix",
+            name="", icon_name=mixes_module.DEFAULT_ICON,
+        )
+        dialog.connect("mix-confirmed", self._on_mix_created)
+        dialog.present(self)
+
+    def _on_rename_mix_clicked(self, _matrix, mix_id):
+        mix = self._mixes.get(mix_id)
+        if mix is None:
+            return
+        dialog = MixDialog(
+            heading="Rename Mix", confirm_label="Save",
+            name=mix.get("name", ""),
+            icon_name=mix.get("icon_name", mixes_module.DEFAULT_ICON),
+        )
+        dialog.connect("mix-confirmed", self._on_mix_renamed, mix_id)
+        dialog.present(self)
+
+    def _on_remove_mix_clicked(self, _matrix, mix_id):
+        if len(self._mixes) <= 1:
+            return  # the header control is already insensitive; belt and braces
+        mix = self._mixes.get(mix_id)
+        if mix is None:
+            return
+        name = mix.get("name", "this mix")
+        description = mix.get("description") or mix.get("sink", "")
+        dialog = Adw.AlertDialog(
+            heading="Delete mix?",
+            body=f"“{name}” and its levels for every source are deleted, "
+                 f"and the “{description}” audio device disappears. "
+                 f"Anything recording or listening to it — OBS, Discord — "
+                 f"loses that input until it is pointed somewhere else.",
+        )
+        dialog.add_response("cancel", "Cancel")
+        dialog.add_response("delete", "Delete")
+        dialog.set_response_appearance("delete", Adw.ResponseAppearance.DESTRUCTIVE)
+        dialog.set_default_response("cancel")
+        dialog.choose(
+            self, None, lambda d, r: self._on_remove_mix_response(d, r, mix_id),
+        )
+
+    def _refresh_source_meter(self, source_id):
+        """Point a source's meter at whatever currently carries its audio."""
+        source = self._sources.get(source_id)
+        if not source:
+            return
+        if sources_module.kind(source) == sources_module.KIND_DEVICE:
+            self._refresh_device_meter(source_id, source)
+        else:
+            self._refresh_app_meter(source_id)
+
+    def _set_source_waiting(self, source_id, waiting, hint="Waiting for audio"):
+        cell = self.matrix.source(source_id)
+        if cell is not None:
+            cell.set_waiting(waiting, hint)
+
+    def remote_levels(self):
+        """Every live meter's latest peak, as JSON, for the `levels` action.
+
+        Fed by the same callbacks that move the bars — publishing costs a
+        dict write per meter frame, and reading is one Describe. A remote
+        polls this only while a dial with a meter is actually on screen.
+        """
+        return json.dumps(self._remote_levels)
+
+    def _bound_app_names(self):
+        """Application names some row already matches, so the picker cannot
+        offer a duplicate. claim_streams() gives every stream exactly one
+        owner regardless, so a duplicate could never double-route -- but it
+        would sit in the matrix as a silently inert fader, which reads as
+        broken. Built from bindings() so multi-name rows cover all of theirs.
+        """
+        return {
+            name
+            for source in self._sources.values()
+            for name in sources_module.bindings(source)
+        }
+
+    def _bound_capture_nodes(self):
+        """Capture nodes that already have a row, so the picker cannot make a
+        duplicate. The Wave's own mic is in the set: it is the built-in row,
+        and a second row for it would double the same audio into every mix."""
+        nodes = {
+            source.get("node_name")
+            for source in self._sources.values()
+            if sources_module.kind(source) == sources_module.KIND_DEVICE
+        }
+        # mixer.mic is deliberately NOT excluded: the Wave's own input gets a
+        # row like any other, and the device controls in the sidebar are a
+        # separate concern from whether it appears in the matrix.
+        return {node for node in nodes if node}
+
+    def _on_device_source_confirmed(self, _dialog, name, node_name, icon_name,
+                                    group=""):
+        # Queue the re-snapshot before installing: the reconcile that
+        # _install_source triggers refuses to wire a node the snapshot has not
+        # seen, and the worker runs queued tasks in insertion order, so the
+        # refresh lands first. Doing it synchronously would put a pw-dump on
+        # the GTK thread in a click handler.
+        self.mixer.request_capture_poll()
+        source = sources_module.new_device_source(
+            name=name, node_name=node_name, icon_name=icon_name,
+        )
+        if group:
+            source["group"] = group
+        self._install_source(source)
+
+    def _show_error(self, heading, error):
+        logging.warning("%s: %s", heading, error)
+        dialog = Adw.AlertDialog(heading=heading, body=str(error))
+        dialog.add_response("ok", "OK")
+        dialog.choose(self, None, lambda d, r: d.choose_finish(r))
+
+    def _refresh_outputs(self):
+        sinks, default = self.mixer.output_sinks(), self.mixer.default_sink()
+        for mid in self._mixes:
+            self.matrix.set_mix_outputs(mid, *self._output_entries(mid, sinks, default))
+
+    def _on_mix_output_changed(self, _matrix, mix_id, output):
+        self.mixer.set_output(mix_id, output)
+        self._refresh_outputs()
+
+    def _on_mix_volume_changed(self, _matrix, mix_id, value):
+        self.mixer.set_mix_volume(mix_id, value)
+
+    def _on_mix_created(self, _dialog, name, icon_name):
+        mix = mixes_module.new_mix(name=name, icon_name=icon_name)
+        self._mixes = mixes_module.add(self._mixes, mix)
+        self.mixer.set_mixes(self._mixes)
+        self.matrix.add_mix(mix["id"], title=mix["name"], subtitle=mix["subtitle"], icon_name=icon_name)
+        for sid in self._sources:
+            self._wire_cell(sid, mix["id"])
+        self._refresh_outputs()
+
+    def _on_mix_renamed(self, _dialog, name, icon_name, mix_id):
+        if mix_id not in self._mixes:
+            return
+        self._mixes = mixes_module.update(self._mixes, mix_id, name=name, icon_name=icon_name)
+        self.mixer.set_mixes(self._mixes)
+        self.matrix.set_mix(mix_id, title=name, icon_name=icon_name)
+
+    def _cancel_cell_edits(self, source_id=None, mix_id=None):
+        for key, timer in list(self._cell_debounce_ids.items()):
+            if (source_id is None or key[0] == source_id) and (mix_id is None or key[1] == mix_id):
+                GLib.source_remove(timer)
+                del self._cell_debounce_ids[key]
+
+    def _on_remove_mix_response(self, dialog, result, mix_id):
+        if dialog.choose_finish(result) != "delete" or mix_id not in self._mixes:
+            return
+        self._cancel_cell_edits(mix_id=mix_id)
+        self._mixes = mixes_module.remove(self._mixes, mix_id)
+        self.mixer.set_mixes(self._mixes)
+        self._stop_mix_meter(mix_id)
+        self.matrix.remove_mix(mix_id)
+        self._remote_levels.pop("mix:" + mix_id, None)
+
+    def _refresh_mix_emptiness(self):
+        cells = self.mixer.cells()
+        for mid in self._mixes:
+            fed = any(not source.get("muted") and source.get("level", 1.0) > 0
+                and cells.get(f"{sid}.{mid}", {}).get("volume", 0) > 0
+                and not cells.get(f"{sid}.{mid}", {}).get("muted")
+                for sid, source in self._sources.items())
+            self.matrix.set_mix_empty(mid, not fed)
+
+    def _refresh_device_meter(self, source_id, source):
+        node = source["node_name"]
+        capture = next((item for item in self.mixer.capture_sources() if item["name"] == node), None)
+        row = self.matrix.source(source_id)
+        if row is not None:
+            row.set_available(capture is not None, reason="Capture device not connected")
+            if source.get("protected"):
+                row.set_removable(capture is None, tooltip="Remove disconnected device")
+        if capture is None:
+            self.meter.stop(source_id)
+            self._meter_targets.pop(source_id, None)
+            self._set_source_level(source_id, 0.0)
+            return
+        target = (node, capture.get("identity"))
+        if self._meter_targets.get(source_id) == target and self.meter.active(source_id):
+            return
+        self._meter_targets[source_id] = target
+        self.meter.start(source_id, node,
+            lambda level, sid=source_id: self._set_source_level(sid, level),
+            identity=capture["identity"])
+
+    def _add_source_widget(self, source):
+        sid = source["id"]
+        self.matrix.add_source(sid, name=source["name"], icon_name=source["icon_name"],
+            has_level=True, removable=not source.get("protected"), editable=True,
+            reorderable=True, is_capture=sources_module.kind(source) == sources_module.KIND_DEVICE)
+        self._wire_source_row(sid)
+
+    def _wire_source_row(self, source_id):
+        source = self._sources[source_id]
+        row = self.matrix.source(source_id)
+        row.set_volume(source.get("level", 1.0))
+        row.set_muted(source.get("muted", False))
+        self.matrix.set_source_group(source_id, sources_module.group(source))
+        row.connect("volume-changed", self._on_source_level_changed, source_id)
+        row.connect("mute-toggled", self._on_source_mute_toggled, source_id)
+
+    def _install_source(self, source):
+        self._sources = sources_module.add(self._sources, source)
+        self.mixer.set_sources(self._sources)
+        self._add_source_widget(source)
+        for mid in self._mixes:
+            self._wire_cell(source["id"], mid)
+        self._refresh_source_meter(source["id"])
+
+    def _add_discovered_inputs(self, captures):
+        waves = [item for item in captures if item["name"].startswith(SOURCE_MATCHES)]
+        bound = self._bound_capture_nodes()
+        for capture in waves:
+            node = capture["name"]
+            if node in bound or node in self._offered_nodes:
+                continue
+            source = sources_module.new_device_source(name=capture["description"], node_name=node)
+            source["protected"] = True
+            source["channels"] = capture.get("channels", 2)
+            self._install_source(source)
+            self._offered_nodes.add(node)
+            if len(waves) == 1 and "mic" not in self._sources:
+                legacy = {key.split(".", 1)[1]: state for key, state in self.mixer.cells().items() if key.startswith("mic.")}
+                for mid, state in legacy.items():
+                    if mid in self._mixes:
+                        self.mixer.set_cell(source["id"], mid, state["volume"], state["muted"])
+                        cell = self.matrix.cell(source["id"], mid)
+                        cell.set_volume(state["volume"])
+                        cell.set_muted(state["muted"])
+                if legacy:
+                    self.mixer.remove_source("mic")
+            self._save_ui_state()
+
+    def _on_edit_source_clicked(self, _matrix, source_id):
+        if source_id not in self._sources:
+            return
+        dialog = AddSourceDialog(source=self._sources[source_id],
+            streams=self.mixer.streams().values(), captures=self.mixer.capture_sources())
+        dialog.connect("source-edited", self._on_source_edited)
+        dialog.present(self)
+
+    def _on_source_edited(self, _dialog, source_id, name, binding, icon_name, group=""):
+        if source_id not in self._sources:
+            return
+        fields = dict(name=name, icon_name=icon_name, group=group)
+        if group.strip() and group.strip() != sources_module.group(self._sources[source_id]):
+            if any(sid != source_id and sources_module.group(record) == group.strip()
+                   and not record["muted"] for sid, record in self._sources.items()):
+                fields["muted"] = True
+        if sources_module.kind(self._sources[source_id]) == sources_module.KIND_APP:
+            fields["match_app_names"] = sources_module.parse_bindings(binding)
+        self._sources = sources_module.update(self._sources, source_id, **fields)
+        self.mixer.set_sources(self._sources)
+        self.matrix.set_source(source_id, name=name, icon_name=icon_name)
+        self.matrix.set_source_group(source_id, group)
+        self.matrix.source(source_id).set_muted(self._sources[source_id]["muted"])
+        if "muted" in fields:
+            self._sync_hw_mute(self._sources[source_id], fields["muted"])
+        self.meter.stop(source_id)
+        self._meter_targets.pop(source_id, None)
+        self._refresh_source_meter(source_id)
+
+    def _on_move_source_clicked(self, _matrix, source_id, delta):
+        if source_id not in self._sources:
+            return
+        self._sources = sources_module.reorder(self._sources, source_id, delta)
+        self.mixer.set_sources(self._sources)
+        self.matrix.reorder_sources(list(self._sources))
+        for sid in self._sources:
+            self._wire_source_row(sid)
+        self._wire_matrix_cells()
+
+    def set_source_volume(self, source_id, level):
+        if source_id not in self._sources:
+            return False
+        level = sources_module.level(level)
+        self._sources = sources_module.update(self._sources, source_id, level=level)
+        self.mixer.set_source_level(source_id, level, self._sources[source_id]["muted"])
+        self.matrix.source(source_id).set_volume(level)
+        self._refresh_mix_emptiness()
+        return True
+
+    def _on_source_level_changed(self, _row, level, source_id):
+        self.set_source_volume(source_id, level)
+
+    def _set_source_muted(self, source_id, muted, *, hardware=True):
+        source = self._sources.get(source_id)
+        if source is None:
+            return None
+        group = sources_module.group(source)
+        changes = {}
+        for sid, record in self._sources.items():
+            value = bool(muted) if sid == source_id else record["muted"]
+            if not muted and group and sid != source_id and sources_module.group(record) == group:
+                value = True
+            if value != record["muted"]:
+                changes[sid] = value
+        candidate = {sid: dict(record, muted=changes.get(sid, record["muted"]))
+                     for sid, record in self._sources.items()}
+        sources_module.save(candidate)
+        self._sources = candidate
+        # One desired-state snapshot prevents an intermediate double-live group.
+        self.mixer.set_sources(candidate)
+        for sid, value in sorted(changes.items(), key=lambda item: not item[1]):
+            self.matrix.source(sid).set_muted(value)
+            if hardware or sid != source_id:
+                self._sync_hw_mute(candidate[sid], value)
+        self._refresh_mix_emptiness()
+        self._notify_tray()
+        return bool(muted)
+
+    def _on_source_mute_toggled(self, _row, muted, source_id):
+        self._set_source_muted(source_id, muted)
+
+    def toggle_source_mute(self, source_id):
+        if source_id not in self._sources:
+            return None
+        return self._set_source_muted(source_id, not self._sources[source_id]["muted"])
+
+    def _device_for_source(self, source):
+        capture = next((item for item in self.mixer.capture_sources()
+                        if item["name"] == source.get("node_name")), None)
+        if capture is None:
+            return None
+        candidates = [dev for dev in self._devs if
+            (capture.get("alsa_card") is not None and str(capture["alsa_card"]) == str(dev.alsa_card))
+            or (capture.get("serial") and capture["serial"] == dev.info.get("serial"))]
+        return candidates[0] if len(candidates) == 1 else None
+
+    def _sync_hw_mute(self, source, muted):
+        if sources_module.kind(source) != sources_module.KIND_DEVICE:
+            return
+        device = self._device_for_source(source)
+        if device is None:
+            self.mixer.set_capture_mute(source["node_name"], muted)
+            return
+        self._usb_async(lambda: device.set_mute(muted),
+            on_error=lambda error: self._on_device_error(device, error), device=device)
+
+    def _follow_capture_mutes(self):
+        mutes = self.mixer.capture_mutes()
+        previous = self._capture_mute_seen
+        self._capture_mute_seen = mutes
+        for sid, source in list(self._sources.items()):
+            node = source.get("node_name")
+            if node not in mutes or node not in previous or self._device_for_source(source) is not None:
+                continue
+            if mutes[node] != previous[node] and mutes[node] != source["muted"]:
+                self._set_source_muted(sid, mutes[node], hardware=False)
+
+    def _notify_tray(self):
+        application = self.get_application()
+        if isinstance(application, WaveXLRApp):
+            application.refresh_tray()
+
+    def capture_rows_muted(self):
+        captures = [record for record in self._sources.values()
+                    if sources_module.kind(record) == sources_module.KIND_DEVICE]
+        return bool(captures) and all(record["muted"] for record in captures)
+
+    def source_groups(self):
+        groups = [sources_module.group(record) for record in self._sources.values()]
+        return sorted(name for name in set(groups) if name and groups.count(name) > 1)
+
+    def switch_group(self, name):
+        members = [sid for sid, record in self._sources.items() if sources_module.group(record) == name]
+        if len(members) < 2:
+            return ""
+        live = next((sid for sid in members if not self._sources[sid]["muted"]), None)
+        target = members[0] if live is None else members[(members.index(live) + 1) % len(members)]
+        self._set_source_muted(target, False)
+        return target
+
+    def _on_switch_source_clicked(self, _matrix, source_id):
+        source = self._sources.get(source_id)
+        if source is None:
+            return
+        if source["muted"]:
+            self._set_source_muted(source_id, False)
+        else:
+            self.switch_group(sources_module.group(source))
+
+    def _on_group_sources_clicked(self, _matrix, dragged_id, target_id):
+        if dragged_id == target_id or dragged_id not in self._sources or target_id not in self._sources:
+            return
+        target = self._sources[target_id]
+        group = sources_module.group(target) or target["name"]
+        self._sources[dragged_id]["group"] = group
+        self._sources[target_id]["group"] = group
+        self.matrix.set_source_group(dragged_id, group)
+        self.matrix.set_source_group(target_id, group)
+        self._set_source_muted(target_id, False)
+
+    def set_cell_volume(self, source_id, mix_id, volume):
+        if source_id not in self._sources or mix_id not in self._mixes:
+            return False
+        volume = sources_module.level(volume)
+        state = self.mixer.get_cell(source_id, mix_id)
+        self.mixer.set_cell(source_id, mix_id, volume, state["muted"])
+        self.matrix.cell(source_id, mix_id).set_volume(volume)
+        self._refresh_mix_emptiness()
+        return True
+
+    def toggle_cell_mute(self, source_id, mix_id):
+        if source_id not in self._sources or mix_id not in self._mixes:
+            return None
+        state = self.mixer.get_cell(source_id, mix_id)
+        muted = not state["muted"]
+        self.mixer.set_cell(source_id, mix_id, state["volume"], muted)
+        self.matrix.cell(source_id, mix_id).set_muted(muted)
+        self._refresh_mix_emptiness()
+        return muted
 
 
 class WaveXLRApp(Adw.Application):
@@ -893,21 +1424,21 @@ class WaveXLRApp(Adw.Application):
             # The user unit is OpenWave-owned state, so keep it aligned with
             # the installed app without hiding a routine upgrade behind the
             # first-run dialog. Failures still fall through to that repair UI.
-            if service.is_installed() and service.needs_refresh():
+            if not setup.is_sandboxed() and service.is_installed() and service.needs_refresh():
                 try:
                     service.install()
                 except Exception as e:
                     logging.getLogger("openwave.app").warning(
                         "Failed to refresh audio service: %s", e
                     )
-            if setup.needs_setup():
+            if not setup.is_sandboxed() and setup.needs_setup():
                 self._show_setup_dialog()
                 return
             self._window = WaveXLRWindow(application=self)
             # Hide-to-tray on close instead of quitting
             self._window.connect("close-request", self._on_close_request)
             self._setup_tray()
-            if self._start_hidden:
+            if self._start_hidden and self._tray is not None:
                 self._start_hidden = False  # only first launch
                 return
         self._window.present()
@@ -933,14 +1464,17 @@ class WaveXLRApp(Adw.Application):
             )
 
     def do_shutdown(self):
-        """Tear down device and audio subprocesses before exit."""
+        if self._tray is not None:
+            self._tray.unregister()
+            self._tray = None
         if self._window is not None:
-            self._window.shutdown()
-            if hasattr(self._window, "mixer"):
-                self._window.mixer.stop()
-            if hasattr(self._window, "meter"):
-                self._window.meter.stop_all()
+            window = self._window
+            window._save_ui_state()
+            window.shutdown()
+            window.mixer.stop()
+            window.meter.stop_all()
         Adw.Application.do_shutdown(self)
+
 
     def _on_close_request(self, window):
         if self._tray:
@@ -950,14 +1484,13 @@ class WaveXLRApp(Adw.Application):
 
     def _setup_tray(self):
         from .tray import TrayIcon
-        self._tray = TrayIcon(
-            on_activate=self._show_window,
-            on_mute=self._toggle_mute,
-            on_quit=self._quit_app,
-        )
-        self._tray.register()
-        # Keep app alive when window is hidden
-        self.hold()
+        tray = TrayIcon(on_activate=self._show_window, on_open=self._show_window,
+                        on_mute=self._toggle_mute, on_quit=self._quit_app)
+        if tray.register():
+            self._tray = tray
+            self.hold()
+            self.refresh_tray()
+
 
     def _toggle_mute(self):
         if self._window and self._window.dev.connected:
@@ -965,8 +1498,10 @@ class WaveXLRApp(Adw.Application):
             self._window._device_async("set_mute", not current)
 
     def _quit_app(self):
-        self.release()
+        if self._tray is not None:
+            self.release()
         self.quit()
+
 
     def _show_window(self):
         if self._window:
@@ -1024,8 +1559,16 @@ class WaveXLRApp(Adw.Application):
         self._window = win
         win.present()
 
+    def refresh_tray(self):
+        if self._tray is not None and self._window is not None:
+            window = self._window
+            self._tray.set_state(bool(window._devs),
+                hardware_muted=any(state["mute"] for state in window._device_states.values()),
+                row_muted=window.capture_rows_muted(),
+                display_name=window.dev.profile.display_name if window.dev.profile else None)
+
 
 
 def main():
     app = WaveXLRApp()
-    app.run(sys.argv)
+    return app.run(sys.argv)

--- a/wavexlr/child.py
+++ b/wavexlr/child.py
@@ -1,0 +1,32 @@
+"""Exec audio helpers with Linux parent-death protection, without preexec_fn.
+
+The prctl call runs in a fresh interpreter, never between fork and exec in the
+threaded GTK process. The helper becomes the audio process; no supervisor stays.
+"""
+
+import os
+import subprocess
+import sys
+
+
+def spawn(argv, **kwargs):
+    return subprocess.Popen(
+        [sys.executable, "-m", "wavexlr.child", str(os.getpid()), *argv], **kwargs
+    )
+
+
+def main():
+    import ctypes
+    import signal
+
+    parent = int(sys.argv[1])
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(1, int(signal.SIGTERM), 0, 0, 0) != 0:
+        raise OSError(ctypes.get_errno(), "Cannot protect audio child lifetime")
+    if os.getppid() != parent:
+        return 1
+    os.execvp(sys.argv[2], sys.argv[2:])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wavexlr/desktop.py
+++ b/wavexlr/desktop.py
@@ -1,0 +1,186 @@
+"""Desktop integration: the app drawer entry and starting at login.
+
+Both are freedesktop .desktop files in the user's own directories, so neither
+needs privileges and neither belongs in the first-run setup dialog that asks
+for a password. The menu entry is written on every launch if it is missing or
+stale; autostart is a choice, so it is only ever written when asked for.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import shlex
+
+APP_ID = "openwave"
+NAME = "OpenWave"
+# Identity must match the packaged wavexlr.desktop: whichever entry the user
+# ends up with depends only on install path, so the two disagreeing means the
+# app renames itself depending on how it was installed.
+COMMENT = "The audio mixing matrix for Linux"
+ICON = "openwave"
+ICON_FALLBACK = "audio-input-microphone"
+# One main category only. AudioVideo plus Settings validates, but
+# desktop-file-validate warns it may list the app twice in the menu,
+# and a mixer belongs under Audio rather than under system settings.
+CATEGORIES = "AudioVideo;Audio;Mixer;"
+
+
+def _data_home():
+    return os.environ.get("XDG_DATA_HOME") or os.path.expanduser("~/.local/share")
+
+
+def _config_home():
+    return os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser("~/.config")
+
+
+def menu_entry_path():
+    return os.path.join(_data_home(), "applications", f"{APP_ID}.desktop")
+
+
+def autostart_path():
+    return os.path.join(_config_home(), "autostart", f"{APP_ID}.desktop")
+
+
+def _exec_arg(value):
+    """Quote one argument using the Desktop Entry Exec escaping rules."""
+    value = value.replace("%", "%%")
+    for char in ("\\", '"', "`", "$"):
+        value = value.replace(char, "\\" + char)
+    return '"' + value.replace("\\", "\\\\") + '"'
+
+
+def launch_command():
+    """How to start OpenWave again, from however it was started this time.
+
+    `openwave` on PATH when there is one, because that survives the checkout
+    moving. Otherwise the running interpreter and the module, with an absolute
+    path: a desktop file has no working directory to inherit, so a bare
+    "python3 -m wavexlr" would only work when the checkout happens to be the
+    session's cwd, which it never is at login.
+    """
+    installed = shutil.which(APP_ID)
+    if installed:
+        return _exec_arg(installed)
+    # PYTHONPATH rather than a flag or a Path= key: a desktop file inherits no
+    # working directory, so "python3 -m wavexlr" would only resolve when the
+    # checkout happened to be the session's cwd, which at login it never is.
+    checkout = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    return " ".join(_exec_arg(arg) for arg in (
+        "env", f"PYTHONPATH={checkout}", sys.executable, "-m", "wavexlr"))
+
+
+def icon_name():
+    """The themed icon when it is installed, a stock one when it is not.
+
+    A run-in-place checkout has no openwave.svg in any icon directory, and a
+    .desktop entry naming an unresolvable icon renders as the generic broken
+    gear — worse than the stock microphone. The check mirrors where the
+    Makefile and the Nix wrapper put the icon: hicolor under each XDG data
+    dir.
+    """
+    data_dirs = [_data_home()] + (
+        os.environ.get("XDG_DATA_DIRS") or "/usr/local/share:/usr/share"
+    ).split(":")
+    for base in filter(None, data_dirs):
+        if os.path.isfile(os.path.join(
+                base, "icons", "hicolor", "scalable", "apps", f"{ICON}.svg")):
+            return ICON
+    return ICON_FALLBACK
+
+
+def _render(exec_command, autostart=False):
+    lines = [
+        "[Desktop Entry]",
+        "Type=Application",
+        f"Name={NAME}",
+        f"Comment={COMMENT}",
+        f"Exec={exec_command}",
+        f"Icon={icon_name()}",
+        f"Categories={CATEGORIES}",
+        "Terminal=false",
+        # Without this the tray icon and the window are two entries in the
+        # dock, because the shell has no way to tell they are one app.
+        f"StartupWMClass=com.github.openwave",
+        "X-GNOME-UsesNotifications=true",
+    ]
+    if autostart:
+        # Honoured by GNOME and KDE; ignored elsewhere, where the file simply
+        # being present is what enables it.
+        lines.append("X-GNOME-Autostart-enabled=true")
+    return "\n".join(lines) + "\n"
+
+
+def _write(path, contents):
+    directory = os.path.dirname(path)
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".openwave-", suffix=".tmp", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(contents)
+        os.replace(tmp, path)
+    finally:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+
+
+def ensure_menu_entry():
+    """Put OpenWave in the app drawer, rewriting a stale entry.
+
+    Rewritten rather than only created, because the Exec line embeds where
+    OpenWave was found: an entry written from a checkout that has since been
+    installed properly would otherwise keep launching the old path forever.
+    """
+    path = menu_entry_path()
+    wanted = _render(launch_command())
+    try:
+        try:
+            with open(path, encoding="utf-8") as handle:
+                if handle.read() == wanted:
+                    return False
+        except FileNotFoundError:
+            pass
+        _write(path, wanted)
+    except OSError:
+        return False
+    return True
+
+
+def autostart_state():
+    """(enabled, hidden) for starting at login."""
+    path = autostart_path()
+    try:
+        with open(path, encoding="utf-8") as handle:
+            contents = handle.read()
+    except OSError:
+        return False, False
+    values = dict(line.split("=", 1) for line in contents.splitlines()
+                  if "=" in line and not line.lstrip().startswith("#"))
+    enabled = (values.get("X-GNOME-Autostart-enabled") != "false"
+               and values.get("Hidden") != "true")
+    try:
+        hidden = "--hide" in shlex.split(values.get("Exec", ""))
+    except ValueError:
+        hidden = False
+    return enabled, hidden
+
+
+def set_autostart(enabled, hidden=False):
+    """Turn starting at login on or off. Returns the new (enabled, hidden)."""
+    path = autostart_path()
+    if not enabled:
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            return autostart_state()
+        return False, hidden
+    command = launch_command() + (" --hide" if hidden else "")
+    try:
+        _write(path, _render(command, autostart=True))
+    except OSError:
+        return autostart_state()
+    return True, hidden

--- a/wavexlr/device.py
+++ b/wavexlr/device.py
@@ -318,6 +318,39 @@ def _alsa_hp_to_fw(alsa_hp, scale):
     return int(db * scale)
 
 
+# PipeWire's ALSA device.serial is udev ID_SERIAL: manufacturer_product_serial.
+# These are the supported units' udev prefixes, not node-name substring matches.
+_CAPTURE_SERIAL_PREFIXES = {
+    "wave_xlr": "Elgato_Systems_Elgato_Wave_XLR_",
+    "wave_xlr_mk2": "Elgato_Systems_Elgato_XLR_Dock_",
+    "wave3": "Elgato_Systems_Elgato_Wave_3_",
+}
+
+
+def device_for_capture(capture, devices):
+    """Map a capture only to one connected unit with an exact serial identity.
+
+    ALSA card indices are reusable and cannot establish physical identity.
+    Accept a bare firmware serial or its model's complete udev ID_SERIAL;
+    unknown formats and missing or duplicate identities use PipeWire instead.
+    """
+    serial = capture.get("serial")
+    if not isinstance(serial, str) or not serial:
+        return None
+    match = None
+    for dev in devices:
+        unit_serial = dev.info.get("serial")
+        if not dev.connected or not isinstance(unit_serial, str) or not unit_serial:
+            continue
+        prefix = _CAPTURE_SERIAL_PREFIXES.get(dev.profile.key)
+        if serial != unit_serial and (prefix is None or serial != prefix + unit_serial):
+            continue
+        if match is not None:
+            return None
+        match = dev
+    return match
+
+
 class WaveDevice:
     def __init__(self):
         self._handle = None

--- a/wavexlr/device.py
+++ b/wavexlr/device.py
@@ -333,6 +333,11 @@ class WaveDevice:
     def connected(self):
         return self._handle is not None
 
+    @property
+    def alsa_card(self):
+        """Exact ALSA card number paired with this USB handle."""
+        return self._card
+
     def connect(self, profile=None, bus=None, addr=None):
         """Open the exact scanned unit, only after its ALSA controls are ready."""
         if profile is None:

--- a/wavexlr/icons.py
+++ b/wavexlr/icons.py
@@ -1,0 +1,86 @@
+"""Resolve icons at draw time without changing persisted source/mix choices."""
+
+# Import GTK only when a display is available; icon metadata is also used headless.
+_ALTERNATIVES = {
+    "openwave-symbolic": ("audio-input-microphone-symbolic",),
+    "openwave-muted-symbolic": ("microphone-sensitivity-muted-symbolic",),
+    "openwave-attention-symbolic": ("dialog-warning-symbolic",),
+    "web-browser-symbolic": (
+        "internet-web-browser-symbolic",
+        "applications-internet-symbolic",
+        "globe-symbolic",
+    ),
+    "input-gaming-symbolic": (
+        "applications-games-symbolic",
+        "input-gamepad-symbolic",
+    ),
+    "audio-x-generic-symbolic": (
+        "multimedia-player-symbolic",
+        "media-optical-audio-symbolic",
+    ),
+    "list-drag-handle-symbolic": (
+        "view-list-symbolic",
+        "open-menu-symbolic",
+    ),
+    "network-transmit-symbolic": (
+        "network-wired-symbolic",
+        "network-connect-symbolic",
+    ),
+    "preferences-desktop-multimedia-symbolic": (
+        "multimedia-player-symbolic",
+        "applications-multimedia-symbolic",
+    ),
+    "video-display-symbolic": (
+        "computer-symbolic",
+        "preferences-desktop-display-symbolic",
+    ),
+}
+
+_cache = {}
+_watched = False
+
+
+def _theme():
+    """The display's icon theme, or None when there is no display yet."""
+    global _watched
+    try:
+        import gi
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gdk, Gtk
+    except (ImportError, ValueError):
+        return None
+    display = Gdk.Display.get_default()
+    if display is None:
+        return None
+    theme = Gtk.IconTheme.get_for_display(display)
+    if theme is not None and not _watched:
+        # A theme change makes every earlier answer stale, including the ones
+        # that needed no substitution.
+        theme.connect("changed", lambda *_: _cache.clear())
+        _watched = True
+    return theme
+
+
+def resolve(name):
+    """Return name, or the nearest name the active theme actually has.
+
+    Unknown names are returned untouched: a theme we have no table for is not
+    improved by guessing, and the broken glyph is at least honest about it.
+    """
+    if not name:
+        return name
+    if name in _cache:
+        return _cache[name]
+
+    theme = _theme()
+    if theme is None:
+        return name
+    chosen = name
+    if theme is not None and not theme.has_icon(name):
+        for alternative in _ALTERNATIVES.get(name, ()):
+            if theme.has_icon(alternative):
+                chosen = alternative
+                break
+
+    _cache[name] = chosen
+    return chosen

--- a/wavexlr/meter.py
+++ b/wavexlr/meter.py
@@ -1,115 +1,217 @@
-"""Per-source level metering.
+"""Low-rate PipeWire peak meters with worker-owned process lifetimes.
 
-For each source we want a level bar for, spawn a low-rate `pw-cat --record`
-in mono s16 at 8 kHz (16 KB/s — cheap), read in a daemon thread, compute the
-peak of each chunk, and marshal the value onto the GTK main thread via
-GLib.idle_add. Independent of the loopback subprocess plumbing in mixer.py
-to keep concerns separate.
+start(id, node_name, callback, capture_sink=False) replaces that id's generation.
+callback(peak: float) runs on the GLib main thread, with normalized linear peaks.
+stop(id) and stop_all() cancel immediately without waiting on the GTK thread.
+wait_stopped(timeout=3.0) joins cancelled workers during off-thread shutdown;
+it returns False if the timeout expires. A worker owns spawn, read, pipe closure
+and bounded terminate/kill/reap, including when cancelled during process startup.
+ui_suspended suppresses visual callbacks only; byte-flow timestamps still update.
 """
 
+import json
 import os
+import selectors
 import struct
 import subprocess
 import threading
+import time
+from dataclasses import dataclass, field
 
 import gi
 
 gi.require_version("GLib", "2.0")
 from gi.repository import GLib  # noqa: E402
 
-from .mixer import _set_pdeathsig  # share the pdeathsig helper
+
+@dataclass(eq=False)
+class _Meter:
+    callback: object
+    stop: threading.Event = field(default_factory=threading.Event)
+    proc: object = None
+    thread: object = None
+    last_data: float = field(default_factory=time.monotonic)
 
 
 class MeterMonitor:
     SAMPLE_RATE = 8000
-    CHUNK_BYTES = 256  # ~16 ms of s16 mono @ 8 kHz → ~60 Hz updates
+    CHUNK_BYTES = 1024
+    _QUIET = 0.004
+    _TAIL_FRAMES = 20
+    _POLL_SECONDS = 0.1
+    _REAP_SECONDS = 0.5
 
     def __init__(self):
-        self._procs = {}        # source_id -> Popen
-        self._threads = {}      # source_id -> Thread
-        self._stop_flags = {}   # source_id -> threading.Event
-        self._cbs = {}          # source_id -> callable(float)
+        self.ui_suspended = False
+        self._meters = {}
+        self._workers = set()
+        self._lock = threading.RLock()
 
-    def start(self, source_id, source_node_name, callback):
-        """Begin streaming peak values for `source_id`. Replaces any existing
-        meter for that id. `callback(level: float)` is invoked on the main
-        thread at the chunk rate."""
-        if source_id in self._procs:
-            self.stop(source_id)
-        try:
-            proc = subprocess.Popen(
-                [
-                    "pw-cat", "--record",
-                    "--target", source_node_name,
-                    "--rate", str(self.SAMPLE_RATE),
-                    "--channels", "1",
-                    "--format", "s16",
-                    "-",
-                ],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
-                preexec_fn=_set_pdeathsig,
-            )
-        except (FileNotFoundError, OSError):
-            return
+    def start(self, source_id, source_node_name, callback, capture_sink=False):
+        """Start a source tap, or a sink-monitor tap with capture_sink=True.
 
-        stop_flag = threading.Event()
-        thread = threading.Thread(
+        Spawn errors produce a final zero callback; running() stays False.
+        No callback or byte timestamp from an older generation can affect the
+        replacement, including callbacks already queued on the GLib main loop.
+        """
+        state = _Meter(callback)
+        state.thread = threading.Thread(
             target=self._reader,
-            args=(source_id, proc, stop_flag),
-            daemon=True,
+            args=(source_id, source_node_name, capture_sink, state),
+            name=f"openwave-meter-{source_id}",
+            daemon=False,
         )
-        self._procs[source_id] = proc
-        self._threads[source_id] = thread
-        self._stop_flags[source_id] = stop_flag
-        self._cbs[source_id] = callback
-        thread.start()
+        with self._lock:
+            self.stop(source_id)
+            self._meters[source_id] = state
+            self._workers.add(state.thread)
+            state.thread.start()
+
+    def running(self, source_id):
+        """Whether this id has a live, uncancelled meter subprocess."""
+        with self._lock:
+            state = self._meters.get(source_id)
+            return bool(state and state.proc and state.proc.poll() is None
+                        and not state.stop.is_set())
 
     def stop(self, source_id):
-        flag = self._stop_flags.pop(source_id, None)
-        if flag is not None:
-            flag.set()
-        proc = self._procs.pop(source_id, None)
-        self._threads.pop(source_id, None)
-        self._cbs.pop(source_id, None)
-        if proc is None:
-            return
-        try:
-            proc.terminate()
-        except (OSError, ProcessLookupError):
-            return
-        try:
-            proc.wait(timeout=1)
-        except subprocess.TimeoutExpired:
-            try:
-                proc.kill()
-                proc.wait(timeout=1)
-            except (OSError, ProcessLookupError, subprocess.TimeoutExpired):
-                pass
+        """Invalidate queued callbacks and request bounded off-thread cleanup."""
+        with self._lock:
+            state = self._meters.pop(source_id, None)
+            if state is not None:
+                state.stop.set()
 
     def stop_all(self):
-        for sid in list(self._procs.keys()):
-            self.stop(sid)
+        """Cancel all generations, including workers still spawning pw-cat."""
+        with self._lock:
+            for state in self._meters.values():
+                state.stop.set()
+            self._meters.clear()
 
-    def _reader(self, source_id, proc, stop_flag):
-        """Background thread: read s16 chunks, compute peak, marshal to UI."""
+    def wait_stopped(self, timeout=3.0):
+        """Join workers within one total deadline; do not call from GTK.
+
+        Call stop_all() first. This does not cancel currently running meters.
+        """
+        deadline = time.monotonic() + max(0.0, timeout)
+        with self._lock:
+            workers = tuple(self._workers)
+        for worker in workers:
+            if worker is threading.current_thread():
+                return False
+            worker.join(max(0.0, deadline - time.monotonic()))
+        return all(not worker.is_alive() for worker in workers)
+
+    def silent_for(self, source_id):
+        """Seconds since any bytes arrived, or None when no tap is running.
+
+        Silence (zero-valued samples) is data. A failed pw-cat does not imply a
+        stalled device, and therefore returns None rather than a growing age.
+        """
+        with self._lock:
+            state = self._meters.get(source_id)
+            if not self.running(source_id):
+                return None
+            return time.monotonic() - state.last_data
+
+    def _reader(self, source_id, node_name, capture_sink, state):
+        proc = None
         try:
-            while not stop_flag.is_set():
-                data = proc.stdout.read(self.CHUNK_BYTES)
-                if not data or len(data) < 2:
-                    break
-                n = len(data) // 2
-                samples = struct.unpack(f"<{n}h", data[: n * 2])
-                peak = max(abs(s) for s in samples) / 32768.0
-                GLib.idle_add(self._dispatch, source_id, peak)
+            if state.stop.is_set():
+                return
+            props = {
+                "node.name": f"openwave_meter_{source_id}",
+                "node.description": f"OpenWave level meter ({source_id})",
+                "application.name": "OpenWave",
+            }
+            if capture_sink:
+                props["stream.capture.sink"] = True
+            proc = subprocess.Popen(
+                ["pw-cat", "--record", "--target", node_name,
+                 "--properties", json.dumps(props),
+                 "--rate", str(self.SAMPLE_RATE), "--channels", "1",
+                 "--format", "s16", "-"],
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                bufsize=0,
+            )
+            with self._lock:
+                state.proc = proc
+                state.last_data = time.monotonic()
+            os.set_blocking(proc.stdout.fileno(), False)
+            tail = 0
+            settled = False
+            pending = b""
+            with selectors.DefaultSelector() as selector:
+                selector.register(proc.stdout, selectors.EVENT_READ)
+                while not state.stop.is_set():
+                    if not selector.select(self._POLL_SECONDS):
+                        continue
+                    try:
+                        data = os.read(proc.stdout.fileno(), self.CHUNK_BYTES)
+                    except BlockingIOError:
+                        continue
+                    if not data:
+                        break
+                    with self._lock:
+                        if self._meters.get(source_id) is not state:
+                            break
+                        state.last_data = time.monotonic()
+                    if self.ui_suspended:
+                        settled = False
+                        tail = 0
+                    data = pending + data
+                    size = len(data) & ~1
+                    pending = data[size:]
+                    if not size or self.ui_suspended:
+                        continue
+                    samples = struct.unpack(f"<{size // 2}h", data[:size])
+                    peak = max(abs(sample) for sample in samples) / 32768.0
+                    if peak >= self._QUIET:
+                        tail = self._TAIL_FRAMES
+                        settled = False
+                    elif tail:
+                        tail -= 1
+                    elif settled:
+                        continue
+                    else:
+                        peak = 0.0
+                        settled = True
+                    GLib.idle_add(self._dispatch, source_id, state, peak)
         except (OSError, ValueError):
             pass
-        # Final zero so the UI doesn't get stuck on the last value when the
-        # subprocess dies (mic unplugged, app closed, etc.)
-        GLib.idle_add(self._dispatch, source_id, 0.0)
+        finally:
+            if proc is not None:
+                self._reap(proc)
+                if proc.stdout is not None:
+                    proc.stdout.close()
+            if not state.stop.is_set() and not self.ui_suspended:
+                GLib.idle_add(self._dispatch, source_id, state, 0.0)
+            with self._lock:
+                self._workers.discard(state.thread)
 
-    def _dispatch(self, source_id, peak):
-        cb = self._cbs.get(source_id)
-        if cb is not None:
-            cb(peak)
-        return False  # one-shot idle handler
+    @classmethod
+    def _reap(cls, proc):
+        try:
+            proc.terminate()
+        except OSError:
+            pass
+        try:
+            proc.wait(timeout=cls._REAP_SECONDS)
+            return
+        except subprocess.TimeoutExpired:
+            pass
+        try:
+            proc.kill()
+        except OSError:
+            pass
+        try:
+            proc.wait(timeout=cls._REAP_SECONDS)
+        except subprocess.TimeoutExpired:
+            pass
+
+    def _dispatch(self, source_id, state, peak):
+        with self._lock:
+            if (self._meters.get(source_id) is state
+                    and not state.stop.is_set() and not self.ui_suspended):
+                state.callback(peak)
+        return False

--- a/wavexlr/meter.py
+++ b/wavexlr/meter.py
@@ -23,10 +23,15 @@ import gi
 gi.require_version("GLib", "2.0")
 from gi.repository import GLib  # noqa: E402
 
+from . import child
+
 
 @dataclass(eq=False)
 class _Meter:
     callback: object
+    node_name: str = ""
+    identity: object = None
+    received: bool = False
     stop: threading.Event = field(default_factory=threading.Event)
     proc: object = None
     thread: object = None
@@ -47,14 +52,14 @@ class MeterMonitor:
         self._workers = set()
         self._lock = threading.RLock()
 
-    def start(self, source_id, source_node_name, callback, capture_sink=False):
+    def start(self, source_id, source_node_name, callback, capture_sink=False, *, identity=None):
         """Start a source tap, or a sink-monitor tap with capture_sink=True.
 
         Spawn errors produce a final zero callback; running() stays False.
         No callback or byte timestamp from an older generation can affect the
         replacement, including callbacks already queued on the GLib main loop.
         """
-        state = _Meter(callback)
+        state = _Meter(callback, source_node_name, identity)
         state.thread = threading.Thread(
             target=self._reader,
             args=(source_id, source_node_name, capture_sink, state),
@@ -73,6 +78,19 @@ class MeterMonitor:
             state = self._meters.get(source_id)
             return bool(state and state.proc and state.proc.poll() is None
                         and not state.stop.is_set())
+
+    def active(self, source_id):
+        """Include a generation whose worker is still starting its process."""
+        with self._lock:
+            state = self._meters.get(source_id)
+            return bool(state and state.thread.is_alive() and not state.stop.is_set())
+
+    def ready(self, node_name, identity):
+        """True only after this exact capture generation has delivered bytes."""
+        with self._lock:
+            return any(state.node_name == node_name and state.identity == identity
+                       and state.received and self.running(source_id)
+                       for source_id, state in self._meters.items())
 
     def stop(self, source_id):
         """Invalidate queued callbacks and request bounded off-thread cleanup."""
@@ -123,10 +141,14 @@ class MeterMonitor:
                 "node.name": f"openwave_meter_{source_id}",
                 "node.description": f"OpenWave level meter ({source_id})",
                 "application.name": "OpenWave",
+                "media.name": f"OpenWave meter: {source_id}",
+                "node.dont-fallback": True,
+                "node.dont-reconnect": True,
+                "node.dont-move": True,
             }
             if capture_sink:
                 props["stream.capture.sink"] = True
-            proc = subprocess.Popen(
+            proc = child.spawn(
                 ["pw-cat", "--record", "--target", node_name,
                  "--properties", json.dumps(props),
                  "--rate", str(self.SAMPLE_RATE), "--channels", "1",
@@ -156,6 +178,7 @@ class MeterMonitor:
                         if self._meters.get(source_id) is not state:
                             break
                         state.last_data = time.monotonic()
+                        state.received = True
                     if self.ui_suspended:
                         settled = False
                         tail = 0

--- a/wavexlr/mixdialog.py
+++ b/wavexlr/mixdialog.py
@@ -1,0 +1,167 @@
+"""Create / rename a mix — a single-page name + icon dialog.
+
+Modelled on sourcedialog.AddSourceDialog, but one page instead of two: there
+is nothing to pick first, so Cancel has to live on this page's own header bar
+rather than on a preceding picker page.
+"""
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Gtk, Adw, GObject, Pango  # noqa: E402
+
+from . import icons
+from .mixes import DEFAULT_ICON
+
+ICON_CHOICES = (
+    ("audio-headphones-symbolic", "Headphones"),
+    ("audio-speakers-symbolic", "Speakers"),
+    ("system-users-symbolic", "Chat"),
+    ("media-record-symbolic", "Record"),
+    ("camera-video-symbolic", "Stream"),
+    ("applications-games-symbolic", "Games"),
+    ("audio-x-generic-symbolic", "Music"),
+    ("microphone-sensitivity-high-symbolic", "Mic"),
+    ("audio-card-symbolic", "Audio"),
+    ("applications-multimedia-symbolic", "Media"),
+    ("network-transmit-symbolic", "Send"),
+    ("multimedia-player-symbolic", "Player"),
+)
+
+
+class MixDialog(Adw.Dialog):
+    """Name + icon for a new or existing mix.
+
+    Deliberately does not offer the sink or the PipeWire description: those are
+    what other applications bind to, and mixes.update() refuses to change the
+    sink at all. Renaming here is a display-only change.
+    """
+
+    __gsignals__ = {
+        # (display_name, icon_name)
+        "mix-confirmed": (GObject.SignalFlags.RUN_FIRST, None, (str, str)),
+    }
+
+    def __init__(self, *, heading="Add Mix", confirm_label="Add Mix",
+                 name="", icon_name=DEFAULT_ICON):
+        super().__init__()
+        self.set_title(heading)
+        self.set_content_width(460)
+        self.set_content_height(430)
+
+        self._selected_icon = icon_name or DEFAULT_ICON
+
+        self._nav = Adw.NavigationView()
+        self.set_child(self._nav)
+        self._nav.push(self._build_page(heading, confirm_label, name))
+
+    def _build_page(self, heading, confirm_label, name):
+        page = Adw.NavigationPage(title=heading)
+
+        view = Adw.ToolbarView()
+        page.set_child(view)
+
+        header = Adw.HeaderBar()
+        view.add_top_bar(header)
+
+        # Single-page dialog: unlike sourcedialog's config page, there is no
+        # picker page behind this one to carry Cancel.
+        cancel_btn = Gtk.Button(label="Cancel")
+        cancel_btn.connect("clicked", lambda _: self.close())
+        header.pack_start(cancel_btn)
+
+        self._confirm_btn = Gtk.Button(label=confirm_label)
+        self._confirm_btn.add_css_class("suggested-action")
+        self._confirm_btn.connect("clicked", self._on_confirm)
+        header.pack_end(self._confirm_btn)
+
+        scroll = Gtk.ScrolledWindow(vexpand=True)
+        view.set_content(scroll)
+
+        clamp = Adw.Clamp(
+            maximum_size=420,
+            margin_start=12, margin_end=12, margin_top=12, margin_bottom=12,
+        )
+        scroll.set_child(clamp)
+
+        outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=16)
+        clamp.set_child(outer)
+
+        name_group = Adw.PreferencesGroup(title="Name")
+        outer.append(name_group)
+
+        self._name_row = Adw.EntryRow(title="Mix name")
+        self._name_row.set_text(name)
+        self._name_row.connect("changed", self._on_name_changed)
+        self._name_row.connect("entry-activated", self._on_confirm)
+        name_group.add(self._name_row)
+
+        hint = Gtk.Label(
+            label="The name is OpenWave's own label. The audio device other "
+                  "applications record from keeps the name it was created "
+                  "with, so renaming never breaks an OBS or Discord setup.",
+            wrap=True, xalign=0,
+        )
+        hint.set_wrap_mode(Pango.WrapMode.WORD_CHAR)
+        hint.add_css_class("dim-label")
+        hint.add_css_class("caption")
+        outer.append(hint)
+
+        icon_group = Adw.PreferencesGroup(title="Icon")
+        outer.append(icon_group)
+
+        flow = Gtk.FlowBox(
+            selection_mode=Gtk.SelectionMode.SINGLE,
+            max_children_per_line=6,
+            min_children_per_line=4,
+            column_spacing=6,
+            row_spacing=6,
+            margin_start=4, margin_end=4, margin_top=8, margin_bottom=8,
+            homogeneous=True,
+        )
+        flow.add_css_class("openwave-icon-picker")
+
+        # A stored icon outside the offered set (hand-edited mixdefs.json, or a
+        # future default) is appended rather than silently swapped on save.
+        choices = list(ICON_CHOICES)
+        if self._selected_icon not in [icon for icon, _ in choices]:
+            choices.append((self._selected_icon, "Current"))
+
+        preselect = None
+        for icon, tooltip in choices:
+            img = Gtk.Image.new_from_icon_name(icons.resolve(icon))
+            img.set_pixel_size(28)
+            child = Gtk.FlowBoxChild()
+            child.set_child(img)
+            child.set_tooltip_text(tooltip)
+            child._icon_name = icon  # noqa: SLF001
+            flow.append(child)
+            if icon == self._selected_icon:
+                preselect = child
+        flow.connect("selected-children-changed", self._on_icon_selected)
+        icon_group.add(flow)
+
+        if preselect is not None:
+            flow.select_child(preselect)
+
+        self._sync_confirm()
+        return page
+
+    def _on_name_changed(self, _row):
+        self._sync_confirm()
+
+    def _sync_confirm(self):
+        self._confirm_btn.set_sensitive(bool(self._name_row.get_text().strip()))
+
+    def _on_icon_selected(self, flow):
+        sel = flow.get_selected_children()
+        if sel:
+            self._selected_icon = getattr(sel[0], "_icon_name", self._selected_icon)
+
+    def _on_confirm(self, _widget):
+        name = self._name_row.get_text().strip()
+        if not name:
+            return
+        self.emit("mix-confirmed", name, self._selected_icon)
+        self.close()

--- a/wavexlr/mixer.py
+++ b/wavexlr/mixer.py
@@ -8,16 +8,14 @@ determine whether links and levels need repair.
 
 import atexit
 import copy
-import ctypes
 import json
 import logging
 import os
-import signal
 import subprocess
 import threading
 import uuid
 
-from . import mixes as mix_store, sources
+from . import child, mixes as mix_store, sources
 
 _log = logging.getLogger(__name__)
 CONFIG_PATH = os.path.join(os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")), "openwave", "mixes.json")
@@ -27,22 +25,24 @@ OUTPUT_AUTO = "auto"
 OUTPUT_NONE = "none"
 OUTPUTS_STATE_KEY = "outputs"
 VOLUMES_STATE_KEY = "volumes"
-try:
-    _libc = ctypes.CDLL(None, use_errno=True)
-except OSError:
-    _libc = None
-
-
-def _set_pdeathsig():
-    if _libc is not None:
-        _libc.prctl(1, int(signal.SIGTERM), 0, 0, 0)
-        if os.getppid() == 1:
-            os.kill(os.getpid(), signal.SIGTERM)
 
 
 def properties(values):
     """SPA property object; JSON quoting also escapes untrusted display labels."""
     return "{ " + " ".join(f"{key} = {json.dumps(value, ensure_ascii=True, allow_nan=False)}" for key, value in values.items()) + " }"
+
+def pulse_properties(values):
+    """Quote both Pulse argument layers; its parser is not a JSON decoder."""
+    def quote(text):
+        if "\0" in text:
+            raise ValueError("Audio properties cannot contain NUL")
+        return '"' + text.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+    pairs = []
+    for key, value in values.items():
+        text = value if isinstance(value, str) else json.dumps(value, allow_nan=False)
+        pairs.append(f"{key}={quote(text)}")
+    return quote(" ".join(pairs))
 
 
 
@@ -125,6 +125,8 @@ class SubprocessPipeWire:
             objects = json.loads(self.run(["pw-dump"]))
             pulse = {kind: json.loads(self.run(["pactl", "--format=json", "list", kind]))
                      for kind in ("sinks", "sources", "sink-inputs", "modules")}
+            devices = {str(obj["id"]): (obj.get("info") or {}).get("props", {})
+                       for obj in objects if obj.get("type") == "PipeWire:Interface:Device"}
             if not isinstance(objects, list) or any(not isinstance(items, list) for items in pulse.values()):
                 raise ValueError("Expected graph arrays")
             generation = next(((obj.get("info") or {}).get("cookie") for obj in objects
@@ -170,7 +172,15 @@ class SubprocessPipeWire:
                         "app_name": props.get("application.name") or name, "node_name": name,
                         "media_name": props.get("media.name", ""), "binary": props.get("application.process.binary", "")}
                 if media_class == "Audio/Source" and not name.startswith("openwave_") and not name.endswith(".monitor"):
-                    captures.append({"name": name, "description": props.get("node.description", name), "priority": int(props.get("priority.session", 0))})
+                    device = devices.get(str(props.get("device.id")), {})
+                    captures.append({
+                        "name": name, "description": props.get("node.description", name),
+                        "priority": int(props.get("priority.session", 0)),
+                        "identity": (generation, node["serial"]),
+                        "channels": int(props.get("audio.channels", 2)),
+                        "alsa_card": props.get("api.alsa.pcm.card", device.get("api.alsa.card")),
+                        "serial": props.get("device.serial", device.get("device.serial")),
+                    })
             mutes = {item["name"]: bool(item.get("mute")) for item in pulse["sources"]}
             return {"nodes": nodes, "ports": ports, "links": links, "sinks": sinks, "streams": streams,
                     "captures": captures, "capture_mutes": mutes, "modules": pulse["modules"], "default": default,
@@ -197,8 +207,8 @@ class SubprocessPipeWire:
 
     def create_sink(self, name, description):
         token = uuid.uuid4().hex
-        props = properties({"node.description": description, "media.name": name, "openwave.owner": token,
-                            "priority.session": 0, "monitor.channel-volumes": True, "state.restore-props": False})
+        props = pulse_properties({"node.description": description, "media.name": name, "openwave.owner": token,
+                                  "priority.session": 0, "monitor.channel-volumes": True, "state.restore-props": False})
         try:
             module_id = int(self.run(["pactl", "load-module", "module-null-sink", "sink_name=" + name,
                                       "channels=2", "channel_map=front-left,front-right", "sink_properties=" + props]).strip())
@@ -208,7 +218,9 @@ class SubprocessPipeWire:
 
     def destroy_sink(self, handle, graph):
         module_id, token = handle
-        owned = any(str(module.get("index")) == str(module_id) and token in str(module.get("argument", "")) for module in graph["modules"])
+        owned = any(str(node["props"].get("pulse.module.id")) == str(module_id)
+                    and node["props"].get("openwave.owner") == token
+                    for node in graph["nodes"].values())
         return not owned or self.command(["pactl", "unload-module", str(module_id)])
 
     def remove_mix_sink(self, name, graph):
@@ -227,9 +239,9 @@ class SubprocessPipeWire:
             playback.update({"media.class": "Audio/Source", "node.virtual": True,
                              "node.description": description or name})
         try:
-            return subprocess.Popen(["pw-loopback", "--capture-props=" + properties(capture),
-                                     "--playback-props=" + properties(playback)], stdout=subprocess.DEVNULL,
-                                    stderr=subprocess.DEVNULL, preexec_fn=_set_pdeathsig)
+            return child.spawn(["pw-loopback", "--capture-props=" + properties(capture),
+                                "--playback-props=" + properties(playback)], stdout=subprocess.DEVNULL,
+                               stderr=subprocess.DEVNULL)
         except OSError:
             return None
 
@@ -241,8 +253,9 @@ class Mixer:
     levels are retried every poll; no success is inferred from a living child.
     """
 
-    def __init__(self, pw=None, *, config_path=None, mixes_config_path=None, poll_interval=1.0):
+    def __init__(self, pw=None, *, config_path=None, mixes_config_path=None, poll_interval=1.0, capture_ready=None):
         self._pw = pw or SubprocessPipeWire()
+        self._capture_ready = capture_ready
         self._path = config_path or CONFIG_PATH
         self._mixes_config_path = mixes_config_path
         self._lock = threading.RLock()
@@ -296,7 +309,6 @@ class Mixer:
         self._owned_sinks = {}
         self._moved = {}
         self.mic = self.hp = None
-        self._reported_streams = set()
         atexit.register(self.stop)
 
     def _persist(self):
@@ -464,13 +476,6 @@ class Mixer:
     def request_volume_sync(self):
         self._wake.set()
 
-    def poll_streams(self):
-        """Compatibility for current UI; deltas concern cached observations only."""
-        self.request_stream_poll()
-        current = set(self.streams())
-        added, removed = current - self._reported_streams, self._reported_streams - current
-        self._reported_streams = current
-        return added, removed
 
     def start(self):
         with self._lock:
@@ -534,7 +539,7 @@ class Mixer:
             return False
         handle = self._owned_sinks.get(name)
         if handle is not None:
-            if any(str(module.get("index")) == str(handle[0]) and handle[1] in str(module.get("argument", "")) for module in graph["modules"]):
+            if any(handle[1] in str(module.get("argument", "")) for module in graph["modules"]):
                 return False
             del self._owned_sinks[name]
         handle = self._pw.create_sink(name, description)
@@ -600,8 +605,11 @@ class Mixer:
                 self._drop_route(key)
             return False
         route["missing"] = 0
-        if not self._pw.set_level(node["id"], volume, muted):
-            return False
+        applied = (graph.get("generation"), node.get("serial", node["id"]), volume, muted)
+        if route.get("applied") != applied:
+            if not self._pw.set_level(node["id"], volume, muted):
+                return False
+            route["applied"] = applied
         # Establish gain before audio can enter a newly created stream.
         playback_ok = publish or self._link_nodes(graph, name, target)
         capture_ok = self._link_nodes(graph, source, name + "_cap") if playback_ok else False
@@ -675,14 +683,26 @@ class Mixer:
             setup.install_mixes(mixes, path=self._mixes_config_path)
             self._definitions_written = definitions_revision
         self._sync_capture_mutes(graph)
-        # Until the UI owns its mic row, retain the established built-in id.
-        if "mic" not in records and self.mic:
-            records["mic"] = {"id": "mic", "kind": "device", "node_name": self.mic, "name": "Microphone", "level": 1.0}
         wanted_sinks = {mix["sink"] for mix in mixes.values()}
         ready = {mid for mid, mix in mixes.items() if self._ensure_sink(mix["sink"], mix["description"], graph)}
         ready &= self._sync_masters(graph, mixes)
         claims = claim_streams(records, graph["streams"])
         desired = set()
+        # Silence departing/muted sends before any group hand-over opens another.
+        for key, route in list(self._procs.items()):
+            if key[0] != "cell":
+                continue
+            _, sid, mid = key
+            source = records.get(sid)
+            cell = state.get(f"{sid}.{mid}", {})
+            if source is None or mid not in mixes or cell.get("volume", 0.0) <= 0:
+                self._drop_route(key)
+                continue
+            if source.get("muted") or cell.get("muted"):
+                self._route(key, route["spec"][0], route["spec"][1], route["name"],
+                            cell["volume"] * source.get("level", 1.0), True, graph)
+                if route["name"] in graph["nodes"] and not route.get("applied", (False,))[-1]:
+                    raise GraphError("Cannot silence the previous source; group hand-over deferred")
         wanted_moves = {}
         for sid, source in records.items():
             if sources.kind(source) == sources.KIND_APP:
@@ -698,7 +718,7 @@ class Mixer:
                         if self._pw.move_stream(stream, capture):
                             self._moved.setdefault(stream["serial"], stream["sink"])
             else:
-                capture = source.get("node_name") or (self.mic if sid == "mic" else None)
+                capture = source.get("node_name")
                 if capture not in {item["name"] for item in graph["captures"]}:
                     continue
             for mid in ready:
@@ -718,6 +738,12 @@ class Mixer:
             self._route(key, mix["sink"], None, mix_capture_name(mid), 1.0, False, graph,
                         publish=True, description=mix["description"])
             output = self.resolve_output(mid)
+            if output and self._capture_ready is not None and _is_wave_card(output):
+                stem = output.removeprefix("alsa_output.").rsplit(".", 1)[0]
+                captures = [item for item in graph["captures"]
+                            if item["name"].removeprefix("alsa_input.").rsplit(".", 1)[0] == stem]
+                if not captures or not all(self._capture_ready(item) for item in captures):
+                    output = None
             if output:
                 key = ("output", mid)
                 desired.add(key)

--- a/wavexlr/mixer.py
+++ b/wavexlr/mixer.py
@@ -359,7 +359,10 @@ class Mixer:
 
     def set_capture_mute(self, node_name, muted):
         with self._lock:
-            self._capture_requests[node_name] = bool(muted)
+            binding = self._capture_binding(node_name)
+            if binding is None:
+                return
+            self._capture_requests[node_name] = (binding, bool(muted))
         self._wake.set()
 
     def capture_device_present(self, node_name):
@@ -449,6 +452,7 @@ class Mixer:
         normalized = sources.normalize(records)
         with self._lock:
             self._sources = normalized
+            self._prune_capture_requests()
         self._wake.set()
 
     def set_source_level(self, source_id, volume, muted):
@@ -463,6 +467,7 @@ class Mixer:
             if sources.is_protected(self._sources.get(source_id, {})):
                 raise ValueError("Protected source cannot be removed")
             self._sources.pop(source_id, None)
+            self._prune_capture_requests()
             self._state = {key: value for key, value in self._state.items() if not key.startswith(source_id + ".")}
         self._persist()
         self._wake.set()
@@ -669,14 +674,29 @@ class Mixer:
             self._persist()
         return ready
 
+    def _capture_binding(self, name):
+        owners = frozenset(sid for sid, source in self._sources.items()
+                           if sources.kind(source) == sources.KIND_DEVICE and source.get("node_name") == name)
+        return owners or None
+
+    def _prune_capture_requests(self):
+        for name, (binding, _) in list(self._capture_requests.items()):
+            if self._capture_binding(name) != binding:
+                del self._capture_requests[name]
+
     def _sync_capture_mutes(self, graph):
         with self._lock:
+            self._prune_capture_requests()
             pending = dict(self._capture_requests)
         live = {item["name"] for item in graph["captures"]}
-        for name, muted in pending.items():
+        for name, request in pending.items():
+            binding, muted = request
+            with self._lock:
+                if self._capture_requests.get(name) != request or self._capture_binding(name) != binding:
+                    continue
             if name in live and self._pw.set_capture_mute(name, muted):
                 with self._lock:
-                    if self._capture_requests.get(name) == muted:
+                    if self._capture_requests.get(name) == request:
                         del self._capture_requests[name]
 
     def _reconcile(self, graph):

--- a/wavexlr/mixmatrix.py
+++ b/wavexlr/mixmatrix.py
@@ -1,15 +1,56 @@
-"""Mix matrix widget — two-axis sources × mixes grid.
+"""Dynamic sources × mixes GTK4 matrix.
 
-Pure GTK4/libadwaita. No external deps. Phase 1 is structural: the mic source
-is wired to real device state via the parent app; other sources and per-cell
-mix routing are placeholders until PipeWire mix-sink backend lands (v0.3.0).
+MixMatrix emits source/mix CRUD, reorder/group and output/master requests.
+SourceCell emits volume-changed(float), mute-toggled(bool), edit-clicked(),
+remove-clicked(), move-clicked(int), switch-clicked(), fx-changed() and
+fx-autotune(). Read fx_settings() after fx-changed; fx-autotune requests the
+parent's calibration workflow. MixCell emits volume-changed(float) and
+mute-toggled(bool). MixHeaderCell emits output-changed(str),
+volume-changed(float), rename-clicked() and remove-clicked().
+
+Programmatic setters do not emit requests. The parent owns routing/persistence,
+connects source/cell signals, and restores state after reorder_sources() rebuilds
+the rows. All signal callbacks receive the emitting widget first.
 """
+
 
 import gi
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
-from gi.repository import Gtk, Adw, GObject  # noqa: E402
+from gi.repository import Gtk, Adw, GObject, Gdk, GLib, Pango  # noqa: E402
+
+from . import icons
+
+
+def _emit_later(obj, signal, *args):
+    """Emit `signal` once the current GTK frame has unwound.
+
+    For signals whose handlers dismantle the very thing that is emitting —
+    a popover being popped down, a row about to be destroyed by the reorder
+    its own drop handler asks for. GTK is still inside the controller or the
+    popup teardown at that moment, and pulling the widget out from under it
+    is a use-after-free on a good day and an xdg_popup protocol error (which
+    kills the client outright) on Wayland.
+    """
+    def _fire():
+        obj.emit(signal, *args)
+        return GLib.SOURCE_REMOVE
+
+    GLib.idle_add(_fire)
+
+
+def _percent_label():
+    """A fixed-width percentage readout for a 0..1 slider.
+
+    Monospace and width-limited so the row does not reflow as the number
+    changes width between 0% and 100%.
+    """
+    lbl = Gtk.Label(label="0%", xalign=1, width_chars=4)
+    lbl.add_css_class("dim-label")
+    lbl.add_css_class("caption")
+    lbl.add_css_class("monospace")
+    return lbl
 
 
 class MixMatrix(Gtk.Box):
@@ -18,7 +59,24 @@ class MixMatrix(Gtk.Box):
     __gsignals__ = {
         "add-source-clicked": (GObject.SignalFlags.RUN_FIRST, None, ()),
         "remove-source-clicked": (GObject.SignalFlags.RUN_FIRST, None, (str,)),
+        "edit-source-clicked": (GObject.SignalFlags.RUN_FIRST, None, (str,)),
+        # (source_id, delta) -- -1 to move a row up, +1 to move it down
+        "move-source-clicked": (GObject.SignalFlags.RUN_FIRST, None, (str, int)),
+        # Make this source the live one in its group
+        "switch-source-clicked": (GObject.SignalFlags.RUN_FIRST, None, (str,)),
+        # (dragged_id, target_id) -- put the first in the second's group
+        "group-sources-clicked": (GObject.SignalFlags.RUN_FIRST, None, (str, str)),
+        "add-mix-clicked": (GObject.SignalFlags.RUN_FIRST, None, ()),
+        "rename-mix-clicked": (GObject.SignalFlags.RUN_FIRST, None, (str,)),
+        "remove-mix-clicked": (GObject.SignalFlags.RUN_FIRST, None, (str,)),
+        # (mix_id, output name — a sink node.name, OUTPUT_AUTO or OUTPUT_NONE)
+        "mix-output-changed": (GObject.SignalFlags.RUN_FIRST, None, (str, str)),
+        "mix-volume-changed": (GObject.SignalFlags.RUN_FIRST, None, (str, float)),
     }
+
+    # Shown instead of deleting the only mix. The matrix's whole geometry is
+    # sources × mixes; with no column left there is nothing to route into.
+    LAST_MIX_REASON = "OpenWave needs at least one mix."
 
     def __init__(self):
         super().__init__(orientation=Gtk.Orientation.VERTICAL)
@@ -37,54 +95,183 @@ class MixMatrix(Gtk.Box):
             margin_start=12,
             margin_end=12,
             margin_top=12,
-            margin_bottom=0,
+            # Matches the other three sides: at zero the last source row sat
+            # flush against the window edge and read as clipped.
+            margin_bottom=12,
         )
         wrapper.append(self._grid)
 
         self._mix_ids = []
         self._source_ids = []
+        # How each row was built, so reorder_sources can rebuild it verbatim.
+        self._source_specs = {}
         self._sources = {}
+        self._headers = {}
         self._cells = {}
 
         corner = Gtk.Box()
-        corner.set_size_request(260, 64)
+        # Reserve room for the row's identity and controls.
+        corner.set_size_request(400, 64)
         self._grid.attach(corner, 0, 0, 1, 1)
 
-        # "+ Add Source" trailing affordance, lives below the grid
+        # "+ Add Source" / "+ Add Mix" sit above the grid, at the top left,
+        # rather than trailing below it: below, they moved down the window as
+        # rows were added and ended up off-screen on a full matrix. Neither is
+        # a grid column, so adding or removing one never renumbers them.
         add_row = Gtk.Box(
             orientation=Gtk.Orientation.HORIZONTAL,
-            margin_start=12, margin_end=12, margin_bottom=12,
+            spacing=6,
+            halign=Gtk.Align.START,
+            margin_start=12, margin_end=12, margin_top=12, margin_bottom=2,
         )
-        wrapper.append(add_row)
+        wrapper.prepend(add_row)
         self._add_btn = Gtk.Button(
             label="+ Add Source",
             halign=Gtk.Align.START,
         )
         self._add_btn.add_css_class("openwave-add-source")
-        self._add_btn.set_size_request(260, -1)
         self._add_btn.connect("clicked", lambda _: self.emit("add-source-clicked"))
         add_row.append(self._add_btn)
 
+        self._add_mix_btn = Gtk.Button(
+            label="+ Add Mix",
+            halign=Gtk.Align.START,
+        )
+        self._add_mix_btn.add_css_class("openwave-add-mix")
+        self._add_mix_btn.connect("clicked", lambda _: self.emit("add-mix-clicked"))
+        add_row.append(self._add_mix_btn)
+
     def add_mix(self, mix_id, *, title, subtitle, icon_name):
+        if mix_id in self._mix_ids:
+            return self._headers[mix_id]
         col = len(self._mix_ids) + 1
         header = MixHeaderCell(title=title, subtitle=subtitle, icon_name=icon_name)
+        header.connect(
+            "output-changed",
+            lambda _h, name, mid=mix_id: self.emit("mix-output-changed", mid, name),
+        )
+        header.connect(
+            "volume-changed",
+            lambda _h, value, mid=mix_id: self.emit("mix-volume-changed", mid, value),
+        )
+        header.connect(
+            "rename-clicked", lambda _h, mid=mix_id: self.emit("rename-mix-clicked", mid),
+        )
+        header.connect(
+            "remove-clicked", lambda _h, mid=mix_id: self.emit("remove-mix-clicked", mid),
+        )
         self._grid.attach(header, col, 0, 1, 1)
         self._mix_ids.append(mix_id)
+        self._headers[mix_id] = header
 
-    def add_source(self, source_id, *, name, icon_name, has_level=False, removable=False):
+        # A mix added after the rows exist still needs a cell in every row.
+        for row_idx, source_id in enumerate(self._source_ids):
+            cell = MixCell()
+            self._grid.attach(cell, col, row_idx + 1, 1, 1)
+            self._cells[(source_id, mix_id)] = cell
+
+        self._sync_delete_sensitivity()
+        return header
+
+    def remove_mix(self, mix_id):
+        if mix_id not in self._mix_ids:
+            return
+        idx = self._mix_ids.index(mix_id)
+        # Column mirror of remove_source's remove_row: Gtk.Grid shifts every
+        # column to the right of this one left by one, so the list index of the
+        # remaining mixes stays exactly their grid column minus one.
+        self._grid.remove_column(idx + 1)
+        self._mix_ids.pop(idx)
+        self._headers.pop(mix_id, None)
+        for source_id in self._source_ids:
+            self._cells.pop((source_id, mix_id), None)
+        self._sync_delete_sensitivity()
+
+    def _sync_delete_sensitivity(self):
+        """Grey out Delete on every header while only one mix is left."""
+        enabled = len(self._mix_ids) > 1
+        for header in self._headers.values():
+            header.set_delete_enabled(enabled, self.LAST_MIX_REASON)
+
+    def set_mix_volume(self, mix_id, value):
+        header = self._headers.get(mix_id)
+        if header is not None:
+            header.set_volume(value)
+
+    def set_mix_level(self, mix_id, value):
+        header = self._headers.get(mix_id)
+        if header is not None:
+            header.set_level(value)
+
+    def set_mix_empty(self, mix_id, empty):
+        header = self._headers.get(mix_id)
+        if header is not None:
+            header.set_empty(empty)
+
+    def set_mix(self, mix_id, *, title=None, subtitle=None, icon_name=None):
+        """Live-update a header's identity after a rename."""
+        header = self._headers.get(mix_id)
+        if header is None:
+            return
+        if title is not None:
+            header.set_title(title)
+        if subtitle is not None:
+            header.set_subtitle(subtitle)
+        if icon_name is not None:
+            header.set_icon(icon_name)
+
+    def set_mix_outputs(self, mix_id, entries, current, summary, monitored=True):
+        """Refresh one header's output chooser and the routing it displays.
+
+        `entries` is [(output name, label), ...] in menu order; `current` is
+        the persisted choice; `summary` is the short text shown on the header.
+        """
+        header = self._headers.get(mix_id)
+        if header is not None:
+            header.set_outputs(entries, current, summary, monitored)
+
+    def add_source(self, source_id, *, name, icon_name, has_level=False,
+                   removable=False, editable=False, reorderable=False,
+                   is_capture=False):
         row = len(self._source_ids) + 1
         source = SourceCell(
-            name=name, icon_name=icon_name,
-            has_level=has_level, removable=removable,
+            name=name, icon_name=icon_name, has_level=has_level,
+            removable=removable, editable=editable, reorderable=reorderable,
+            is_capture=is_capture,
         )
+        if editable:
+            source.connect(
+                "edit-clicked",
+                lambda _s, sid=source_id: self.emit("edit-source-clicked", sid),
+            )
         if removable:
             source.connect(
                 "remove-clicked",
                 lambda _s, sid=source_id: self.emit("remove-source-clicked", sid),
             )
+        if reorderable:
+            self._make_row_draggable(source, source_id)
+        source.connect(
+            "switch-clicked",
+            lambda _s, sid=source_id: self.emit("switch-source-clicked", sid),
+        )
+        source.connect(
+            "move-clicked",
+            # Deferred for the same reason as the drop path: the reorder this
+            # asks for destroys the row holding the button that was clicked,
+            # while GTK is still inside that button's own emission.
+            lambda _s, delta, sid=source_id: _emit_later(
+                self, "move-source-clicked", sid, delta),
+        )
         self._grid.attach(source, 0, row, 1, 1)
         self._sources[source_id] = source
         self._source_ids.append(source_id)
+        # Remembered so reorder_sources can rebuild a row exactly as it was.
+        self._source_specs[source_id] = dict(
+            name=name, icon_name=icon_name, has_level=has_level,
+            removable=removable, editable=editable, reorderable=reorderable,
+            is_capture=is_capture,
+        )
 
         for col_idx, mix_id in enumerate(self._mix_ids):
             cell = MixCell()
@@ -93,6 +280,133 @@ class MixMatrix(Gtk.Box):
 
         return source
 
+    def _make_row_draggable(self, cell, source_id):
+        """Let a row be dragged onto another to take its place.
+
+        The drop is expressed as a delta and pushed through the same
+        move-source-clicked path the buttons used, so ordering, clamping and
+        persistence stay in one place.
+        """
+        drag = Gtk.DragSource(actions=Gdk.DragAction.MOVE)
+        drag.connect(
+            "prepare",
+            lambda _d, _x, _y, sid=source_id: Gdk.ContentProvider.new_for_value(sid),
+        )
+
+        def _begin(_source, drag_obj, widget=cell):
+            # Drag the row's own likeness, so it is obvious what is moving.
+            icon = Gtk.DragIcon.get_for_drag(drag_obj)
+            paintable = Gtk.WidgetPaintable.new(widget)
+            picture = Gtk.Picture.new_for_paintable(paintable)
+            # A row remapped but not yet allocated (a workspace switch, a
+            # window just unhidden) measures 0x0, and a 0x0 drag icon is an
+            # invisible drag. Same fallback the drop-zone maths uses.
+            picture.set_size_request(widget.get_width() or 320,
+                                     widget.get_height() or 64)
+            icon.set_child(picture)
+            widget.set_opacity(0.35)
+
+        drag.connect("drag-begin", _begin)
+        drag.connect("drag-end", lambda _s, _d, _r, w=cell: w.set_opacity(1.0))
+        drag.connect("drag-cancel",
+                     lambda _s, _d, _r, w=cell: (w.set_opacity(1.0), False)[1])
+        cell.add_controller(drag)
+
+        drop = Gtk.DropTarget.new(GObject.TYPE_STRING, Gdk.DragAction.MOVE)
+        drop.connect("drop", self._on_row_drop, source_id)
+        drop.connect("motion", self._on_row_motion, source_id)
+        drop.connect("leave", lambda _t, w=cell: self._clear_drop_hint(w))
+        cell.add_controller(drop)
+
+    # Fraction of a row's height at each end that means "move here" rather
+    # than "group with this". The middle is the larger target because grouping
+    # is the deliberate act; reordering is the one you can repeat cheaply.
+    _EDGE_ZONE = 0.28
+
+    def _drop_is_grouping(self, cell, y):
+        height = cell.get_height() or 64
+        return self._EDGE_ZONE * height <= y <= (1 - self._EDGE_ZONE) * height
+
+    def _on_row_motion(self, target, _x, y, target_id):
+        """Show which of the two outcomes a release would produce."""
+        cell = self._sources.get(target_id)
+        if cell is None:
+            return Gdk.DragAction.MOVE
+        grouping = self._drop_is_grouping(cell, y)
+        cell.remove_css_class("openwave-drop-target")
+        cell.remove_css_class("openwave-drop-group")
+        cell.add_css_class(
+            "openwave-drop-group" if grouping else "openwave-drop-target")
+        return Gdk.DragAction.MOVE
+
+    def _clear_drop_hint(self, cell):
+        if cell is not None:
+            cell.remove_css_class("openwave-drop-target")
+            cell.remove_css_class("openwave-drop-group")
+
+    def _on_row_drop(self, _target, value, _x, y, target_id):
+        dragged = str(value)
+        cell = self._sources.get(target_id)
+        self._clear_drop_hint(cell)
+        if dragged == target_id or dragged not in self._source_ids:
+            return False
+        # Both outcomes end in reorder_sources, which destroys every row —
+        # including this one, whose GtkDropTarget GTK is still emitting from
+        # and whose likeness the live GtkDragIcon is still painting. Deferred
+        # so the drop finishes against widgets that still exist.
+        if cell is not None and self._drop_is_grouping(cell, y):
+            _emit_later(self, "group-sources-clicked", dragged, target_id)
+            return True
+        delta = self._source_ids.index(target_id) - self._source_ids.index(dragged)
+        _emit_later(self, "move-source-clicked", dragged, delta)
+        return True
+
+    def set_source_group(self, source_id, group):
+        cell = self._sources.get(source_id)
+        if cell is not None and hasattr(cell, "set_group"):
+            cell.set_group(group)
+
+    def set_source(self, source_id, *, name=None, icon_name=None):
+        """Update a row's label, and the spec a rebuild restores it from.
+
+        Setting it on the widget alone is not enough: reorder_sources tears
+        every row down and rebuilds it from _source_specs, so a name applied
+        only to the cell is silently reverted by the next drag.
+        """
+        cell = self._sources.get(source_id)
+        spec = self._source_specs.get(source_id)
+        if name is not None:
+            if cell is not None:
+                cell.set_name(name)
+            if spec is not None:
+                spec["name"] = name
+        if icon_name is not None:
+            if cell is not None:
+                cell.set_icon(icon_name)
+            if spec is not None:
+                spec["icon_name"] = icon_name
+
+    def reorder_sources(self, order):
+        """Redraw the source rows in `order`.
+
+        Gtk.Grid has no row-move, so the rows are torn down and rebuilt. Every
+        MixCell is recreated, so the caller must re-wire the cells afterwards --
+        their widgets are new objects and carry no state.
+        """
+        # Rows omitted by the caller remain pinned ahead of the supplied order.
+        pinned = [sid for sid in self._source_ids if sid not in order]
+        specs = [(sid, self._source_specs[sid])
+                 for sid in pinned + [s for s in order if s not in pinned]
+                 if sid in self._source_specs]
+        for _ in range(len(self._source_ids)):
+            self._grid.remove_row(1)     # row 0 is the header; rows shift up
+        self._source_ids = []
+        self._sources = {}
+        self._cells = {}
+        self._source_specs = {}
+        for sid, spec in specs:
+            self.add_source(sid, **spec)
+
     def remove_source(self, source_id):
         if source_id not in self._source_ids:
             return
@@ -100,6 +414,7 @@ class MixMatrix(Gtk.Box):
         self._grid.remove_row(idx + 1)
         self._source_ids.pop(idx)
         self._sources.pop(source_id, None)
+        self._source_specs.pop(source_id, None)
         for mix_id in self._mix_ids:
             self._cells.pop((source_id, mix_id), None)
 
@@ -111,7 +426,19 @@ class MixMatrix(Gtk.Box):
 
 
 class MixHeaderCell(Gtk.Box):
-    """Column header at the top of each mix."""
+    """Column header at the top of each mix: identity, routing, and its menu.
+
+    The menu is a Gtk.Popover of ordinary widgets rather than a Gio.Menu: the
+    output list changes with the hardware and differs per mix, and a Gio.Menu
+    would mean installing and tearing down a set of Gio actions per column.
+    """
+
+    __gsignals__ = {
+        "output-changed": (GObject.SignalFlags.RUN_FIRST, None, (str,)),
+        "volume-changed": (GObject.SignalFlags.RUN_FIRST, None, (float,)),
+        "rename-clicked": (GObject.SignalFlags.RUN_FIRST, None, ()),
+        "remove-clicked": (GObject.SignalFlags.RUN_FIRST, None, ()),
+    }
 
     def __init__(self, *, title, subtitle, icon_name):
         super().__init__(
@@ -120,36 +447,333 @@ class MixHeaderCell(Gtk.Box):
         )
         self.add_css_class("openwave-mix-header")
         self.add_css_class("card")
-        self.set_size_request(220, 64)
+        # Taller than the 64px data cells because a third line — the live
+        # output — is worth seeing without opening the menu. Only row 0 grows;
+        # the corner box beside it simply stretches to match.
+        self.set_size_request(220, 78)
+
+        self._updating = False
+        self._current_output = None
 
         inner = Gtk.Box(
             orientation=Gtk.Orientation.HORIZONTAL,
             spacing=10,
             margin_start=14,
-            margin_end=14,
-            margin_top=10,
-            margin_bottom=10,
+            margin_end=6,
+            margin_top=8,
+            margin_bottom=8,
             hexpand=True,
         )
         self.append(inner)
 
-        icon = Gtk.Image.new_from_icon_name(icon_name)
-        icon.set_pixel_size(22)
-        inner.append(icon)
+        self._icon = Gtk.Image.new_from_icon_name(icons.resolve(icon_name))
+        self._icon.set_pixel_size(22)
+        inner.append(self._icon)
 
         text = Gtk.Box(
-            orientation=Gtk.Orientation.VERTICAL, spacing=2, hexpand=True, valign=Gtk.Align.CENTER
+            orientation=Gtk.Orientation.VERTICAL, spacing=1, hexpand=True,
+            valign=Gtk.Align.CENTER,
         )
         inner.append(text)
 
-        title_lbl = Gtk.Label(label=title, xalign=0)
-        title_lbl.add_css_class("heading")
-        text.append(title_lbl)
+        # max_width_chars is what actually caps the label: an ellipsizing GTK
+        # label still requests its full natural width without it, and
+        # set_size_request(220, …) is a minimum, so a long user-typed name
+        # would otherwise stretch the whole column. width_chars pins the
+        # natural width to the same value so every column comes out identical
+        # regardless of how long or short its name happens to be.
+        self._title_lbl = Gtk.Label(label=title, xalign=0)
+        self._title_lbl.set_ellipsize(Pango.EllipsizeMode.END)
+        self._title_lbl.set_width_chars(14)
+        self._title_lbl.set_max_width_chars(14)
+        self._title_lbl.add_css_class("heading")
+        self._title_lbl.set_tooltip_text(title)
+        text.append(self._title_lbl)
 
-        subtitle_lbl = Gtk.Label(label=subtitle, xalign=0)
-        subtitle_lbl.add_css_class("dim-label")
-        subtitle_lbl.add_css_class("caption")
-        text.append(subtitle_lbl)
+        self._subtitle_lbl = Gtk.Label(label=subtitle, xalign=0)
+        self._subtitle_lbl.set_ellipsize(Pango.EllipsizeMode.END)
+        self._subtitle_lbl.set_width_chars(16)
+        self._subtitle_lbl.set_max_width_chars(16)
+        self._subtitle_lbl.add_css_class("dim-label")
+        self._subtitle_lbl.add_css_class("caption")
+        self._subtitle_lbl.set_visible(bool(subtitle))
+        text.append(self._subtitle_lbl)
+
+        # Hidden until the app has resolved the routing, so the header never
+        # shows a placeholder that reads like a real device.
+        self._out_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4)
+        self._out_box.set_visible(False)
+        text.append(self._out_box)
+
+        self._out_icon = Gtk.Image.new_from_icon_name("audio-speakers-symbolic")
+        self._out_icon.set_pixel_size(12)
+        self._out_icon.add_css_class("dim-label")
+        self._out_box.append(self._out_icon)
+
+        self._out_lbl = Gtk.Label(label="", xalign=0, hexpand=True)
+        self._out_lbl.set_ellipsize(Pango.EllipsizeMode.END)
+        self._out_lbl.set_width_chars(16)
+        self._out_lbl.set_max_width_chars(16)
+        self._out_lbl.add_css_class("dim-label")
+        self._out_lbl.add_css_class("caption")
+        self._out_box.append(self._out_lbl)
+
+        # Master volume + live level. The master is a plain PipeWire sink
+        # volume anything may move (pavucontrol, a media key, a scene), so
+        # the slider is set from observation as much as it drives — writes
+        # go out through volume-changed, external moves come back through
+        # set_volume with the handler blocked.
+        vol_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        text.append(vol_row)
+        self._vol_scale = Gtk.Scale(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            draw_value=False,
+            adjustment=Gtk.Adjustment(
+                lower=0.0, upper=1.0, step_increment=0.01, page_increment=0.05
+            ),
+            hexpand=True,
+            valign=Gtk.Align.CENTER,
+            round_digits=2,
+        )
+        self._vol_scale.add_css_class("openwave-mix-slider")
+        self._vol_scale.set_tooltip_text("Mix master volume")
+        self._vol_handler = self._vol_scale.connect(
+            "value-changed", self._on_volume_changed)
+        vol_row.append(self._vol_scale)
+        self._vol_pct = Gtk.Label(label="", xalign=1)
+        self._vol_pct.add_css_class("dim-label")
+        self._vol_pct.add_css_class("caption")
+        self._vol_pct.set_width_chars(4)
+        vol_row.append(self._vol_pct)
+
+        self._level = Gtk.LevelBar(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            mode=Gtk.LevelBarMode.CONTINUOUS,
+            min_value=0.0,
+            max_value=1.0,
+            valign=Gtk.Align.CENTER,
+        )
+        self._level.set_size_request(-1, 6)
+        self._level.add_css_class("openwave-level")
+        self._level.add_offset_value(Gtk.LEVEL_BAR_OFFSET_LOW, 0.70)
+        self._level.add_offset_value(Gtk.LEVEL_BAR_OFFSET_HIGH, 0.90)
+        self._level.add_offset_value(Gtk.LEVEL_BAR_OFFSET_FULL, 1.00)
+        text.append(self._level)
+
+        self._menu_btn = Gtk.MenuButton(
+            icon_name="view-more-symbolic",
+            valign=Gtk.Align.CENTER,
+            tooltip_text="Output, rename, delete",
+        )
+        self._menu_btn.add_css_class("flat")
+        self._menu_btn.add_css_class("circular")
+        self._menu_btn.set_popover(self._build_popover())
+        inner.append(self._menu_btn)
+
+    # ----- popover -----
+    @staticmethod
+    def _menu_row_button(icon_name, label, label_css=None):
+        btn = Gtk.Button(hexpand=True)
+        btn.add_css_class("flat")
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        row.append(Gtk.Image.new_from_icon_name(icons.resolve(icon_name)))
+        lbl = Gtk.Label(label=label, xalign=0, hexpand=True)
+        if label_css:
+            lbl.add_css_class(label_css)
+        row.append(lbl)
+        btn.set_child(row)
+        return btn
+
+    def _build_popover(self):
+        pop = Gtk.Popover()
+        box = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL, spacing=8,
+            margin_start=8, margin_end=8, margin_top=8, margin_bottom=8,
+        )
+        box.set_size_request(272, -1)
+        pop.set_child(box)
+
+        heading = Gtk.Label(label="Output", xalign=0)
+        heading.add_css_class("heading")
+        box.append(heading)
+
+        scroll = Gtk.ScrolledWindow(
+            hscrollbar_policy=Gtk.PolicyType.NEVER,
+            vscrollbar_policy=Gtk.PolicyType.AUTOMATIC,
+            propagate_natural_height=True,
+            max_content_height=260,
+        )
+        box.append(scroll)
+
+        self._out_list = Gtk.ListBox(selection_mode=Gtk.SelectionMode.SINGLE)
+        self._out_list.add_css_class("boxed-list")
+        self._out_list.connect("row-selected", self._on_output_row_selected)
+        scroll.set_child(self._out_list)
+
+        box.append(Gtk.Separator())
+
+        rename_btn = self._menu_row_button("document-edit-symbolic", "Rename Mix…")
+        rename_btn.connect("clicked", self._on_rename_clicked)
+        box.append(rename_btn)
+
+        # The tooltip hangs off a sensitive wrapper as well as the button:
+        # an insensitive GTK4 widget is skipped by picking and never gets the
+        # motion event that would show its own tooltip.
+        self._delete_wrap = Gtk.Box()
+        box.append(self._delete_wrap)
+        self._delete_btn = self._menu_row_button(
+            "user-trash-symbolic", "Delete Mix", label_css="error",
+        )
+        self._delete_btn.connect("clicked", self._on_delete_clicked)
+        self._delete_wrap.append(self._delete_btn)
+
+        # Belt and braces for the tooltip: a disabled button with no visible
+        # explanation reads as a bug.
+        self._delete_hint = Gtk.Label(label="", xalign=0, wrap=True, visible=False)
+        self._delete_hint.add_css_class("dim-label")
+        self._delete_hint.add_css_class("caption")
+        box.append(self._delete_hint)
+
+        return pop
+
+    def _popdown(self):
+        pop = self._menu_btn.get_popover()
+        if pop is not None:
+            pop.popdown()
+
+    def _on_output_row_selected(self, _box, row):
+        if self._updating or row is None:
+            return
+        name = getattr(row, "_output_name", None)
+        # GTK re-emits row-selected when the popover is first mapped, because
+        # the selection made on the unrealised list is re-applied then. Compare
+        # against the value we last displayed rather than trusting the signal:
+        # re-picking the current output is a no-op either way.
+        if name is None or name == self._current_output:
+            return
+        self._current_output = name
+        self._popdown()
+        self.emit("output-changed", name)
+
+    def _on_rename_clicked(self, _btn):
+        self._popdown()
+        _emit_later(self, "rename-clicked")
+
+    def _on_delete_clicked(self, _btn):
+        self._popdown()
+        _emit_later(self, "remove-clicked")
+
+    def _on_volume_changed(self, scale):
+        value = scale.get_value()
+        self._vol_pct.set_label(f"{round(value * 100):d}%")
+        self.emit("volume-changed", value)
+
+    # ----- setters -----
+    def set_volume(self, value):
+        """Reflect the master without firing the changed signal."""
+        value = max(0.0, min(1.0, value))
+        with GObject.signal_handler_block(self._vol_scale, self._vol_handler):
+            self._vol_scale.set_value(value)
+        self._vol_pct.set_label(f"{round(value * 100):d}%")
+
+    def set_level(self, value):
+        """Display a raw peak using cubic fader taper and ~140 ms peak decay.
+
+        The decay factor assumes the monitor's approximately 15 Hz updates.
+        """
+        shown = max(0.0, min(1.0, value)) ** (1.0 / 3.0)
+        held = getattr(self, "_level_held", 0.0) * 0.72
+        self._level_held = max(shown, held)
+        self._level.set_value(self._level_held)
+
+    def set_title(self, title):
+        self._title_lbl.set_label(title)
+        self._title_lbl.set_tooltip_text(title)
+
+    def set_subtitle(self, subtitle):
+        self._subtitle_lbl.set_label(subtitle or "")
+        self._subtitle_lbl.set_visible(bool(subtitle))
+
+    def set_icon(self, icon_name):
+        self._icon.set_from_icon_name(icons.resolve(icon_name))
+
+    def set_empty(self, empty):
+        """Mark the column as carrying nothing.
+
+        A mix whose cells are all at zero is silent, and looks identical to a
+        working one: the sink exists, apps can select it, and it plays nothing.
+        Saying so here is the difference between "misconfigured" and "broken",
+        which is not otherwise visible anywhere.
+        """
+        if getattr(self, "_empty", None) == empty:
+            return
+        self._empty = empty
+        if empty:
+            self._out_lbl.set_label("No sources routed")
+            self._out_lbl.set_tooltip_text(
+                "Every source is at zero for this mix, so it carries no audio. "
+                "Raise a slider in this column."
+            )
+            self._out_icon.set_from_icon_name("dialog-information-symbolic")
+        else:
+            self._out_lbl.set_label(getattr(self, "_out_summary", ""))
+            self._out_lbl.set_tooltip_text(None)
+            self._out_icon.set_from_icon_name(
+                "audio-speakers-symbolic" if getattr(self, "_monitored", True)
+                else "audio-volume-muted-symbolic"
+            )
+
+    def set_outputs(self, entries, current, summary, monitored=True):
+        """Rebuild the chooser. `entries` is [(output name, label), ...]."""
+        self._updating = True
+        try:
+            child = self._out_list.get_first_child()
+            while child is not None:
+                nxt = child.get_next_sibling()
+                self._out_list.remove(child)
+                child = nxt
+            selected = None
+            for name, label in entries:
+                row = Gtk.ListBoxRow()
+                lbl = Gtk.Label(
+                    label=label, xalign=0,
+                    margin_start=12, margin_end=12, margin_top=8, margin_bottom=8,
+                )
+                lbl.set_ellipsize(Pango.EllipsizeMode.END)
+                lbl.set_max_width_chars(28)
+                row.set_child(lbl)
+                row._output_name = name  # noqa: SLF001
+                self._out_list.append(row)
+                if name == current:
+                    selected = row
+            if selected is not None:
+                self._out_list.select_row(selected)
+            self._current_output = current
+        finally:
+            self._updating = False
+
+        self._monitored = monitored
+        self._out_summary = summary
+        self._out_lbl.set_label(summary)
+        self._out_lbl.set_tooltip_text(summary)
+        self._out_icon.set_from_icon_name(
+            "audio-speakers-symbolic" if monitored else "audio-volume-muted-symbolic"
+        )
+        self._out_box.set_visible(True)
+        if getattr(self, "_empty", False):
+            # Re-assert after the icon and label above, which would otherwise
+            # overwrite it: an empty column keeps saying so, because where it
+            # routes is moot until something feeds it.
+            self._empty = None
+            self.set_empty(True)
+
+    def set_delete_enabled(self, enabled, reason=""):
+        self._delete_btn.set_sensitive(enabled)
+        tip = None if enabled else (reason or None)
+        self._delete_btn.set_tooltip_text(tip)
+        self._delete_wrap.set_tooltip_text(tip)
+        self._delete_hint.set_label(reason or "")
+        self._delete_hint.set_visible(not enabled)
 
 
 class SourceCell(Gtk.Box):
@@ -159,16 +783,29 @@ class SourceCell(Gtk.Box):
         "volume-changed": (GObject.SignalFlags.RUN_FIRST, None, (float,)),
         "mute-toggled": (GObject.SignalFlags.RUN_FIRST, None, (bool,)),
         "remove-clicked": (GObject.SignalFlags.RUN_FIRST, None, ()),
+        # (delta) -- -1 to move this row up, +1 to move it down
+        "move-clicked": (GObject.SignalFlags.RUN_FIRST, None, (int,)),
+        # Make this the live source in its group
+        "switch-clicked": (GObject.SignalFlags.RUN_FIRST, None, ()),
+        "edit-clicked": (GObject.SignalFlags.RUN_FIRST, None, ()),
+        # DSP popover moved; read the values back with fx_settings()
+        "fx-changed": (GObject.SignalFlags.RUN_FIRST, None, ()),
+        # "Auto" pressed in the DSP popover: run the calibration wizard
+        "fx-autotune": (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
-    def __init__(self, *, name, icon_name, has_level, removable=False):
+    def __init__(self, *, name, icon_name, has_level, removable=False,
+                 editable=False, reorderable=False, is_capture=False):
         super().__init__(
             orientation=Gtk.Orientation.HORIZONTAL,
             spacing=10,
         )
         self.add_css_class("openwave-source-cell")
         self.add_css_class("card")
-        self.set_size_request(260, 64)
+        self.set_size_request(400, 64)
+        # A microphone row is muted at the microphone, not at a speaker: the
+        # playback icons there read as "this output is silenced".
+        self._is_capture = is_capture
 
         inner = Gtk.Box(
             orientation=Gtk.Orientation.HORIZONTAL,
@@ -181,18 +818,79 @@ class SourceCell(Gtk.Box):
         )
         self.append(inner)
 
-        icon = Gtk.Image.new_from_icon_name(icon_name)
-        icon.set_pixel_size(26)
-        inner.append(icon)
+        if reorderable:
+            handle = Gtk.Image.new_from_icon_name(
+                icons.resolve("list-drag-handle-symbolic"))
+            handle.set_pixel_size(14)
+            handle.add_css_class("dim-label")
+            handle.set_tooltip_text("Drag to reorder")
+            inner.append(handle)
+
+        self._icon = Gtk.Image.new_from_icon_name(icons.resolve(icon_name))
+        self._icon.set_pixel_size(26)
+        inner.append(self._icon)
+
+        text = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=0,
+            hexpand=True,
+            valign=Gtk.Align.CENTER,
+        )
+        inner.append(text)
 
         self._name_lbl = Gtk.Label(label=name, xalign=0, hexpand=True, ellipsize=3)
+        # Without a width request the label yields all its space to the
+        # controls beside it and renders as a bare ellipsis.
+        self._name_lbl.set_width_chars(10)
+        self._name_lbl.set_tooltip_text(name)
+
+        # Group badge. A grouping that is only visible by opening each row's
+        # edit dialog is a grouping nobody knows they have.
+        self._group_lbl = Gtk.Label(label="", xalign=0, visible=False)
+        self._group_lbl.add_css_class("openwave-group-badge")
+        self._group_lbl.add_css_class("caption")
+        text.append(self._group_lbl)
         self._name_lbl.add_css_class("heading")
-        inner.append(self._name_lbl)
+        text.append(self._name_lbl)
+
+        # Only idle applications need the second status line.
+        self._status_lbl = Gtk.Label(label="", xalign=0, ellipsize=3, visible=False)
+        self._status_lbl.add_css_class("dim-label")
+        self._status_lbl.add_css_class("caption")
+        text.append(self._status_lbl)
+
+        # None, not False: the first set_waiting call must always apply.
+        self._waiting = None
 
         self._mute_btn = Gtk.ToggleButton(valign=Gtk.Align.CENTER)
         self._mute_btn.add_css_class("flat")
         self._mute_btn.add_css_class("circular")
-        self._mute_icon = Gtk.Image.new_from_icon_name("audio-volume-high-symbolic")
+        # Shown only on a grouped row: one press makes this the live source
+        # and silences its group-mates, rather than unmuting one and
+        # remembering to mute the other.
+        self._switch_btn = Gtk.Button(
+            valign=Gtk.Align.CENTER, visible=False,
+            tooltip_text="Switch to this source",
+        )
+        self._switch_btn.add_css_class("flat")
+        self._switch_btn.add_css_class("circular")
+        # Hidden means blanked-in-place, never removed: every optional
+        # control keeps its column or the sliders zigzag across rows.
+        self._switch_btn.set_visible(True)
+        self._reserve(self._switch_btn, False)
+        # Two opposing arrows rather than a radio dot: this is an action --
+        # "make this one live" -- not a state to read. The state is already on
+        # the row, which is red when muted.
+        self._switch_icon = Gtk.Image.new_from_icon_name(
+            "mail-send-receive-symbolic")
+        self._switch_btn.set_child(self._switch_icon)
+        self._switch_btn.connect("clicked", lambda _b: self.emit("switch-clicked"))
+        inner.append(self._switch_btn)
+
+        self._mute_icon = Gtk.Image.new_from_icon_name(
+            "audio-input-microphone-symbolic" if is_capture
+            else "audio-volume-high-symbolic"
+        )
         self._mute_btn.set_child(self._mute_icon)
         self._mute_handler = self._mute_btn.connect("toggled", self._on_mute_toggled)
         inner.append(self._mute_btn)
@@ -206,10 +904,12 @@ class SourceCell(Gtk.Box):
             valign=Gtk.Align.CENTER,
             round_digits=2,
         )
+        self._pct_lbl = _percent_label()
         self._scale.add_css_class("openwave-mix-slider")
         self._scale.set_size_request(110, -1)
         self._scale_handler = self._scale.connect("value-changed", self._on_value_changed)
         inner.append(self._scale)
+        inner.append(self._pct_lbl)
 
         self._level = None
         if has_level:
@@ -228,29 +928,306 @@ class SourceCell(Gtk.Box):
             self._level.add_offset_value(Gtk.LEVEL_BAR_OFFSET_FULL, 1.00)
             inner.append(self._level)
 
+        # A text label, deliberately: no icon theme ships an "effects"
+        # glyph everywhere, Breeze drew the broken-image box here, and
+        # "FX" is the clearer button anyway. Built for EVERY row and
+        # merely blanked on non-capture ones, because the controls to its
+        # left only line up across rows if each optional widget keeps its
+        # column when idle.
+        self._fx_widgets = None
+        self._fx_btn = Gtk.MenuButton(
+            label="FX",
+            valign=Gtk.Align.CENTER,
+            tooltip_text="Effects: low cut, gate, compressor, EQ, delay",
+        )
+        self._fx_btn.add_css_class("flat")
+        if is_capture:
+            self._fx_btn.set_popover(self._build_fx_popover())
+        else:
+            self._reserve(self._fx_btn, False)
+        inner.append(self._fx_btn)
+
+        if editable:
+            edit_btn = Gtk.Button(
+                icon_name="document-edit-symbolic",
+                valign=Gtk.Align.CENTER,
+                tooltip_text="Edit source",
+            )
+            edit_btn.add_css_class("flat")
+            edit_btn.add_css_class("circular")
+            edit_btn.connect("clicked", lambda _: self.emit("edit-clicked"))
+            inner.append(edit_btn)
+
+        self._remove_btn = None
         if removable:
-            remove_btn = Gtk.Button(
+            self._remove_btn = Gtk.Button(
                 icon_name="window-close-symbolic",
                 valign=Gtk.Align.CENTER,
                 tooltip_text="Remove source",
             )
-            remove_btn.add_css_class("flat")
-            remove_btn.add_css_class("circular")
-            remove_btn.connect("clicked", lambda _: self.emit("remove-clicked"))
-            inner.append(remove_btn)
+            self._remove_btn.add_css_class("flat")
+            self._remove_btn.add_css_class("circular")
+            self._remove_btn.connect(
+                "clicked", lambda _: self.emit("remove-clicked"))
+            inner.append(self._remove_btn)
+
+    __FX_SIGNAL = "fx-changed"
+
+    def _build_fx_popover(self):
+        """The per-microphone DSP controls: low cut, tone, delay, mono.
+
+        Widgets are the state; fx_settings() reads them and set_fx() writes
+        them with signals blocked, mirroring how every other control here
+        round-trips. Emission is per-gesture — the app debounces the
+        respawn, not the popover.
+        """
+        pop = Gtk.Popover()
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8,
+                      margin_top=12, margin_bottom=12,
+                      margin_start=12, margin_end=12)
+        pop.set_child(box)
+
+        def row(label, widget):
+            r = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+            lbl = Gtk.Label(label=label, xalign=0)
+            lbl.set_width_chars(9)
+            r.append(lbl)
+            r.append(widget)
+            box.append(r)
+
+        auto_btn = Gtk.Button(label="Auto-calibrate gate + comp")
+        # Defer calibration until the popover's Wayland grab is released.
+        auto_btn.connect("clicked",
+                         lambda _b: (pop.popdown(),
+                                     _emit_later(self, "fx-autotune")))
+        box.append(auto_btn)
+
+        self._fx_lowcut = Gtk.DropDown.new_from_strings(
+            ["Off", "80 Hz", "120 Hz"])
+        self._fx_lowcut.connect("notify::selected", self._on_fx_changed)
+        row("Low cut", self._fx_lowcut)
+
+        def switch():
+            s = Gtk.Switch(halign=Gtk.Align.START, valign=Gtk.Align.CENTER)
+            s.connect("notify::active", self._on_fx_changed)
+            return s
+
+        def scale(lo, hi, step, digits=0):
+            s = Gtk.Scale(
+                orientation=Gtk.Orientation.HORIZONTAL,
+                draw_value=True, digits=digits,
+                adjustment=Gtk.Adjustment(
+                    lower=lo, upper=hi, step_increment=step,
+                    page_increment=step * 5),
+                hexpand=True,
+            )
+            s.set_size_request(160, -1)
+            s.connect("value-changed", self._on_fx_changed)
+            return s
+
+        self._fx_gate = switch()
+        row("Gate", self._fx_gate)
+        self._fx_gate_thresh = scale(-70, -20, 1)
+        row("Gate dB", self._fx_gate_thresh)
+
+        self._fx_comp = switch()
+        row("Comp", self._fx_comp)
+        self._fx_comp_thresh = scale(-40, 0, 1)
+        row("Comp dB", self._fx_comp_thresh)
+        self._fx_comp_ratio = scale(1, 10, 0.5, digits=1)
+        row("Ratio", self._fx_comp_ratio)
+
+        # A slider whose effect is off is either misleading (it moves,
+        # nothing happens) or a statement of intent. Both, resolved:
+        # the sliders dim while their switch is off, and dragging one
+        # anyway flips the switch — choosing a threshold IS enabling.
+        def bind(sw, *scales):
+            def sync(*_a):
+                for s in scales:
+                    s.set_sensitive(sw.get_active())
+            sw.connect("notify::active", sync)
+            sync()
+            for s in scales:
+                def enable(_s, sw=sw):
+                    if not getattr(self, "_fx_updating", False) \
+                            and not sw.get_active():
+                        sw.set_active(True)
+                s.connect("value-changed", enable)
+
+        bind(self._fx_gate, self._fx_gate_thresh)
+        bind(self._fx_comp, self._fx_comp_thresh, self._fx_comp_ratio)
+
+        def eq_scale():
+            s = Gtk.Scale(
+                orientation=Gtk.Orientation.HORIZONTAL,
+                draw_value=True, digits=0,
+                adjustment=Gtk.Adjustment(
+                    lower=-12, upper=12, step_increment=1, page_increment=3),
+                hexpand=True,
+            )
+            s.set_size_request(160, -1)
+            s.add_mark(0, Gtk.PositionType.BOTTOM, None)
+            s.connect("value-changed", self._on_fx_changed)
+            return s
+
+        self._fx_eq_low = eq_scale()
+        self._fx_eq_mid = eq_scale()
+        self._fx_eq_high = eq_scale()
+        row("Low dB", self._fx_eq_low)
+        row("Mid dB", self._fx_eq_mid)
+        row("High dB", self._fx_eq_high)
+
+        self._fx_delay = Gtk.SpinButton(
+            adjustment=Gtk.Adjustment(
+                lower=0, upper=500, step_increment=5, page_increment=25),
+            climb_rate=1, digits=0,
+        )
+        self._fx_delay.connect("value-changed", self._on_fx_changed)
+        row("Delay ms", self._fx_delay)
+
+        self._fx_mono = Gtk.Switch(halign=Gtk.Align.START,
+                                   valign=Gtk.Align.CENTER)
+        self._fx_mono.connect("notify::active", self._on_fx_changed)
+        row("Mono", self._fx_mono)
+
+        self._fx_updating = False
+        return pop
+
+    def _on_fx_changed(self, *_args):
+        if getattr(self, "_fx_updating", False):
+            return
+        self.emit(self.__FX_SIGNAL)
+
+    def fx_settings(self):
+        """The popover's current values, in the sources.DEFAULT_FX shape."""
+        lowcut = (0, 80, 120)[self._fx_lowcut.get_selected()]
+        return {
+            "lowcut": lowcut,
+            "gate": bool(self._fx_gate.get_active()),
+            "gate_thresh": float(self._fx_gate_thresh.get_value()),
+            "comp": bool(self._fx_comp.get_active()),
+            "comp_thresh": float(self._fx_comp_thresh.get_value()),
+            "comp_ratio": float(self._fx_comp_ratio.get_value()),
+            "eq_low": float(self._fx_eq_low.get_value()),
+            "eq_mid": float(self._fx_eq_mid.get_value()),
+            "eq_high": float(self._fx_eq_high.get_value()),
+            "delay_ms": int(self._fx_delay.get_value()),
+            "mono": bool(self._fx_mono.get_active()),
+        }
+
+    def set_fx(self, fx):
+        """Load stored settings into the popover without emitting."""
+        if self._fx_widgets is None and not hasattr(self, "_fx_lowcut"):
+            return
+        self._fx_updating = True
+        try:
+            self._fx_lowcut.set_selected(
+                {0: 0, 80: 1, 120: 2}.get(int(fx.get("lowcut", 0)), 0))
+            self._fx_gate.set_active(bool(fx.get("gate", False)))
+            self._fx_gate_thresh.set_value(fx.get("gate_thresh", -50.0))
+            self._fx_comp.set_active(bool(fx.get("comp", False)))
+            self._fx_comp_thresh.set_value(fx.get("comp_thresh", -18.0))
+            self._fx_comp_ratio.set_value(fx.get("comp_ratio", 3.0))
+            self._fx_eq_low.set_value(fx.get("eq_low", 0.0))
+            self._fx_eq_mid.set_value(fx.get("eq_mid", 0.0))
+            self._fx_eq_high.set_value(fx.get("eq_high", 0.0))
+            self._fx_delay.set_value(fx.get("delay_ms", 0))
+            self._fx_mono.set_active(bool(fx.get("mono", False)))
+        finally:
+            self._fx_updating = False
+
+    @staticmethod
+    def _reserve(widget, shown):
+        """Blank a control in place instead of removing it.
+
+        Rows line up column by column only while every optional widget
+        keeps its allocation; set_visible collapses the slot and shifts
+        everything beside it, which is how the sliders came to zigzag.
+        """
+        widget.set_opacity(1.0 if shown else 0.0)
+        widget.set_sensitive(shown)
+        widget.set_can_target(shown)
+
+    def set_removable(self, removable, tooltip="Remove source"):
+        """Show or blank the remove button on a row that owns one.
+
+        Auto-discovered device rows are built with the button and normally
+        blank it: while the hardware is connected, removing its row would
+        only make it come back confusing. Unplugged, the row is clutter the
+        user may clear — so removability follows presence.
+        """
+        if self._remove_btn is not None:
+            self._reserve(self._remove_btn, removable)
+            self._remove_btn.set_tooltip_text(tooltip if removable else None)
+
+    def set_group(self, group):
+        """Show which exclusivity group this row is in, if any."""
+        group = (group or "").strip()
+        self._reserve(self._switch_btn, bool(group))
+        self._group_lbl.set_label(f"\u2b24 {group}" if group else "")
+        self._group_lbl.set_visible(bool(group))
+        self._group_lbl.set_tooltip_text(
+            f"Only one source in \u201c{group}\u201d is live at a time"
+            if group else None
+        )
 
     def set_name(self, name):
         self._name_lbl.set_label(name)
+        self._name_lbl.set_tooltip_text(name)
+
+    def set_icon(self, icon_name):
+        self._icon.set_from_icon_name(icons.resolve(icon_name))
+    def set_available(self, available, *, reason="Device not connected"):
+        """Dim the row when the device behind it is gone.
+
+        The controls stay live on purpose: the level is persisted whether or
+        not the device is present, so one set while a headset is off takes
+        effect the moment it comes back.
+        """
+        if available:
+            self._name_lbl.remove_css_class("dim-label")
+            self.set_tooltip_text(None)
+        else:
+            self._name_lbl.add_css_class("dim-label")
+            self.set_tooltip_text(reason)
+
+    def _sync_percent(self):
+        if getattr(self, "_pct_lbl", None) is not None:
+            self._pct_lbl.set_label(f"{round(self._scale.get_value() * 100):d}%")
 
     def set_volume(self, value):
         """Update the master slider without firing the changed signal."""
         with GObject.signal_handler_block(self._scale, self._scale_handler):
             self._scale.set_value(max(0.0, min(1.0, value)))
+        # The changed handler is blocked above, so the readout is updated here.
+        self._sync_percent()
 
     def set_level(self, value):
         """Update the audio activity meter (0.0–1.0). No-op if not enabled."""
         if self._level is not None:
             self._level.set_value(max(0.0, min(1.0, value)))
+    def set_waiting(self, waiting, hint="Waiting for audio"):
+        """Show or clear the 'bound application is not playing' state.
+
+        A bound-but-idle source should read as waiting, not broken: the row
+        dims and gains a hint line, but stays interactive so levels can be set
+        up before the application is launched.
+
+        Called on every stream-poll tick, so it no-ops unless something
+        actually changed rather than churning the layout twice a second.
+        """
+        waiting = bool(waiting)
+        state = (waiting, hint if waiting else "")
+        if state == self._waiting:
+            return
+        self._waiting = state
+        self._status_lbl.set_label(hint if waiting else "")
+        self._status_lbl.set_visible(waiting)
+        self.set_tooltip_text(hint if waiting else None)
+        if waiting:
+            self.add_css_class("openwave-source-waiting")
+        else:
+            self.remove_css_class("openwave-source-waiting")
 
     def set_muted(self, muted):
         """Update the mute toggle without firing its signal."""
@@ -259,9 +1236,29 @@ class SourceCell(Gtk.Box):
         self._reflect_mute_icon(muted)
 
     def _reflect_mute_icon(self, muted):
-        self._mute_icon.set_from_icon_name(
-            "audio-volume-muted-symbolic" if muted else "audio-volume-high-symbolic"
-        )
+        if getattr(self, "_is_capture", False):
+            icon = ("microphone-sensitivity-muted-symbolic" if muted
+                    else "audio-input-microphone-symbolic")
+        else:
+            icon = ("audio-volume-muted-symbolic" if muted
+                    else "audio-volume-high-symbolic")
+        self._mute_icon.set_from_icon_name(icon)
+        self._mute_btn.set_tooltip_text("Unmute" if muted else "Mute")
+        if getattr(self, "_switch_btn", None) is not None:
+            # Deliberately always sensitive. A control that greys out exactly
+            # when you press it reads as broken, and switching to the source
+            # that is already live is harmless.
+            self._switch_btn.set_tooltip_text(
+                "Switch to this source"
+                if muted else "This source is already live"
+            )
+        # A muted row should be obvious at a glance down the column, not a
+        # difference of one small icon.
+        for widget in (self, self._name_lbl, self._mute_icon):
+            if muted:
+                widget.add_css_class("openwave-muted")
+            else:
+                widget.remove_css_class("openwave-muted")
         if self._level is not None:
             if muted:
                 self._level.add_css_class("dim-label")
@@ -271,6 +1268,7 @@ class SourceCell(Gtk.Box):
                 self._level.add_css_class("success")
 
     def _on_value_changed(self, scale):
+        self._sync_percent()
         self.emit("volume-changed", scale.get_value())
 
     def _on_mute_toggled(self, btn):
@@ -325,27 +1323,58 @@ class MixCell(Gtk.Box):
             hexpand=True,
             round_digits=2,
         )
+        self._pct_lbl = _percent_label()
         self._scale.add_css_class("openwave-mix-slider")
+
+        # A new cell routes nothing, so it starts muted and says so. Leaving it
+        # unmuted at 0% shows an armed-looking control that carries no audio.
+        with GObject.signal_handler_block(self._mute_btn, self._mute_handler):
+            self._mute_btn.set_active(True)
+        self._reflect_mute(True)
         self._scale_handler = self._scale.connect("value-changed", self._on_value_changed)
         inner.append(self._scale)
+        inner.append(self._pct_lbl)
+
+    def _sync_percent(self):
+        if getattr(self, "_pct_lbl", None) is not None:
+            self._pct_lbl.set_label(f"{round(self._scale.get_value() * 100):d}%")
 
     def set_volume(self, value):
         with GObject.signal_handler_block(self._scale, self._scale_handler):
             self._scale.set_value(max(0.0, min(1.0, value)))
+        # The changed handler is blocked above, so the readout is updated here.
+        self._sync_percent()
+
+    def _reflect_mute(self, muted):
+        self._mute_icon.set_from_icon_name(
+            "audio-volume-muted-symbolic" if muted else "audio-volume-high-symbolic"
+        )
+        self._mute_btn.set_tooltip_text("Unmute" if muted else "Mute")
+        for widget in (self, self._mute_icon):
+            if muted:
+                widget.add_css_class("openwave-muted")
+            else:
+                widget.remove_css_class("openwave-muted")
 
     def set_muted(self, muted):
         with GObject.signal_handler_block(self._mute_btn, self._mute_handler):
             self._mute_btn.set_active(muted)
-        self._mute_icon.set_from_icon_name(
-            "audio-volume-muted-symbolic" if muted else "audio-volume-high-symbolic"
-        )
+        self._reflect_mute(muted)
 
     def _on_value_changed(self, scale):
+        self._sync_percent()
+        # A cell at zero and a muted cell mean the same thing, and letting them
+        # disagree produces a slider at 0% next to an unmuted icon, or a slider
+        # the user raises with no sound because a mute they forgot is still on.
+        should_mute = scale.get_value() <= 0.0
+        if should_mute != self._mute_btn.get_active():
+            with GObject.signal_handler_block(self._mute_btn, self._mute_handler):
+                self._mute_btn.set_active(should_mute)
+            self._reflect_mute(should_mute)
+            self.emit("mute-toggled", should_mute)
         self.emit("volume-changed", scale.get_value())
 
     def _on_mute_toggled(self, btn):
         muted = btn.get_active()
-        self._mute_icon.set_from_icon_name(
-            "audio-volume-muted-symbolic" if muted else "audio-volume-high-symbolic"
-        )
+        self._reflect_mute(muted)
         self.emit("mute-toggled", muted)

--- a/wavexlr/scheduler.py
+++ b/wavexlr/scheduler.py
@@ -1,0 +1,107 @@
+"""Scheduler — the timing/threading seam device work runs on.
+
+Ported from CryoByte33/openwave (github.com/CryoByte33/openwave): both the
+Scheduler seam and the Throttler's leading/periodic/trailing pacing are
+cryobyte33's design, taken essentially verbatim.
+
+The controller never touches GLib or threads directly: it asks a Scheduler to
+run blocking USB work off the main thread and to fire repeating timers, and to
+marshal results back. GLibScheduler is the production adapter; a fake
+(synchronous, controllable-clock) one lets the connect/poll/reconnect logic be
+exercised without a GTK main loop or a real device.
+
+Interface (duck-typed):
+    run_async(fn, on_done=None, on_error=None)
+        Run fn() off the main thread; deliver on_done(result) or on_error(exc)
+        back on the main thread.
+    call_every(interval_s, fn) -> handle
+        Call fn() every interval_s seconds; fn returns True to keep going.
+    cancel(handle)
+        Stop a timer started by call_every.
+"""
+
+import threading
+
+# GLib is imported inside GLibScheduler, not here: the Throttler is pure
+# Python and gets exercised on runners that install no PyGObject at all,
+# and a module-level import would take it down with the production half.
+
+
+class GLibScheduler:
+    """Production scheduler: GLib timeouts + worker threads marshalled via idle_add."""
+
+    def __init__(self):
+        from gi.repository import GLib
+        self._glib = GLib
+
+    def run_async(self, fn, on_done=None, on_error=None):
+        glib = self._glib
+
+        def deliver(callback, value):
+            callback(value)
+            return False
+
+        def _worker():
+            try:
+                result = fn()
+                if on_done is not None:
+                    glib.idle_add(deliver, on_done, result)
+            except Exception as e:
+                if on_error is not None:
+                    glib.idle_add(deliver, on_error, e)
+        threading.Thread(target=_worker, daemon=True).start()
+
+    def call_every(self, interval_s, fn):
+        return self._glib.timeout_add(int(interval_s * 1000), fn)
+
+    def cancel(self, handle):
+        if handle is not None:
+            self._glib.source_remove(handle)
+
+
+class Throttler:
+    """Paces rapid live updates (mixer + device sliders) so a drag doesn't flood
+    the device or the audio graph: the first value fires immediately (leading),
+    then at most once per interval while values keep arriving (periodic), then a
+    final trailing value once they stop. Keyed by name so independent sliders
+    pace independently.
+
+    The Throttler owns only the timing; the caller's `setter` owns dispatch —
+    inline for the mixer (which queues to its own worker), or off-thread with a
+    connected-guard for the device. Runs on an injected Scheduler, so the pacing
+    is testable with a controllable-clock fake (no GLib, no main loop)."""
+
+    def __init__(self, scheduler, interval_s):
+        self._sched = scheduler
+        self._interval = interval_s
+        self._pending = {}   # name -> latest value awaiting send
+        self._setter = {}    # name -> callable(value)
+        self._handle = {}    # name -> timer handle (None = idle)
+
+    def push(self, name, value, setter):
+        """Record the latest value for `name` and send it, paced."""
+        self._pending[name] = value
+        self._setter[name] = setter
+        if self._handle.get(name) is None:
+            self._flush(name)            # leading edge
+            self._handle[name] = self._sched.call_every(
+                self._interval, lambda n=name: self._tick(n))
+
+    def _tick(self, name):
+        if name in self._pending:        # value changed since last flush
+            self._flush(name)
+            return True                  # keep the timer alive
+        self._handle[name] = None        # idle — stop ticking
+        return False
+
+    def _flush(self, name):
+        if name not in self._pending:
+            return
+        self._setter[name](self._pending.pop(name))
+
+    def cancel_all(self):
+        for handle in self._handle.values():
+            self._sched.cancel(handle)
+        self._handle.clear()
+        self._pending.clear()
+        self._setter.clear()

--- a/wavexlr/sourcedialog.py
+++ b/wavexlr/sourcedialog.py
@@ -1,4 +1,15 @@
-"""'Add Source' picker — two pages: app picker, then name + icon config."""
+"""'Add Source': source kind, then a per-kind picker, then name + icon.
+
+Page 0 forks between an application source and a hardware capture device. The
+app branch can also bind an application that is not running, by typing its
+name. The branches share only the final name/icon page, which is parameterised
+so each supplies its own defaults and confirm handler, and each emits its own
+signal so neither has to know the other exists.
+
+Passing source= opens straight to the config page in edit mode: the pickers
+list only what is present right now, and requiring the bound app to be playing
+in order to rename its row would be nonsense.
+"""
 
 import gi
 
@@ -6,7 +17,8 @@ gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 from gi.repository import Gtk, Adw, GObject  # noqa: E402
 
-from .mixer import list_audio_streams
+from . import icons
+from . import sources as sources_module
 
 ICON_CHOICES = (
     ("applications-multimedia-symbolic", "Generic"),
@@ -25,28 +37,79 @@ ICON_CHOICES = (
 
 
 class AddSourceDialog(Adw.Dialog):
+    """Edit source identity using caller-owned, nonblocking audio snapshots.
+
+    ``streams`` is an iterable of dictionaries with ``app_name`` and optional
+    ``display_name``, ``media_name``, ``node_name`` and ``binary`` fields.
+    ``captures`` contains ``name`` (node name) and ``description`` dictionaries.
+    Pass ``Mixer.streams().values()`` and ``Mixer.capture_sources()``.
+
+    Signals omit the emitting widget here:
+      source-confirmed(name, comma_separated_bindings, icon_name, group)
+      device-source-confirmed(name, node_name, icon_name, group)
+      source-edited(id, name, comma_separated_bindings, icon_name, group)
+    Device edits emit an empty bindings string and preserve their node binding.
+    """
     __gsignals__ = {
-        # (display_name, match_app_name, icon_name)
-        "source-confirmed": (GObject.SignalFlags.RUN_FIRST, None, (str, str, str)),
+        # (display_name, match_app_name, icon_name, group)
+        "source-confirmed": (GObject.SignalFlags.RUN_FIRST, None, (str, str, str, str)),
+        # (display_name, capture_node_name, icon_name, group)
+        "device-source-confirmed": (GObject.SignalFlags.RUN_FIRST, None, (str, str, str, str)),
+        # (source_id, display_name, binding, icon_name, group). `binding` is the
+        # match_app_name for an app source and "" for a device source, whose
+        # node_name is hardware and is not editable here.
+        "source-edited": (GObject.SignalFlags.RUN_FIRST, None, (str, str, str, str, str)),
     }
 
-    def __init__(self):
+    def __init__(self, source=None, *, exclude_nodes=(), exclude_apps=(),
+                 streams=(), captures=()):
         super().__init__()
-        self.set_title("Add Source")
+        self._source = source
+        self._streams = tuple(streams)
+        self._captures = tuple(captures)
+        self._editing_device = (
+            source is not None
+            and sources_module.kind(source) == sources_module.KIND_DEVICE
+        )
+        self.set_title("Edit Source" if source else "Add Source")
         self.set_content_width(480)
         self.set_content_height(560)
 
         self._nav = Adw.NavigationView()
         self.set_child(self._nav)
 
-        self._selected_app = None
-        self._selected_icon = ICON_CHOICES[0][0]
+        # Capture nodes that already have a matrix row.
+        self._exclude_nodes = frozenset(exclude_nodes)
+        # Compared case-insensitively, the same way stream matching does:
+        # a row bound to "spotify" already covers the app reporting "Spotify".
+        self._exclude_apps = frozenset(a.casefold() for a in exclude_apps)
+        # None = nothing picked yet, "" = manual entry, else the picked app.
+        # Every binding, comma-separated: a source can gather more than one
+        # application, and an edit that showed only the first would silently
+        # drop the rest on save.
+        self._selected_app = (
+            None if source is None else sources_module.format_bindings(source)
+        )
+        self._selected_device = None
+        self._selected_icon = (source or {}).get("icon_name") or ICON_CHOICES[0][0]
 
-        self._nav.push(self._build_picker_page())
+        if source is None:
+            self._nav.push(self._build_type_page())
+        else:
+            # Config page as the navigation root; it packs its own Cancel,
+            # because the type page that normally carries one was never built.
+            self._nav.push(self._build_config_page(
+                show_app_row=not self._editing_device,
+            ))
 
-    # ------------------------------------------------------------ page 1
-    def _build_picker_page(self):
-        page = Adw.NavigationPage(title="Pick Application")
+    def _build_type_page(self):
+        """Fork between the source kinds.
+
+        A separate first page rather than a mode switch on the app picker: the
+        two flows share only the name/icon page, and keeping them in separate
+        pages means the app picker needs no knowledge of devices at all.
+        """
+        page = Adw.NavigationPage(title="Add Source")
 
         view = Adw.ToolbarView()
         page.set_child(view)
@@ -57,6 +120,172 @@ class AddSourceDialog(Adw.Dialog):
         cancel_btn = Gtk.Button(label="Cancel")
         cancel_btn.connect("clicked", lambda _: self.close())
         header.pack_start(cancel_btn)
+
+        clamp = Adw.Clamp(
+            maximum_size=440,
+            margin_start=12, margin_end=12, margin_top=12, margin_bottom=12,
+        )
+        view.set_content(clamp)
+
+        outer = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL, spacing=12,
+            valign=Gtk.Align.START,
+        )
+        clamp.set_child(outer)
+
+        hint = Gtk.Label(
+            label="What should this row carry into your mixes?",
+            wrap=True, xalign=0,
+        )
+        hint.add_css_class("dim-label")
+        outer.append(hint)
+
+        listbox = Gtk.ListBox(selection_mode=Gtk.SelectionMode.NONE)
+        listbox.add_css_class("boxed-list")
+        outer.append(listbox)
+
+        app_row = Adw.ActionRow(
+            title="Application",
+            subtitle="Follows every stream an app plays, now and later",
+            activatable=True,
+        )
+        app_row.add_prefix(
+            Gtk.Image.new_from_icon_name("applications-multimedia-symbolic")
+        )
+        app_row.add_suffix(Gtk.Image.new_from_icon_name("go-next-symbolic"))
+        app_row.connect(
+            "activated", lambda _r: self._nav.push(self._build_picker_page()),
+        )
+        listbox.append(app_row)
+
+        device_row = Adw.ActionRow(
+            title="Capture Device",
+            subtitle="A microphone or line input, such as a headset mic",
+            activatable=True,
+        )
+        device_row.add_prefix(
+            Gtk.Image.new_from_icon_name("audio-input-microphone-symbolic")
+        )
+        device_row.add_suffix(Gtk.Image.new_from_icon_name("go-next-symbolic"))
+        device_row.connect(
+            "activated", lambda _r: self._nav.push(self._build_device_page()),
+        )
+        listbox.append(device_row)
+
+        return page
+
+    # ------------------------------------------------------- device picker
+    def _build_device_page(self):
+        page = Adw.NavigationPage(title="Pick Capture Device")
+
+        view = Adw.ToolbarView()
+        page.set_child(view)
+
+        header = Adw.HeaderBar()
+        view.add_top_bar(header)
+
+        self._device_next_btn = Gtk.Button(label="Next")
+        self._device_next_btn.add_css_class("suggested-action")
+        self._device_next_btn.set_sensitive(False)
+        self._device_next_btn.connect("clicked", self._on_device_next)
+        header.pack_end(self._device_next_btn)
+
+        scroll = Gtk.ScrolledWindow(vexpand=True)
+        view.set_content(scroll)
+
+        clamp = Adw.Clamp(
+            maximum_size=440,
+            margin_start=12, margin_end=12, margin_top=12, margin_bottom=12,
+        )
+        scroll.set_child(clamp)
+
+        outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        clamp.set_child(outer)
+
+        hint = Gtk.Label(
+            label="Pick a microphone or line input. OpenWave mixes it into each "
+                  "mix at the level you set, alongside the Wave's own mic.",
+            wrap=True, xalign=0,
+        )
+        hint.add_css_class("dim-label")
+        outer.append(hint)
+
+        self._device_list = Gtk.ListBox(selection_mode=Gtk.SelectionMode.SINGLE)
+        self._device_list.add_css_class("boxed-list")
+        self._device_list.connect("row-selected", self._on_device_row_selected)
+        outer.append(self._device_list)
+
+        self._populate_devices()
+        return page
+
+    def _populate_devices(self):
+        # Already-bound nodes are filtered out rather than shown disabled: the
+        # Wave's own mic is the built-in row, and a second row for it would
+        # double the same audio into every mix.
+        devices = [
+            d for d in self._captures if d["name"] not in self._exclude_nodes
+        ]
+        if not devices:
+            empty = Adw.ActionRow(title="No other capture devices")
+            empty.set_subtitle(
+                "Connect a headset or microphone, then open this dialog again"
+            )
+            empty.set_sensitive(False)
+            self._device_list.append(empty)
+            return
+        for device in devices:
+            row = Adw.ActionRow(title=device["description"])
+            # The node name disambiguates two inputs on one card that share a
+            # description, and is what actually gets persisted.
+            row.set_subtitle(device["name"])
+            row.add_prefix(
+                Gtk.Image.new_from_icon_name("audio-input-microphone-symbolic")
+            )
+            row._device = device  # noqa: SLF001
+            self._device_list.append(row)
+
+    def _on_device_row_selected(self, _box, row):
+        self._selected_device = (
+            getattr(row, "_device", None) if row is not None else None
+        )
+        self._device_next_btn.set_sensitive(self._selected_device is not None)
+
+    def _on_device_next(self, _btn):
+        if not self._selected_device:
+            return
+        self._nav.push(self._build_config_page(
+            default_name=self._selected_device["description"],
+            default_icon="microphone-sensitivity-high-symbolic",
+            on_confirm=self._on_device_confirm,
+            # A capture device has no application name, and confirm is gated
+            # on that row being non-empty: leaving it in would make the device
+            # flow impossible to complete.
+            show_app_row=False,
+        ))
+
+    def _on_device_confirm(self, _btn):
+        if not self._selected_device:
+            return
+        name = (
+            self._name_row.get_text().strip()
+            or self._selected_device["description"]
+        )
+        self.emit(
+            "device-source-confirmed",
+            name, self._selected_device["name"], self._selected_icon,
+            self._group_text(),
+        )
+        self.close()
+
+    # ------------------------------------------------------------ page 1
+    def _build_picker_page(self):
+        page = Adw.NavigationPage(title="Pick Application")
+
+        view = Adw.ToolbarView()
+        page.set_child(view)
+
+        header = Adw.HeaderBar()
+        view.add_top_bar(header)
 
         self._next_btn = Gtk.Button(label="Next")
         self._next_btn.add_css_class("suggested-action")
@@ -77,8 +306,9 @@ class AddSourceDialog(Adw.Dialog):
         clamp.set_child(outer)
 
         hint = Gtk.Label(
-            label="Pick an application that's currently playing audio. "
-                  "OpenWave will route any future streams from this app through the new source row.",
+            label="Pick an application that's currently playing audio, or enter one "
+                  "manually if it isn't running yet. OpenWave will route any future "
+                  "streams from that app through the new source row.",
             wrap=True, xalign=0,
         )
         hint.add_css_class("dim-label")
@@ -94,20 +324,26 @@ class AddSourceDialog(Adw.Dialog):
         return page
 
     def _populate_apps(self):
-        streams = list_audio_streams()
         apps = {}
-        for s in streams:
+        for s in self._streams:
+            if s["app_name"].casefold() in self._exclude_apps:
+                continue
             apps.setdefault(s["app_name"], []).append(s)
 
         if not apps:
-            empty = Adw.ActionRow(title="No audio streams playing")
-            empty.set_subtitle("Start playback in an app, then click + Add Source again")
+            title = ("No new apps playing audio" if self._exclude_apps
+                     else "No audio streams playing")
+            empty = Adw.ActionRow(title=title)
+            empty.set_subtitle("Start playback in an app, or enter a name manually below")
             empty.set_sensitive(False)
             self._listbox.append(empty)
-            return
 
         for app_name in sorted(apps.keys()):
-            row = Adw.ActionRow(title=app_name)
+            # display_name is a label only; app_name below stays the match key,
+            # so a row bound by its friendly title still captures by exact
+            # application.name equality.
+            row = Adw.ActionRow(
+                title=apps[app_name][0].get("display_name") or app_name)
             sample = apps[app_name][0].get("media_name") or apps[app_name][0].get("node_name", "")
             if sample:
                 row.set_subtitle(sample)
@@ -115,22 +351,45 @@ class AddSourceDialog(Adw.Dialog):
             row._app_name = app_name  # noqa: SLF001
             self._listbox.append(row)
 
+        # Always offered. An app that isn't running publishes no stream, so
+        # without this row it could never be bound at all -- and with an empty
+        # list the page is otherwise a dead end, since the placeholder row is
+        # insensitive and Next stays disabled forever.
+        manual = Adw.ActionRow(title="Enter manually…")
+        manual.set_subtitle("Bind an application that isn't running yet")
+        manual.add_prefix(Gtk.Image.new_from_icon_name("document-edit-symbolic"))
+        manual._app_name = ""  # noqa: SLF001
+        self._listbox.append(manual)
+
     def _on_row_selected(self, _box, row):
-        if row is None:
-            self._selected_app = None
-            self._next_btn.set_sensitive(False)
-            return
-        self._selected_app = getattr(row, "_app_name", None)
-        self._next_btn.set_sensitive(self._selected_app is not None)
+        # "" is the manual row: a real choice, just with nothing prefilled.
+        # Compare against None, not truthiness, or it reads as "no selection".
+        app = getattr(row, "_app_name", None) if row is not None else None
+        self._selected_app = app
+        self._next_btn.set_sensitive(app is not None)
 
     def _on_next(self, _btn):
-        if not self._selected_app:
+        if self._selected_app is None:
             return
         self._nav.push(self._build_config_page())
 
     # ------------------------------------------------------------ page 2
-    def _build_config_page(self):
-        page = Adw.NavigationPage(title="Name and Icon")
+    def _build_config_page(self, *, default_name=None, default_icon=None,
+                           on_confirm=None, show_app_row=True):
+        """Shared final page for every source flow.
+
+        Every argument defaults to the app-picker behaviour, so the plain
+        `self._build_config_page()` call in _on_next keeps working verbatim.
+
+        show_app_row is the one that is not cosmetic. The Application entry is
+        what makes a not-yet-running app bindable and a mis-bound source
+        fixable, and confirm is gated on it being non-empty — but a capture
+        device has no application name at all, so leaving the row in the device
+        flow would leave confirm permanently insensitive and make device
+        sources impossible to create.
+        """
+        editing = self._source is not None
+        page = Adw.NavigationPage(title="Edit Source" if editing else "Name and Icon")
 
         view = Adw.ToolbarView()
         page.set_child(view)
@@ -138,10 +397,17 @@ class AddSourceDialog(Adw.Dialog):
         header = Adw.HeaderBar()
         view.add_top_bar(header)
 
-        add_btn = Gtk.Button(label="Add Source")
-        add_btn.add_css_class("suggested-action")
-        add_btn.connect("clicked", self._on_confirm)
-        header.pack_end(add_btn)
+        if editing:
+            # This page is the navigation root, so NavigationView draws no back
+            # button and the page that carries Cancel was never built.
+            cancel_btn = Gtk.Button(label="Cancel")
+            cancel_btn.connect("clicked", lambda _: self.close())
+            header.pack_start(cancel_btn)
+
+        self._confirm_btn = Gtk.Button(label="Save" if editing else "Add Source")
+        self._confirm_btn.add_css_class("suggested-action")
+        self._confirm_btn.connect("clicked", on_confirm or self._on_confirm)
+        header.pack_end(self._confirm_btn)
 
         scroll = Gtk.ScrolledWindow(vexpand=True)
         view.set_content(scroll)
@@ -160,10 +426,82 @@ class AddSourceDialog(Adw.Dialog):
         outer.append(name_group)
 
         self._name_row = Adw.EntryRow(title="Source name")
-        self._name_row.set_text(self._selected_app or "")
+        self._name_row.set_text(
+            (self._source or {}).get("name")
+            or default_name
+            or self._selected_app
+            or ""
+        )
+        self._name_row.connect("changed", self._on_binding_changed)
         name_group.add(self._name_row)
 
+        # Application binding — app sources only.
+        # None on the capture-device page, a list on the application page.
+        self._bindings = None
+        if show_app_row:
+            app_group = Adw.PreferencesGroup(
+                title="Applications",
+                description="Audio from any of these is gathered under this "
+                            "row's single fader.",
+            )
+            outer.append(app_group)
+
+            # A managed list rather than a comma-separated entry. The seeded
+            # rows carry a dozen names each, which is unreadable as one string
+            # and impossible to edit a single entry out of.
+            self._bindings = sources_module.parse_bindings(self._selected_app or "")
+            self._bind_group = app_group
+            self._bind_rows = []
+
+            self._add_row = Adw.EntryRow(title="Add an application")
+            add_btn = Gtk.Button(
+                icon_name="list-add-symbolic", valign=Gtk.Align.CENTER,
+                tooltip_text="Add this name",
+            )
+            add_btn.add_css_class("flat")
+            add_btn.connect("clicked", lambda _b: self._add_binding_from_entry())
+            self._add_row.add_suffix(add_btn)
+            self._add_row.connect("entry-activated",
+                                  lambda _r: self._add_binding_from_entry())
+            self._add_row.connect("changed", lambda _r: self._sync_confirm())
+
+            # Anything currently making sound, minus what is already bound --
+            # the common case is "the app is running, I just do not know what
+            # PipeWire calls it".
+            self._running_btn = Gtk.MenuButton(
+                label="From running apps", halign=Gtk.Align.START, margin_top=6,
+            )
+            self._running_btn.add_css_class("flat")
+            self._running_pop = Gtk.Popover()
+            self._running_btn.set_popover(self._running_pop)
+
+            self._rebuild_bindings()
+        elif editing:
+            # A device source's binding is hardware, not text: show it, do not
+            # offer to edit it. Re-pointing a row at a different capture device
+            # means adding a new row.
+            dev_group = Adw.PreferencesGroup(title="Capture Device")
+            outer.append(dev_group)
+            dev_row = Adw.ActionRow(
+                title=self._source.get("node_name", ""),
+                subtitle="The capture device this row is bound to",
+            )
+            dev_row.add_prefix(
+                Gtk.Image.new_from_icon_name("audio-input-microphone-symbolic")
+            )
+            dev_group.add(dev_row)
+
         # Icon picker
+        group_group = Adw.PreferencesGroup(
+            title="Group",
+            description="Sources sharing a group are mutually exclusive: "
+                        "unmuting one mutes the others. Leave blank for none.",
+        )
+        outer.append(group_group)
+        self._group_row = Adw.EntryRow(title="Group name")
+        self._group_row.set_text((self._source or {}).get("group", "") or "")
+        group_group.add(self._group_row)
+
         icon_group = Adw.PreferencesGroup(title="Icon")
         outer.append(icon_group)
 
@@ -177,25 +515,124 @@ class AddSourceDialog(Adw.Dialog):
             homogeneous=True,
         )
         flow.add_css_class("openwave-icon-picker")
-        first_child = None
+
+        # Preserve stored icons even when they are no longer offered here.
+        if default_icon:
+            self._selected_icon = default_icon
+        preselect = None
         for icon_name, tooltip in ICON_CHOICES:
-            btn = Gtk.Image.new_from_icon_name(icon_name)
+            btn = Gtk.Image.new_from_icon_name(icons.resolve(icon_name))
             btn.set_pixel_size(28)
             child = Gtk.FlowBoxChild()
             child.set_child(btn)
             child.set_tooltip_text(tooltip)
             child._icon_name = icon_name  # noqa: SLF001
             flow.append(child)
-            if first_child is None:
-                first_child = child
+            if icon_name == self._selected_icon:
+                preselect = child
         flow.connect("selected-children-changed", self._on_icon_selected)
         icon_group.add(flow)
 
-        if first_child is not None:
-            flow.select_child(first_child)
-            self._selected_icon = first_child._icon_name  # noqa: SLF001
+        if preselect is not None:
+            flow.select_child(preselect)
 
+        self._sync_confirm()
         return page
+
+    def _on_binding_changed(self, _row):
+        self._sync_confirm()
+
+    def _sync_confirm(self):
+        """A source that binds nothing can never be metered or routed, so refuse
+        to create one rather than persisting dead config. With no Application
+        row (a capture device) the name is the only requirement."""
+        if self._bindings is not None:
+            # A pending name in the entry counts: confirming without pressing +
+            # first should not silently discard what was typed.
+            pending = self._add_row.get_text().strip() if self._add_row else ""
+            ok = bool(self._bindings or pending)
+        else:
+            ok = bool(self._name_row.get_text().strip())
+        self._confirm_btn.set_sensitive(ok)
+
+    def _rebuild_bindings(self):
+        """Redraw one removable row per bound application."""
+        for row in self._bind_rows:
+            self._bind_group.remove(row)
+        self._bind_rows = []
+
+        for name in self._bindings:
+            row = Adw.ActionRow(title=name)
+            row.add_prefix(Gtk.Image.new_from_icon_name("application-x-executable-symbolic"))
+            rm = Gtk.Button(
+                icon_name="window-close-symbolic", valign=Gtk.Align.CENTER,
+                tooltip_text=f"Stop matching {name}",
+            )
+            rm.add_css_class("flat")
+            rm.connect("clicked", lambda _b, n=name: self._remove_binding(n))
+            row.add_suffix(rm)
+            self._bind_group.add(row)
+            self._bind_rows.append(row)
+
+        if not self._bindings:
+            empty = Adw.ActionRow(
+                title="No applications yet",
+                subtitle="Add one below, or pick from what is playing",
+            )
+            empty.set_sensitive(False)
+            self._bind_group.add(empty)
+            self._bind_rows.append(empty)
+
+        self._bind_group.add(self._add_row)
+        self._bind_rows.append(self._add_row)
+        self._bind_group.add(self._running_btn)
+        self._bind_rows.append(self._running_btn)
+
+        self._populate_running_menu()
+        self._sync_confirm()
+
+    def _populate_running_menu(self):
+        """List what is playing now, excluding names already bound."""
+        box = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL, spacing=2,
+            margin_top=6, margin_bottom=6, margin_start=6, margin_end=6,
+        )
+        bound = {n.casefold() for n in self._bindings}
+        names = []
+        for stream in self._streams:
+            for candidate in (stream.get("app_name"), stream.get("binary")):
+                if candidate and candidate.casefold() not in bound and candidate not in names:
+                    names.append(candidate)
+        if not names:
+            lbl = Gtk.Label(label="Nothing is playing", margin_top=6, margin_bottom=6)
+            lbl.add_css_class("dim-label")
+            box.append(lbl)
+        for name in names:
+            btn = Gtk.Button(label=name, halign=Gtk.Align.FILL)
+            btn.add_css_class("flat")
+            btn.connect("clicked", lambda _b, n=name: self._add_binding(n))
+            box.append(btn)
+        self._running_pop.set_child(box)
+
+    def _add_binding_from_entry(self):
+        text = self._add_row.get_text().strip()
+        if text:
+            self._add_row.set_text("")
+            self._add_binding(text)
+
+    def _add_binding(self, name):
+        if name.casefold() not in {n.casefold() for n in self._bindings}:
+            self._bindings.append(name)
+        self._running_pop.popdown()
+        self._rebuild_bindings()
+
+    def _remove_binding(self, name):
+        self._bindings = [n for n in self._bindings if n != name]
+        self._rebuild_bindings()
+
+    def _group_text(self):
+        row = getattr(self, "_group_row", None)
+        return row.get_text().strip() if row is not None else ""
 
     def _on_icon_selected(self, flow):
         sel = flow.get_selected_children()
@@ -203,8 +640,25 @@ class AddSourceDialog(Adw.Dialog):
             self._selected_icon = getattr(sel[0], "_icon_name", self._selected_icon)
 
     def _on_confirm(self, _btn):
-        if not self._selected_app:
+        # Read the field, not _selected_app: with manual entry the picker's
+        # value is "" and the entry is the only source of truth.
+        if self._bindings is not None:
+            # Fold in anything still sitting in the entry, unconfirmed.
+            self._add_binding_from_entry()
+            app = ", ".join(self._bindings)
+        else:
+            app = ""
+        if self._source is None and not app:
             return
-        name = self._name_row.get_text().strip() or self._selected_app
-        self.emit("source-confirmed", name, self._selected_app, self._selected_icon)
+        name = self._name_row.get_text().strip() or app
+        if not name:
+            return
+        if self._source is not None:
+            # Carry the id so app.py routes this through sources.update() and
+            # the row keeps its persisted per-mix levels.
+            self.emit("source-edited", self._source["id"], name, app,
+                      self._selected_icon, self._group_text())
+        else:
+            self.emit("source-confirmed", name, app, self._selected_icon,
+                      self._group_text())
         self.close()

--- a/wavexlr/sources.py
+++ b/wavexlr/sources.py
@@ -72,6 +72,7 @@ def normalize(records):
     if not isinstance(records, dict):
         raise ValueError("Sources must be an object")
     result = {}
+    live_groups = set()
     for sid, original in records.items():
         safe_id(sid)
         if not isinstance(original, dict) or original.get("id", sid) != sid:
@@ -91,6 +92,12 @@ def normalize(records):
         for field in ("name", "icon_name", "group", "node_name"):
             if not isinstance(source[field], str):
                 raise ValueError(f"Source {field} must be a string")
+        source["group"] = group(source)
+        if source["group"] and not source["muted"]:
+            if source["group"] in live_groups:
+                source["muted"] = True
+            else:
+                live_groups.add(source["group"])
         result[sid] = source
     return result
 

--- a/wavexlr/style.css
+++ b/wavexlr/style.css
@@ -35,3 +35,36 @@
 .openwave-mix-cell:disabled {
     opacity: 0.55;
 }
+.openwave-source-waiting {
+    opacity: 0.55;
+}
+
+.openwave-drop-target {
+  box-shadow: inset 0 3px 0 0 @accent_bg_color;
+}
+
+/* A muted source row: unmistakable scanning down the column, without
+   hiding the controls that un-mute it. */
+.openwave-source-cell.openwave-muted {
+  background-color: alpha(@error_color, 0.12);
+}
+.openwave-muted label,
+label.openwave-muted {
+  color: @error_color;
+}
+.openwave-muted image,
+image.openwave-muted {
+  color: @error_color;
+}
+
+/* Exclusivity group badge on a source row. */
+.openwave-group-badge {
+  color: @accent_color;
+  font-size: 0.75em;
+  opacity: 0.9;
+}
+
+/* Releasing here groups the dragged row with this one, rather than moving it. */
+.openwave-drop-group {
+  box-shadow: inset 0 0 0 2px @accent_bg_color;
+}

--- a/wavexlr/tray.py
+++ b/wavexlr/tray.py
@@ -1,6 +1,10 @@
 """StatusNotifierItem tray icon via D-Bus (no GTK3 dependency)."""
 
+import logging
+
 from gi.repository import Gio, GLib
+
+from . import icons
 
 ITEM_XML = """
 <node>
@@ -25,6 +29,11 @@ ITEM_XML = """
       <arg name="x" type="i" direction="in"/>
       <arg name="y" type="i" direction="in"/>
     </method>
+    <signal name="NewIcon"/>
+    <signal name="NewToolTip"/>
+    <signal name="NewStatus">
+      <arg name="status" type="s" direction="out"/>
+    </signal>
   </interface>
 </node>
 """
@@ -85,81 +94,217 @@ MENU_XML = """
 """
 
 
-class TrayIcon:
-    """Minimal StatusNotifierItem tray icon."""
+# Packaged icons resolve to stock themed icons when running from a checkout.
+ICON_LIVE = "openwave-symbolic"
+ICON_MUTED = "openwave-muted-symbolic"
+ICON_ABSENT = "openwave-attention-symbolic"
 
-    def __init__(self, on_activate=None, on_mute=None, on_quit=None):
+
+def compute(connected, hardware_muted, row_muted, display_name=None):
+    """Return tray state; either hardware or matrix mute means not captured."""
+    if not connected:
+        return {
+            "icon": ICON_ABSENT,
+            "status": "Active",
+            "tooltip": "No device connected",
+            "mute_label": "Mute Mic",
+            "mute_enabled": False,
+            "muted": False,
+        }
+
+    muted = bool(hardware_muted or row_muted)
+    if muted:
+        if hardware_muted and row_muted:
+            detail = "Muted (hardware and matrix)"
+        elif hardware_muted:
+            detail = "Muted (hardware)"
+        else:
+            detail = "Muted (matrix row)"
+    else:
+        detail = "Live"
+
+    return {
+        "icon": ICON_MUTED if muted else ICON_LIVE,
+        "status": "Active",
+        "tooltip": f"{display_name}: {detail}" if display_name else detail,
+        "mute_label": "Unmute Mic" if muted else "Mute Mic",
+        "mute_enabled": True,
+        "muted": muted,
+    }
+
+
+class TrayIcon:
+    """StatusNotifierItem with no-argument activate/open/mute/quit callbacks.
+
+    register() returns False if no host can display it. unregister() releases
+    both exported objects; call it on application shutdown. set_state accepts
+    the selected device's optional display_name for its tooltip.
+    """
+
+    def __init__(self, on_activate=None, on_mute=None, on_quit=None,
+                 on_open=None):
         self._on_activate = on_activate
+        # Separate from on_activate: clicking the icon may toggle, but the
+        # menu item reads "Open OpenWave" and must open. It is also the only
+        # way back to a window that was started hidden.
+        self._on_open = on_open or on_activate
         self._on_mute = on_mute
         self._on_quit = on_quit
         self._bus = None
         self._item_reg_id = None
         self._menu_reg_id = None
-        self._name_id = None
         self._revision = 1
         self._menu_items = {}  # id -> properties dict
+        # Nothing is known before the first poll, and "no device" is the
+        # honest reading of that -- not "live", which would be a guess in the
+        # one direction this icon must never guess.
+        self._state = compute(False, False, False)
+
+    @staticmethod
+    def host_available(bus=None):
+        """True when something on this session bus will actually draw us.
+
+        Asked before anything is allowed to depend on the tray existing.
+        GNOME ships no StatusNotifier host of its own -- the watcher name
+        appears only when an AppIndicator extension is installed -- so on a
+        stock GNOME desktop a tray icon is registered successfully and drawn
+        nowhere, which is indistinguishable from working right up until the
+        window is hidden into it.
+        """
+        try:
+            bus = bus or Gio.bus_get_sync(Gio.BusType.SESSION, None)
+            reply = bus.call_sync(
+                "org.freedesktop.DBus", "/org/freedesktop/DBus",
+                "org.freedesktop.DBus", "NameHasOwner",
+                GLib.Variant("(s)", ("org.kde.StatusNotifierWatcher",)),
+                GLib.VariantType.new("(b)"), Gio.DBusCallFlags.NONE, 2000,
+                None,
+            )
+            if not reply.unpack()[0]:
+                return False
+            reply = bus.call_sync(
+                "org.kde.StatusNotifierWatcher", "/StatusNotifierWatcher",
+                "org.freedesktop.DBus.Properties", "Get",
+                GLib.Variant("(ss)", (
+                    "org.kde.StatusNotifierWatcher",
+                    "IsStatusNotifierHostRegistered")),
+                GLib.VariantType.new("(v)"), Gio.DBusCallFlags.NONE, 2000,
+                None,
+            )
+        except GLib.Error:
+            return False
+        return bool(reply.unpack()[0])
 
     def register(self):
-        self._bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        """Publish the tray item only when a host is registered to draw it."""
+        self.unregister()
+        try:
+            bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+            if not self.host_available(bus):
+                return False
+            self._bus = bus
+            self._build_menu_items()
+            menu_info = Gio.DBusNodeInfo.new_for_xml(MENU_XML)
+            self._menu_reg_id = bus.register_object(
+                "/MenuBar", menu_info.interfaces[0],
+                self._on_menu_call, self._on_menu_get_property, None)
+            item_info = Gio.DBusNodeInfo.new_for_xml(ITEM_XML)
+            self._item_reg_id = bus.register_object(
+                "/StatusNotifierItem", item_info.interfaces[0],
+                self._on_item_call, self._on_item_get_property, None)
+            bus.call_sync(
+                "org.kde.StatusNotifierWatcher", "/StatusNotifierWatcher",
+                "org.kde.StatusNotifierWatcher", "RegisterStatusNotifierItem",
+                GLib.Variant("(s)", (bus.get_unique_name(),)),
+                None, Gio.DBusCallFlags.NONE, 2000, None)
+            return True
+        except GLib.Error:
+            self.unregister()
+            return False
+
+    def unregister(self):
+        """Release exports, including partially completed registration."""
+        bus, self._bus = self._bus, None
+        for attr in ("_item_reg_id", "_menu_reg_id"):
+            registration = getattr(self, attr)
+            setattr(self, attr, None)
+            if bus is not None and registration is not None:
+                bus.unregister_object(registration)
+
+    @staticmethod
+    def _invoke(callback):
+        if callback is not None:
+            callback()
+        return False
+
+    def set_state(self, connected, hardware_muted=False, row_muted=False,
+                  display_name=None):
+        """Show what the microphone is actually doing. Returns True if it moved.
+
+        Announced only on a real change: the poll behind this runs at 10 Hz,
+        and a host redraws on every NewIcon it is handed.
+        """
+        new = compute(connected, hardware_muted, row_muted, display_name)
+        if new == self._state:
+            return False
+
+        icon_changed = new["icon"] != self._state["icon"]
+        tooltip_changed = new["tooltip"] != self._state["tooltip"]
+        menu_changed = (
+            new["mute_label"] != self._state["mute_label"]
+            or new["mute_enabled"] != self._state["mute_enabled"]
+        )
+        self._state = new
         self._build_menu_items()
 
-        # Register the menu object
-        menu_info = Gio.DBusNodeInfo.new_for_xml(MENU_XML)
-        self._menu_reg_id = self._bus.register_object(
-            "/MenuBar",
-            menu_info.interfaces[0],
-            self._on_menu_call,
-            self._on_menu_get_property,
-            None,
-        )
+        if self._bus is None:
+            return True  # not registered yet; the values are already right
+        if icon_changed:
+            self._emit_item("NewIcon", None)
+        if tooltip_changed:
+            self._emit_item("NewToolTip", None)
+        if menu_changed:
+            self._emit_menu_properties(2)
+        return True
 
-        # Register the SNI object
-        item_info = Gio.DBusNodeInfo.new_for_xml(ITEM_XML)
-        self._item_reg_id = self._bus.register_object(
-            "/StatusNotifierItem",
-            item_info.interfaces[0],
-            self._on_item_call,
-            self._on_item_get_property,
-            None,
-        )
-
-        # Own a unique bus name for the item
-        self._name_id = Gio.bus_own_name_on_connection(
-            self._bus,
-            "org.kde.StatusNotifierItem-openwave",
-            Gio.BusNameOwnerFlags.NONE,
-            None, None,
-        )
-
-        # Register with the StatusNotifierWatcher
+    def _emit_item(self, name, params):
+        """A host that has gone away must not take the application with it."""
         try:
-            self._bus.call_sync(
-                "org.kde.StatusNotifierWatcher",
-                "/StatusNotifierWatcher",
-                "org.kde.StatusNotifierWatcher",
-                "RegisterStatusNotifierItem",
-                GLib.Variant("(s)", ("org.kde.StatusNotifierItem-openwave",)),
-                None,
-                Gio.DBusCallFlags.NONE,
-                -1, None,
-            )
-        except Exception:
-            pass  # no watcher running — tray won't show but app still works
+            self._bus.emit_signal(
+                None, "/StatusNotifierItem", "org.kde.StatusNotifierItem",
+                name, params)
+        except GLib.Error as e:
+            logging.debug("tray: could not emit %s: %s", name, e)
+
+    def _emit_menu_properties(self, item_id):
+        props = self._menu_items.get(item_id, {})
+        try:
+            self._bus.emit_signal(
+                None, "/MenuBar", "com.canonical.dbusmenu",
+                "ItemsPropertiesUpdated",
+                GLib.Variant("(a(ia{sv})a(ias))", ([(item_id, props)], [])))
+        except GLib.Error as e:
+            logging.debug("tray: could not emit ItemsPropertiesUpdated: %s", e)
 
     def _on_item_call(self, conn, sender, path, iface, method, params, invocation):
-        if method == "Activate":
-            if self._on_activate:
-                self._on_activate()
         invocation.return_value(None)
+        if method == "Activate":
+            GLib.idle_add(self._invoke, self._on_activate)
+        elif method == "SecondaryActivate":
+            GLib.idle_add(self._invoke, self._on_mute)
+        elif method == "ContextMenu":
+            GLib.idle_add(self._invoke, self._on_open)
 
     def _on_item_get_property(self, conn, sender, path, iface, prop):
         props = {
             "Category": GLib.Variant("s", "Hardware"),
             "Id": GLib.Variant("s", "openwave"),
             "Title": GLib.Variant("s", "OpenWave"),
-            "Status": GLib.Variant("s", "Active"),
-            "IconName": GLib.Variant("s", "audio-input-microphone-symbolic"),
-            "ToolTip": GLib.Variant("(sa(iiay)ss)", ("", [], "OpenWave", "Elgato Wave Control")),
+            "Status": GLib.Variant("s", self._state["status"]),
+            "IconName": GLib.Variant("s", icons.resolve(self._state["icon"])),
+            "ToolTip": GLib.Variant(
+                "(sa(iiay)ss)",
+                ("", [], "OpenWave", self._state["tooltip"])),
             "Menu": GLib.Variant("o", "/MenuBar"),
             "ItemIsMenu": GLib.Variant("b", False),
         }
@@ -173,13 +318,13 @@ class TrayIcon:
                 "label": GLib.Variant("s", "Open OpenWave"),
                 "visible": GLib.Variant("b", True),
                 "enabled": GLib.Variant("b", True),
-                "icon-name": GLib.Variant("s", "audio-input-microphone-symbolic"),
+                "icon-name": GLib.Variant("s", icons.resolve(ICON_LIVE)),
             },
             2: {
-                "label": GLib.Variant("s", "Mute Mic"),
+                "label": GLib.Variant("s", self._state["mute_label"]),
                 "visible": GLib.Variant("b", True),
-                "enabled": GLib.Variant("b", True),
-                "icon-name": GLib.Variant("s", "microphone-sensitivity-muted-symbolic"),
+                "enabled": GLib.Variant("b", self._state["mute_enabled"]),
+                "icon-name": GLib.Variant("s", icons.resolve(ICON_MUTED)),
             },
             3: {
                 "type": GLib.Variant("s", "separator"),
@@ -231,14 +376,13 @@ class TrayIcon:
         elif method == "Event":
             item_id = params[0]
             event_id = params[1]
-            if event_id == "clicked":
-                if item_id == 1 and self._on_activate:
-                    self._on_activate()
-                elif item_id == 2 and self._on_mute:
-                    self._on_mute()
-                elif item_id == 4 and self._on_quit:
-                    self._on_quit()
             invocation.return_value(None)
+            if event_id == "clicked":
+                callback = {1: self._on_open, 4: self._on_quit}.get(item_id)
+                if item_id == 2 and self._state["mute_enabled"]:
+                    callback = self._on_mute
+                if callback is not None:
+                    GLib.idle_add(self._invoke, callback)
 
         elif method == "AboutToShow":
             invocation.return_value(GLib.Variant("(b)", (False,)))


### PR DESCRIPTION
Reviewed replacement for #8, part 7/12. Original contribution: Zedwil / NyleGarcia.

## Stack
Depends on https://github.com/rikkichy/openwave/pull/18; base is `pr8-06-mix-outputs`. Merge the parent first. These are ordered review slices, not independent cherry-picks.

## Scope
- Integrate the routing workers with dynamic source/mix dialogs, ordering, renaming, confirmed deletion and exclusive source groups.
- Keep hardware writes on their captured device identity, cancel stale gestures, and preserve surviving devices during hotplug.
- Bound raw-meter process/thread lifetimes and expose per-source/per-mix levels without blocking GTK.

## Verification
Actual GTK windows under Xvfb: source/mix dialogs, group switching, trim changes, reorder/rename preserving sends, confirmed deletion and persistence. Two-device identity/hotplug smoke used simulated device I/O; no physical phantom-power test is claimed.

Runtime scenarios were exercised on the integrated stack. Hardware-facing tests do not imply physical USB/phantom-power certification.
