### PR TITLE
Add safe scenes and typed session-bus mixer controls

### DIFF
--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -1,0 +1,156 @@
+import copy
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from wavexlr import scenes
+
+
+class SceneStoreTests(unittest.TestCase):
+    def setUp(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.path = Path(directory.name) / "scenes.json"
+
+    def test_corrupt_storage_survives_read_and_mutation_attempts(self):
+        payloads = (
+            b'{"scenes":',
+            b'{"scenes": []}',
+            b'{"scenes": {"bad": null}}',
+            b'{"scenes": {"bad": {"name": 42}}}',
+            b'{"scenes": {"bad": {"name": "Bad", "sources": []}}}',
+            b'{"scenes": {"bad": {"name": "Bad", "cells": {"mic.main": []}}}}',
+            b'{"scenes": {"bad": {"name": "Bad", "outputs": {"main": 1}}}}',
+            b'{"scenes": {"bad": {"name": "Bad", "sources": {"mic": {"muted": "false"}}}}}',
+            b'\xff',
+        )
+        for payload in payloads:
+            with self.subTest(payload=payload):
+                self.path.write_bytes(payload)
+                for operation in (
+                    lambda: scenes.load(self.path),
+                    lambda: scenes.put("New", {}, self.path),
+                    lambda: scenes.remove("bad", self.path),
+                ):
+                    with self.assertRaises(scenes.Unreadable):
+                        operation()
+                    self.assertEqual(self.path.read_bytes(), payload)
+                    self.assertEqual(set(self.path.parent.iterdir()), {self.path})
+
+    def test_explicit_empty_maps_survive_round_trip_and_removal(self):
+        self.assertEqual(scenes.load(self.path), {})
+        self.assertFalse(self.path.exists())
+        scenes.save({}, self.path)
+        self.assertEqual(scenes.load(self.path), {})
+        payload = {section: {} for section in (
+            "sources", "cells", "outputs", "volumes", "hardware",
+        )}
+        sid = scenes.put("Quiet desk", payload, self.path)
+        self.assertEqual(scenes.load(self.path), {
+            sid: {"name": "Quiet desk", **payload},
+        })
+        self.assertTrue(scenes.remove(sid, self.path))
+        self.assertFalse(scenes.remove(sid, self.path))
+        self.assertEqual(scenes.load(self.path), {})
+
+    def test_named_levels_replace_without_defining_sources_or_mixes(self):
+        payload = {
+            "sources": {"mic": {"level": 0.75, "muted": False}},
+            "cells": {"mic.personal": {"volume": 0.5, "muted": True}},
+            "outputs": {"personal": "alsa_output.headphones", "stream": "none"},
+            "volumes": {"personal": {"volume": 1, "muted": False}},
+            "hardware": {"wave_xlr:abc": {
+                "gain_raw": 10240, "mute": False, "hp_volume_db": -12.5,
+                "low_impedance": True, "monitor_mix": 12800,
+            }},
+        }
+        sid = scenes.put("On Air!", payload, self.path)
+        self.assertEqual(sid, "on-air")
+        self.assertEqual(scenes.load(self.path)[sid], {"name": "On Air!", **payload})
+        self.assertNotIn("name", payload)
+        scenes.put("On Air!", {"sources": {}}, self.path)
+        self.assertEqual(scenes.load(self.path), {
+            sid: {"name": "On Air!", "sources": {}},
+        })
+        with self.assertRaises(ValueError):
+            scenes.put("Definitions", {"mixes": {"new": {}}}, self.path)
+        self.assertNotIn("definitions", scenes.load(self.path))
+
+    def test_invalid_numbers_are_rejected_without_losing_valid_scenes(self):
+        invalid_entries = (
+            ("sources", "mic", {"level": True}),
+            ("sources", "mic", {"level": "0.5"}),
+            ("cells", "mic.main", {"volume": float("nan")}),
+            ("volumes", "main", {"volume": float("inf")}),
+            ("sources", "mic", {"level": -0.01}),
+            ("cells", "mic.main", {"volume": 1.01}),
+            ("hardware", "wave_xlr:abc", {"gain_raw": 1.5}),
+            ("hardware", "wave_xlr:abc", {"gain_raw": 65536}),
+            ("hardware", "wave_xlr:abc", {"monitor_mix": -1}),
+            ("hardware", "wave_xlr:abc", {"hp_volume_db": -129}),
+        )
+        scenes.put("Keep", {}, self.path)
+        original = self.path.read_bytes()
+        for section, key, entry in invalid_entries:
+            with self.subTest(section=section, entry=entry):
+                payload = {section: {key: entry}}
+                with self.assertRaises(ValueError):
+                    scenes.put("Invalid", payload, self.path)
+                self.assertEqual(self.path.read_bytes(), original)
+                bad_path = self.path.parent / "invalid.json"
+                bad_bytes = json.dumps({"scenes": {
+                    "invalid": {"name": "Invalid", **payload},
+                }}).encode()
+                bad_path.write_bytes(bad_bytes)
+                with self.assertRaises(scenes.Unreadable):
+                    scenes.load(bad_path)
+                self.assertEqual(bad_path.read_bytes(), bad_bytes)
+
+    def test_phantom_power_is_not_scene_state(self):
+        payload = {"hardware": {"wave_xlr:abc": {"phantom": False}}}
+        original = copy.deepcopy(payload)
+        with self.assertRaises(ValueError):
+            scenes.put("Power", payload, self.path)
+        self.assertEqual(payload, original)
+        self.assertFalse(self.path.exists())
+
+
+class HardwareEntryTests(unittest.TestCase):
+    def test_exact_serial_wins_over_legacy_even_with_duplicate_models(self):
+        hardware = {
+            "dock": {"gain_raw": 100},
+            scenes.hardware_key("dock", "one"): {"gain_raw": 200},
+            scenes.hardware_key("dock", "two"): {},
+        }
+        self.assertEqual(scenes.pick_hardware_entry(
+            hardware, "dock", "one", profile_count=2,
+        ), {"gain_raw": 200})
+        self.assertEqual(scenes.pick_hardware_entry(
+            hardware, "dock", "two", profile_count=2,
+        ), {})
+
+    def test_replacement_unit_never_borrows_another_serials_levels(self):
+        hardware = {"dock:old": {"gain_raw": 500}}
+        self.assertIsNone(scenes.pick_hardware_entry(hardware, "dock", "new"))
+        self.assertIsNone(scenes.pick_hardware_entry(hardware, "dock", ""))
+        self.assertIsNone(scenes.pick_hardware_entry(hardware, "dock", None))
+
+    def test_legacy_model_requires_exactly_one_connected_unit(self):
+        hardware = {scenes.hardware_key("dock", ""): {"gain_raw": 250}}
+        for serial in ("one", "", None):
+            with self.subTest(serial=serial):
+                self.assertEqual(scenes.pick_hardware_entry(
+                    hardware, "dock", serial,
+                ), {"gain_raw": 250})
+                self.assertIsNone(scenes.pick_hardware_entry(
+                    hardware, "dock", serial, profile_count=2,
+                ))
+                self.assertIsNone(scenes.pick_hardware_entry(
+                    hardware, "dock", serial, profile_count=0,
+                ))
+        self.assertIsNone(scenes.pick_hardware_entry(hardware, "wave3", "one"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 
 from wavexlr import scenes
+from wavexlr.mixer import Mixer
 
 
 class SceneStoreTests(unittest.TestCase):
@@ -114,6 +115,49 @@ class SceneStoreTests(unittest.TestCase):
             scenes.put("Power", payload, self.path)
         self.assertEqual(payload, original)
         self.assertFalse(self.path.exists())
+
+
+class SceneRecallTests(unittest.TestCase):
+    def setUp(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.path = Path(directory.name) / "matrix.json"
+        self.mixer = Mixer(config_path=str(self.path))
+        self.addCleanup(self.mixer.stop)
+        self.mixer.set_mixes({"bus": {"name": "Broadcast", "sink": "openwave_bus"}})
+        self.mixer.set_sources({
+            "primary": {"group": "voice", "level": 0.7},
+            "backup": {"group": "voice", "muted": True},
+        })
+
+    def test_partial_recall_preserves_topology_and_group_exclusion(self):
+        skipped = self.mixer.apply_scene({
+            "sources": {"backup": {"muted": False, "level": 0.4}, "missing": {"level": 1}},
+            "cells": {"backup.bus": {"volume": 0.6}, "missing.bus": {"volume": 1}},
+            "outputs": {"bus": "unplugged_headphones"},
+            "volumes": {"bus": {"volume": 0.3, "muted": True}},
+        })
+        state = self.mixer.scene_state()
+        self.assertEqual(set(state["sources"]), {"primary", "backup"})
+        self.assertTrue(state["sources"]["primary"]["muted"])
+        self.assertEqual(state["sources"]["backup"], {"level": 0.4, "muted": False})
+        self.assertEqual(state["cells"]["backup.bus"], {"volume": 0.6, "muted": False})
+        self.assertEqual(set(state["cells"]), {"primary.bus", "backup.bus"})
+        self.assertEqual(state["volumes"]["bus"], {"volume": 0.3, "muted": True})
+        self.assertIsNone(self.mixer.resolve_output("bus", sinks=[]))
+        self.assertEqual(self.mixer.get_output("bus"), "unplugged_headphones")
+        self.assertIn("missing", " ".join(skipped))
+
+    def test_invalid_recall_cannot_apply_an_earlier_valid_section(self):
+        before = self.mixer.scene_state()
+        persisted = self.path.read_bytes()
+        with self.assertRaises(ValueError):
+            self.mixer.apply_scene({
+                "sources": {"primary": {"level": 0}},
+                "volumes": {"bus": {"volume": float("nan")}},
+            })
+        self.assertEqual(self.mixer.scene_state(), before)
+        self.assertEqual(self.path.read_bytes(), persisted)
 
 
 class HardwareEntryTests(unittest.TestCase):

--- a/wavexlr/app.py
+++ b/wavexlr/app.py
@@ -9,6 +9,7 @@ import logging
 import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
+from collections import Counter
 
 from .device import WaveDevice, DeviceUnresponsiveError, scan
 from .audio import SOURCE_MATCHES
@@ -18,6 +19,7 @@ from .mixmatrix import MixMatrix
 from .mixdialog import MixDialog
 from .sourcedialog import AddSourceDialog
 from . import paths, setup, service, sources as sources_module, mixes as mixes_module, desktop as desktop_module
+from . import scenes as scenes_module
 
 logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
 KNOB_LABELS = {"gain": "Gain", "hp": "Headphones", "mix": "Monitor Mix"}
@@ -104,6 +106,12 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         service_pop.set_child(service_box)
         self.service_btn.set_popover(service_pop)
         header.pack_start(self.service_btn)
+        self.scene_btn = Gtk.MenuButton(label="Scenes")
+        header.pack_start(self.scene_btn)
+        save_scene = Gio.SimpleAction.new("save-scene-as", None)
+        save_scene.connect("activate", lambda *_: self.prompt_save_scene())
+        self.add_action(save_scene)
+        self._rebuild_scene_menu()
         refresh = Gtk.Button(icon_name="view-refresh-symbolic", tooltip_text="Reconnect")
         refresh.connect("clicked", lambda _: self._try_connect())
         header.pack_end(refresh)
@@ -473,14 +481,17 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         if not self._selector_updating and 0 <= index < len(self._devs):
             self._select_device(self._devs[index])
 
-    def _select_device(self, device):
-        # A delayed slider send belongs to the previous device, never the new
-        # selection. Already queued operations captured their device object.
+    def _cancel_device_edits(self):
         for name in ("_gain_timeout", "_hp_timeout", "_mix_timeout"):
             source_id = getattr(self, name)
             if source_id:
                 GLib.source_remove(source_id)
                 setattr(self, name, None)
+
+    def _select_device(self, device):
+        # A delayed slider send belongs to the previous device, never the new
+        # selection. Already queued operations captured their device object.
+        self._cancel_device_edits()
         self.dev = device
         self._last_state = None
         if device is self._empty_device:
@@ -1098,6 +1109,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         sinks, default = self.mixer.output_sinks(), self.mixer.default_sink()
         for mid in self._mixes:
             self.matrix.set_mix_outputs(mid, *self._output_entries(mid, sinks, default))
+        self._push_remote_state()
 
     def _on_mix_output_changed(self, _matrix, mix_id, output):
         self.mixer.set_output(mix_id, output)
@@ -1121,6 +1133,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self._mixes = mixes_module.update(self._mixes, mix_id, name=name, icon_name=icon_name)
         self.mixer.set_mixes(self._mixes)
         self.matrix.set_mix(mix_id, title=name, icon_name=icon_name)
+        self._push_remote_state()
 
     def _cancel_cell_edits(self, source_id=None, mix_id=None):
         for key, timer in list(self._cell_debounce_ids.items()):
@@ -1146,6 +1159,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
                 and not cells.get(f"{sid}.{mid}", {}).get("muted")
                 for sid, source in self._sources.items())
             self.matrix.set_mix_empty(mid, not fed)
+        self._push_remote_state()
 
     def _refresh_device_meter(self, source_id, source):
         node = source["node_name"]
@@ -1191,6 +1205,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         for mid in self._mixes:
             self._wire_cell(source["id"], mid)
         self._refresh_source_meter(source["id"])
+        self._refresh_mix_emptiness()
 
     def _add_discovered_inputs(self, captures):
         waves = [item for item in captures if item["name"].startswith(SOURCE_MATCHES)]
@@ -1244,6 +1259,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self.meter.stop(source_id)
         self._meter_targets.pop(source_id, None)
         self._refresh_source_meter(source_id)
+        self._refresh_mix_emptiness()
 
     def _on_move_source_clicked(self, _matrix, source_id, delta):
         if source_id not in self._sources:
@@ -1396,6 +1412,211 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self._refresh_mix_emptiness()
         return muted
 
+    def scene_names(self):
+        return {sid: scene["name"] for sid, scene in scenes_module.load().items()}
+
+    def _hardware_scene_state(self):
+        keys = [scenes_module.hardware_key(dev.profile.key, dev.info.get("serial", ""))
+                for dev in self._devs]
+        counts = Counter(keys)
+        result = {}
+        for dev, key in zip(self._devs, keys):
+            if counts[key] != 1:
+                continue
+            keep = ["gain_raw", "mute", "hp_volume_db"]
+            if dev.profile.has_low_z:
+                keep.append("low_impedance")
+            if dev.profile.has_monitor_mix:
+                keep.append("monitor_mix")
+            state = self._device_states.get(dev, {})
+            result[key] = {field: state[field] for field in keep if field in state}
+        return result
+
+    def save_scene(self, name):
+        if not name.strip():
+            raise ValueError("A scene needs a name")
+        payload = self.mixer.scene_state()
+        payload["hardware"] = self._hardware_scene_state()
+        sid = scenes_module.put(name.strip(), payload)
+        self._rebuild_scene_menu()
+        return sid
+
+    def _scene_hardware_jobs(self, hardware):
+        profiles = Counter(dev.profile.key for dev in self._devs)
+        identities = Counter((dev.profile.key, dev.info.get("serial", ""))
+                             for dev in self._devs)
+        jobs, used = [], set()
+        for dev in self._devs:
+            serial = dev.info.get("serial", "")
+            if identities[(dev.profile.key, serial)] != 1:
+                continue
+            entry = scenes_module.pick_hardware_entry(
+                hardware, dev.profile.key, serial, profile_count=profiles[dev.profile.key])
+            if entry is None:
+                continue
+            serial_key = scenes_module.hardware_key(dev.profile.key, serial)
+            key = serial_key if serial_key in hardware else dev.profile.key
+            jobs.append((dev, entry, key))
+            used.add(key)
+        return jobs, ["hardware " + key for key in hardware if key not in used]
+
+    def apply_scene(self, sid):
+        scene = scenes_module.load().get(sid)
+        if scene is None:
+            raise KeyError("Unknown scene: " + sid)
+        self._cancel_cell_edits()
+        self._cancel_device_edits()
+        jobs, skipped = self._scene_hardware_jobs(scene.get("hardware", {}))
+        # A row's explicit mute wins. Hardware-only recalls still participate in
+        # exclusive groups rather than opening a second microphone behind them.
+        for dev, entry, _key in jobs:
+            if "mute" in entry:
+                for source_id, source in self._sources.items():
+                    if self._device_for_source(source) is dev:
+                        scene.setdefault("sources", {}).setdefault(source_id, {}).setdefault(
+                            "muted", entry["mute"])
+        try:
+            skipped += self.mixer.apply_scene(scene)
+        except OSError as error:
+            skipped.append("mix persistence")
+            self._show_error("Unable to save recalled mix levels", error)
+        levels = self.mixer.scene_state()
+        previous = self._sources
+        self._sources = {source_id: dict(source, **levels["sources"][source_id])
+                         for source_id, source in previous.items()}
+        try:
+            sources_module.save(self._sources)
+        except OSError as error:
+            skipped.append("source persistence")
+            self._show_error("Unable to save recalled source levels", error)
+        for source_id, source in self._sources.items():
+            row = self.matrix.source(source_id)
+            row.set_volume(source["level"])
+            row.set_muted(source["muted"])
+            if source["muted"] != previous[source_id]["muted"]:
+                self._sync_hw_mute(source, source["muted"])
+            for mix_id in self._mixes:
+                value = levels["cells"][f"{source_id}.{mix_id}"]
+                cell = self.matrix.cell(source_id, mix_id)
+                cell.set_volume(value["volume"])
+                cell.set_muted(value["muted"])
+        for mix_id, value in levels["volumes"].items():
+            self.matrix.set_mix_volume(mix_id, value["volume"])
+        self._apply_scene_hardware(jobs, skipped)
+        self._refresh_outputs()
+        self._refresh_mix_emptiness()
+        self._notify_tray()
+        self.scene_btn.set_tooltip_text("Skipped: " + ", ".join(skipped) if skipped else None)
+        if skipped:
+            logging.warning("Scene %s skipped: %s", sid, ", ".join(skipped))
+        return skipped
+
+    def _apply_scene_hardware(self, jobs, skipped):
+        for dev, entry, key in jobs:
+            commands = []
+            for field, method in (("gain_raw", "set_gain_raw"), ("mute", "set_mute"),
+                                  ("hp_volume_db", "set_hp_volume_db"),
+                                  ("low_impedance", "set_low_impedance"),
+                                  ("monitor_mix", "set_monitor_mix")):
+                if field not in entry:
+                    continue
+                value = entry[field]
+                if field == "gain_raw":
+                    if (self.gain_lock.get_active() and dev is self.dev) or value > dev.profile.gain_max:
+                        skipped.append(f"hardware {key}: gain locked or out of range")
+                        continue
+                if field == "low_impedance" and not dev.profile.has_low_z:
+                    skipped.append(f"hardware {key}: low impedance unsupported")
+                    continue
+                if field == "monitor_mix" and (not dev.profile.has_monitor_mix or value > dev.profile.mix_max):
+                    skipped.append(f"hardware {key}: monitor mix unsupported or out of range")
+                    continue
+                if field == "mute":
+                    bound = [source for source in self._sources.values()
+                             if self._device_for_source(source) is dev]
+                    if bound:
+                        value = all(source["muted"] for source in bound)
+                commands.append((method, value))
+            if not commands:
+                continue
+            def push(device=dev, changes=commands):
+                for method, value in changes:
+                    getattr(device, method)(value)
+                return device.get_all()
+            self._usb_async(push, lambda state, device=dev: self._on_poll_result(device, state),
+                lambda error, device=dev: self._on_device_error(device, error), device=dev)
+
+    def delete_scene(self, sid):
+        removed = scenes_module.remove(sid)
+        self._rebuild_scene_menu()
+        return removed
+
+    def _rebuild_scene_menu(self):
+        menu = Gio.Menu()
+        try:
+            names = self.scene_names()
+        except scenes_module.Unreadable as error:
+            self.scene_btn.set_tooltip_text(str(error))
+            menu.append("Scene store cannot be read", None)
+            self.scene_btn.set_menu_model(menu)
+            logging.warning("%s", error)
+            return
+        recall, delete = Gio.Menu(), Gio.Menu()
+        for sid, name in sorted(names.items(), key=lambda item: item[1].casefold()):
+            for section, action in ((recall, "app.apply-scene"), (delete, "app.delete-scene")):
+                item = Gio.MenuItem.new(name, None)
+                item.set_action_and_target_value(action, GLib.Variant("s", sid))
+                section.append_item(item)
+        if names:
+            menu.append_section(None, recall)
+        manage = Gio.Menu()
+        manage.append("Save current as…", "win.save-scene-as")
+        if names:
+            manage.append_submenu("Delete scene", delete)
+        menu.append_section(None, manage)
+        self.scene_btn.set_menu_model(menu)
+        action = self.get_application().lookup_action("scenes")
+        if action is not None:
+            action.set_state(GLib.Variant("s", json.dumps(names)))
+
+    def prompt_save_scene(self):
+        dialog = Adw.AlertDialog(heading="Save Scene",
+            body="Save trims, sends, mutes, outputs, masters and cached device levels. "
+                 "Phantom power is excluded. Saving the same name replaces it.")
+        entry = Gtk.Entry(placeholder_text="Streaming")
+        dialog.set_extra_child(entry)
+        dialog.add_response("cancel", "Cancel")
+        dialog.add_response("save", "Save")
+        dialog.set_response_enabled("save", False)
+        entry.connect("changed", lambda widget: dialog.set_response_enabled(
+            "save", bool(widget.get_text().strip())))
+        dialog.set_response_appearance("save", Adw.ResponseAppearance.SUGGESTED)
+        dialog.set_default_response("save")
+        def done(alert, result):
+            if alert.choose_finish(result) == "save":
+                try:
+                    self.save_scene(entry.get_text())
+                except (OSError, ValueError, scenes_module.Unreadable) as error:
+                    self._show_error("Unable to save scene", error)
+        dialog.choose(self, None, done)
+
+    def remote_snapshot(self):
+        levels = self.mixer.scene_state()
+        return json.dumps({
+            "sources": [dict(id=sid, name=source["name"], kind=sources_module.kind(source),
+                             group=sources_module.group(source), **levels["sources"][sid])
+                        for sid, source in self._sources.items()],
+            "mixes": [dict(id=mid, name=mix["name"], sink=mix["sink"])
+                      for mid, mix in self._mixes.items()],
+            "cells": levels["cells"], "outputs": levels["outputs"],
+            "volumes": levels["volumes"], "groups": self.source_groups(),
+        }, allow_nan=False)
+
+    def _push_remote_state(self):
+        application = self.get_application()
+        if isinstance(application, WaveXLRApp):
+            application.push_states()
+
 
 class WaveXLRApp(Adw.Application):
     def __init__(self):
@@ -1406,10 +1627,65 @@ class WaveXLRApp(Adw.Application):
         self._window = None
         self._start_hidden = False
         self._tray = None
+        self._register_remote_actions()
         self.add_main_option(
             "hide", 0, GLib.OptionFlags.NONE, GLib.OptionArg.NONE,
             "Start hidden in system tray", None,
         )
+
+    def _register_remote_actions(self):
+        mutations = {
+            "switch-group": ("s", "switch_group"),
+            "set-source-level": ("(sd)", "set_source_volume"),
+            "toggle-source-mute": ("s", "toggle_source_mute"),
+            "set-cell-level": ("(ssd)", "set_cell_volume"),
+            "toggle-cell-mute": ("(ss)", "toggle_cell_mute"),
+            "apply-scene": ("s", "apply_scene"),
+            "save-scene": ("s", "save_scene"),
+            "delete-scene": ("s", "delete_scene"),
+        }
+        for name, (signature, method) in mutations.items():
+            action = Gio.SimpleAction.new(name, GLib.VariantType.new(signature))
+            action.connect("activate", self._remote_activate, method)
+            self.add_action(action)
+        self._remote_getters = {
+            "snapshot": ("s", lambda: self._window.remote_snapshot()),
+            "source-groups": ("as", lambda: self._window.source_groups()),
+            "scenes": ("s", lambda: json.dumps(self._window.scene_names())),
+            "levels": ("s", lambda: self._window.remote_levels()),
+        }
+        for name, (signature, _getter) in self._remote_getters.items():
+            action = Gio.SimpleAction.new_stateful(name, None,
+                GLib.Variant(signature, [] if signature == "as" else "{}"))
+            action.connect("activate", self._remote_read)
+            # Published telemetry is read-only; clients cannot spoof it through
+            # org.gtk.Actions.SetState.
+            action.connect("change-state", lambda *_: None)
+            self.add_action(action)
+
+    def _remote_activate(self, action, parameter, method):
+        if self._window is None or self._window._shutting_down:
+            return
+        try:
+            value = parameter.unpack()
+            args = value if isinstance(value, tuple) else (value,)
+            getattr(self._window, method)(*args)
+            self.push_states()
+        except (OSError, ValueError, KeyError, scenes_module.Unreadable) as error:
+            logging.warning("Remote %s failed: %s", action.get_name(), error)
+
+    def _remote_read(self, action, _parameter=None):
+        if self._window is None or self._window._shutting_down:
+            return
+        signature, getter = self._remote_getters[action.get_name()]
+        try:
+            action.set_state(GLib.Variant(signature, getter()))
+        except (OSError, ValueError, scenes_module.Unreadable) as error:
+            logging.warning("Remote %s failed: %s", action.get_name(), error)
+
+    def push_states(self):
+        for name in ("snapshot", "source-groups"):
+            self._remote_read(self.lookup_action(name))
 
     def do_command_line(self, command_line):
         options = command_line.get_options_dict()
@@ -1435,6 +1711,7 @@ class WaveXLRApp(Adw.Application):
                 self._show_setup_dialog()
                 return
             self._window = WaveXLRWindow(application=self)
+            self.push_states()
             # Hide-to-tray on close instead of quitting
             self._window.connect("close-request", self._on_close_request)
             self._setup_tray()

--- a/wavexlr/mixer.py
+++ b/wavexlr/mixer.py
@@ -325,6 +325,74 @@ class Mixer:
         with self._lock:
             return copy.deepcopy({key: value for key, value in self._state.items() if "." in key})
 
+    def scene_state(self):
+        """One cached snapshot of desired levels and observed, restored masters."""
+        with self._lock:
+            return {
+                "sources": {sid: {"level": source["level"], "muted": source["muted"]}
+                            for sid, source in self._sources.items()},
+                "cells": {f"{sid}.{mid}": dict(self._state.get(
+                    f"{sid}.{mid}", {"volume": 0.0, "muted": False}))
+                    for sid in self._sources for mid in self._mixes},
+                "outputs": {mid: self._state[OUTPUTS_STATE_KEY].get(
+                    mid, OUTPUT_AUTO if mid == "personal" else OUTPUT_NONE)
+                    for mid in self._mixes},
+                "volumes": copy.deepcopy(self._state[VOLUMES_STATE_KEY]),
+            }
+
+    def apply_scene(self, scene):
+        """Publish one level-only desired state; never create source/mix identities."""
+        from . import scenes
+        if not isinstance(scene, dict):
+            raise ValueError("Scene must be an object")
+        scenes.validate({"recall": dict(scene, name=scene.get("name", ""))})
+        skipped = []
+        with self._lock:
+            records, state = copy.deepcopy((self._sources, self._state))
+            for sid, entry in scene.get("sources", {}).items():
+                if sid not in records:
+                    skipped.append("source " + sid)
+                    continue
+                group = sources.group(records[sid])
+                if entry.get("muted") is False and group:
+                    for other_id, other in records.items():
+                        if other_id != sid and sources.group(other) == group:
+                            other["muted"] = True
+                records[sid].update(entry)
+            for sid, entry in scene.get("sources", {}).items():
+                if sid in records and entry.get("muted") is False and records[sid]["muted"]:
+                    skipped.append(f"source {sid}: another group member is live")
+            for key, entry in scene.get("cells", {}).items():
+                sid, _, mid = key.rpartition(".")
+                if sid not in records or mid not in self._mixes:
+                    skipped.append("cell " + key)
+                    continue
+                state[key] = {**state.get(key, {"volume": 0.0, "muted": False}), **entry}
+            for mid, output in scene.get("outputs", {}).items():
+                if mid not in self._mixes or (output and output.startswith("openwave_")):
+                    skipped.append("output " + mid)
+                    continue
+                state[OUTPUTS_STATE_KEY][mid] = output or OUTPUT_AUTO
+            restored_mixes = []
+            for mid, entry in scene.get("volumes", {}).items():
+                if mid not in self._mixes:
+                    skipped.append("volume " + mid)
+                    continue
+                state[VOLUMES_STATE_KEY][mid] = {
+                    **state[VOLUMES_STATE_KEY].get(mid, {"volume": 1.0, "muted": False}),
+                    **entry,
+                }
+                restored_mixes.append(mid)
+            self._sources = records
+            self._state = state
+            for mid in restored_mixes:
+                self._master_revisions[mid] = self._master_revisions.get(mid, 0) + 1
+        try:
+            self._persist()
+        finally:
+            self._wake.set()
+        return skipped
+
     def streams(self):
         with self._lock:
             return copy.deepcopy(self._graph["streams"] if self._graph else {})

--- a/wavexlr/scenes.py
+++ b/wavexlr/scenes.py
@@ -40,7 +40,7 @@ def _number(value, low, high, label, *, integer=False):
         raise ValueError(f"{label} must be a finite number in [{low}, {high}]")
 
 
-def _validate(scenes):
+def validate(scenes):
     _mapping(scenes, "scenes")
     sections = {"sources", "cells", "outputs", "volumes", "hardware"}
     hardware_fields = {
@@ -97,7 +97,7 @@ def load(path=None):
             data = json.load(file)
         if not isinstance(data, dict) or set(data) != {"scenes"}:
             raise ValueError("top-level shape must be {'scenes': {...}}")
-        _validate(data["scenes"])
+        validate(data["scenes"])
         return data["scenes"]
     except FileNotFoundError:
         return {}
@@ -107,7 +107,7 @@ def load(path=None):
 
 def save(scenes, path=None):
     """Validate and atomically replace the store; invalid payloads raise ValueError."""
-    _validate(scenes)
+    validate(scenes)
     path = os.fspath(CONFIG_PATH if path is None else path)
     directory = os.path.dirname(path) or "."
     os.makedirs(directory, exist_ok=True)

--- a/wavexlr/scenes.py
+++ b/wavexlr/scenes.py
@@ -1,0 +1,173 @@
+"""Named level snapshots, not source or mix definitions.
+
+Scenes recall trims, sends, mutes, outputs, masters and optional hardware
+levels without creating or deleting matrix rows or columns. Phantom power
+is deliberately excluded: changing microphone power requires an explicit
+hardware action, never a scene recall.
+
+The XDG config store contains {"scenes": {id: scene}}. Missing storage is an
+empty store; unreadable storage is left untouched and reported to the caller.
+"""
+
+import json
+import math
+import os
+import re
+import tempfile
+
+CONFIG_PATH = os.path.join(
+    os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser("~/.config"),
+    "openwave", "scenes.json",
+)
+
+
+class Unreadable(Exception):
+    """The scene store exists but cannot be read as valid scene data."""
+
+
+def _mapping(value, label):
+    if not isinstance(value, dict) or any(
+        not isinstance(key, str) or not key for key in value
+    ):
+        raise ValueError(f"{label} must be a map with nonempty string keys")
+
+
+def _number(value, low, high, label, *, integer=False):
+    if (type(value) not in (int, float)
+            or (integer and type(value) is not int)
+            or not low <= value <= high
+            or not math.isfinite(value)):
+        raise ValueError(f"{label} must be a finite number in [{low}, {high}]")
+
+
+def _validate(scenes):
+    _mapping(scenes, "scenes")
+    sections = {"sources", "cells", "outputs", "volumes", "hardware"}
+    hardware_fields = {
+        "gain_raw", "mute", "hp_volume_db", "low_impedance", "monitor_mix",
+    }
+    for sid, scene in scenes.items():
+        _mapping(scene, f"scene {sid}")
+        if set(scene) - sections - {"name"}:
+            raise ValueError(f"scene {sid} has unsupported fields")
+        if not isinstance(scene.get("name"), str):
+            raise ValueError(f"scene {sid} needs a string name")
+        for section in sections & scene.keys():
+            entries = scene[section]
+            _mapping(entries, f"scene {sid} {section}")
+            for key, entry in entries.items():
+                label = f"scene {sid} {section} {key}"
+                if section == "outputs":
+                    if entry is not None and not isinstance(entry, str):
+                        raise ValueError(f"{label} must be a sink name or null")
+                    continue
+                _mapping(entry, label)
+                if section == "hardware":
+                    if set(entry) - hardware_fields:
+                        raise ValueError(f"{label} has unsupported hardware fields")
+                    for field in ("mute", "low_impedance"):
+                        if field in entry and type(entry[field]) is not bool:
+                            raise ValueError(f"{label} {field} must be boolean")
+                    for field in ("gain_raw", "monitor_mix"):
+                        if field in entry:
+                            _number(entry[field], 0, 0xFFFF, f"{label} {field}",
+                                    integer=True)
+                    if "hp_volume_db" in entry:
+                        _number(entry["hp_volume_db"], -128, 0,
+                                f"{label} hp_volume_db")
+                    continue
+                if section == "cells":
+                    source_id, separator, mix_id = key.rpartition(".")
+                    if not separator or not source_id or not mix_id:
+                        raise ValueError(f"{label} needs a source.mix key")
+                level_field = "level" if section == "sources" else "volume"
+                if set(entry) - {level_field, "muted"}:
+                    raise ValueError(f"{label} has unsupported level fields")
+                if level_field in entry:
+                    _number(entry[level_field], 0, 1, f"{label} {level_field}")
+                if "muted" in entry and type(entry["muted"]) is not bool:
+                    raise ValueError(f"{label} muted must be boolean")
+
+
+def load(path=None):
+    """Return every scene, or {} on first run; never modify unreadable data."""
+    path = CONFIG_PATH if path is None else path
+    try:
+        with open(path, encoding="utf-8") as file:
+            data = json.load(file)
+        if not isinstance(data, dict) or set(data) != {"scenes"}:
+            raise ValueError("top-level shape must be {'scenes': {...}}")
+        _validate(data["scenes"])
+        return data["scenes"]
+    except FileNotFoundError:
+        return {}
+    except (OSError, ValueError) as exc:
+        raise Unreadable(f"Cannot read scenes from {path}: {exc}") from exc
+
+
+def save(scenes, path=None):
+    """Validate and atomically replace the store; invalid payloads raise ValueError."""
+    _validate(scenes)
+    path = os.fspath(CONFIG_PATH if path is None else path)
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".scenes-", suffix=".tmp", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as file:
+            json.dump({"scenes": scenes}, file, indent=2, allow_nan=False)
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+
+def scene_id(name):
+    """A stable id from a human name: lowercase, dashes, nothing else."""
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return slug or "scene"
+
+
+def hardware_key(profile_key, serial):
+    """Address a unit by serial, or use a legacy model key if serial is absent."""
+    return f"{profile_key}:{serial}" if serial else profile_key
+
+
+def pick_hardware_entry(hardware, profile_key, serial, *, profile_count=1):
+    """Find this unit's levels without borrowing another unit's serial entry.
+
+    A nonempty exact serial wins, even among duplicate models. A legacy bare
+    model key is safe only with exactly one connected unit of that model;
+    callers must count units with missing serials too. Ambiguous serial-less
+    units never share one hardware snapshot.
+    """
+    if not hardware:
+        return None
+    if serial:
+        exact_key = hardware_key(profile_key, serial)
+        if exact_key in hardware:
+            return hardware[exact_key]
+    if profile_count == 1:
+        return hardware.get(profile_key)
+    return None
+
+
+def put(name, payload, path=None):
+    """Store a scene under its name's id, replacing an existing one."""
+    if not isinstance(name, str):
+        raise ValueError("scene name must be a string")
+    scenes = load(path)
+    _mapping(payload, "scene payload")
+    sid = scene_id(name)
+    scenes[sid] = dict(payload, name=name)
+    save(scenes, path)
+    return sid
+
+
+def remove(sid, path=None):
+    """Remove a stored scene, returning whether it existed."""
+    scenes = load(path)
+    if sid in scenes:
+        del scenes[sid]
+        save(scenes, path)
+        return True
+    return False


### PR DESCRIPTION
Reviewed replacement for #8, part 8/12. Original contribution: Zedwil / NyleGarcia.

## Stack
Depends on https://github.com/rikkichy/openwave/pull/19; base is `pr8-07-dynamic-matrix`. Merge the parent first. These are ordered review slices, not independent cherry-picks.

## Scope
- Persist named matrix snapshots and serial-bound hardware settings while excluding phantom power.
- Respect gain locks and partial device/topology matches during recall.
- Expose typed GApplication actions and read-only telemetry; reject invalid levels and forged state writes.

## Verification
Actual session-bus calls exercised scene save/recall/delete, source groups and sends, partial matching, gain locks, no phantom writes, invalid values and read-only telemetry.

Runtime scenarios were exercised on the integrated stack. Hardware-facing tests do not imply physical USB/phantom-power certification.
