### PR TITLE
Add owned capture DSP and explicitly reviewed calibration

### DIFF
--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -1,0 +1,196 @@
+import copy
+import math
+import os
+import struct
+import subprocess
+import sys
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+from wavexlr import calibrate
+
+
+def pcm(left, right=None, frames=24000):
+    if right is None:
+        return struct.pack("<h", left) * frames
+    return struct.pack("<hh", left, right) * frames
+
+
+class CalibrationAnalysisTests(unittest.TestCase):
+    def test_malformed_empty_and_inadequate_audio_is_not_a_measurement(self):
+        for raw, channels in ((b"", 2), (b"\x00", 1), (b"\x00\x00", 2),
+                              (pcm(20, frames=800), 1), (pcm(20), 3), (None, 2)):
+            with self.subTest(raw_type=type(raw), channels=channels):
+                with self.assertRaises(calibrate.CalibrationError):
+                    calibrate.metrics_from_raw(raw, channels)
+
+    def test_all_complete_windows_are_measured_without_stereo_phase_cancellation(self):
+        metrics = calibrate.metrics_from_raw(pcm(8192, -8192))
+        self.assertEqual(len(metrics["peaks_db"]), 30)
+        self.assertAlmostEqual(metrics["peaks_db"][0], -12.041199826559248)
+        self.assertEqual(metrics["balance"], 1)
+        lopsided = calibrate.metrics_from_raw(pcm(8192, 0))
+        self.assertEqual(lopsided["balance"], 0)
+        self.assertEqual(lopsided["peaks_db"], metrics["peaks_db"])
+
+    def test_clipping_cannot_hide_in_one_channel(self):
+        with self.assertRaisesRegex(calibrate.CalibrationError, "clipping"):
+            calibrate.metrics_from_raw(pcm(32767, 0))
+
+    def test_silence_quiet_speech_and_noise_get_actionable_errors(self):
+        with self.assertRaisesRegex(calibrate.CalibrationError, "Speech"):
+            calibrate.analyze([-140] * 180, [-140] * 300)
+        with self.assertRaisesRegex(calibrate.CalibrationError, "quiet"):
+            calibrate.analyze([-90] * 180, [-60] * 300)
+        with self.assertRaisesRegex(calibrate.CalibrationError, "noise floor"):
+            calibrate.analyze([-20] * 180, [-5] * 300)
+        with self.assertRaisesRegex(calibrate.CalibrationError, "noise floor"):
+            calibrate.analyze([-40] * 180, [-25] * 300)
+
+    def test_corrupt_or_insufficient_levels_do_not_produce_settings(self):
+        for values in ([], [-30] * 2, [math.nan] * 30, [math.inf] * 30,
+                       [1] * 30, [-141] * 30):
+            with self.subTest(values=values[:2]), self.assertRaises(calibrate.CalibrationError):
+                calibrate.analyze([-70] * 180, values)
+        with self.assertRaisesRegex(calibrate.CalibrationError, "clipping"):
+            calibrate.analyze([-70] * 180, [-0.01] * 300)
+
+    def test_proposal_leaves_measurements_and_existing_settings_untouched(self):
+        floor, speech = [-65] * 180, [-24] * 270 + [-12] * 30
+        original = copy.deepcopy((floor, speech))
+        proposal = calibrate.analyze(floor, speech)
+        self.assertEqual((floor, speech), original)
+        settings = proposal["fx"]
+        self.assertGreater(settings["gate_thresh"], -65)
+        self.assertLess(settings["gate_thresh"], -24)
+        self.assertGreaterEqual(settings["comp_thresh"], -30)
+        self.assertLess(settings["comp_thresh"], -12)
+        self.assertEqual(settings["comp_ratio"], 3)
+        self.assertNotIn("phantom", settings)
+
+    def test_tone_proposal_protects_low_voice_and_bounds_shelf(self):
+        floor = {"balance": 1, "sub_db": -2, "voice_low_db": -30, "tilt_db": -15}
+        speech = {"balance": 0, "sub_db": -20, "voice_low_db": -8, "tilt_db": -40}
+        original = copy.deepcopy((floor, speech))
+        result = calibrate.analyze_tone(floor, speech)
+        self.assertEqual(result, {"lowcut": 80, "eq_high": 4, "mono": True})
+        self.assertEqual((floor, speech), original)
+        speech.update(voice_low_db=-20, balance=1, tilt_db=-5)
+        self.assertEqual(calibrate.analyze_tone(floor, speech), {"lowcut": 120, "eq_high": -4})
+        speech["tilt_db"] = math.nan
+        with self.assertRaises(calibrate.CalibrationError):
+            calibrate.analyze_tone(floor, speech)
+
+
+class CaptureLifecycleTests(unittest.TestCase):
+    def assert_reaped(self, child):
+        self.assertIsNotNone(child.returncode)
+        self.assertTrue(child.stdout.closed)
+        with self.assertRaises(ChildProcessError):
+            os.waitpid(child.pid, os.WNOHANG)
+
+    def test_cancelled_before_spawn_does_not_open_microphone(self):
+        with patch.object(calibrate.subprocess, "Popen") as popen:
+            with self.assertRaises(calibrate.CalibrationCancelled):
+                calibrate.capture_raw("raw_mic", 1, cancel=lambda: True)
+            popen.assert_not_called()
+
+    def test_cancellation_during_spawn_kills_and_reaps_real_child(self):
+        original_popen = subprocess.Popen
+        cancelled = threading.Event()
+        children = []
+
+        def spawn(*args, **kwargs):
+            # Wait until SIGTERM is ignored, then request cancellation before
+            # Popen returns to capture. The real cleanup must escalate to KILL.
+            child = original_popen(
+                [sys.executable, "-c", "import signal,time; "
+                 "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                 "print('ready', flush=True); time.sleep(60)"],
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            )
+            children.append(child)
+            self.assertEqual(child.stdout.readline(), b"ready\n")
+            cancelled.set()
+            return child
+
+        try:
+            with patch.object(calibrate.subprocess, "Popen", side_effect=spawn):
+                with self.assertRaises(calibrate.CalibrationCancelled):
+                    calibrate.capture_raw("raw_mic", 1, cancel=cancelled.is_set)
+            self.assertLess(children[0].returncode, 0)
+            self.assert_reaped(children[0])
+        finally:
+            for child in children:
+                if child.poll() is None:
+                    child.kill()
+                child.wait()
+                child.stdout.close()
+
+    def test_read_cancellation_does_not_wait_for_silent_child(self):
+        original_popen = subprocess.Popen
+        children = []
+        cancelled = threading.Event()
+        timer = None
+
+        def spawn(*args, **kwargs):
+            nonlocal timer
+            child = original_popen([sys.executable, "-c", "import time; time.sleep(60)"],
+                                   stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+            children.append(child)
+            timer = threading.Timer(0.1, cancelled.set)
+            timer.start()
+            return child
+
+        started = time.monotonic()
+        try:
+            with patch.object(calibrate.subprocess, "Popen", side_effect=spawn):
+                with self.assertRaises(calibrate.CalibrationCancelled):
+                    calibrate.capture_raw("raw_mic", 5, cancel=cancelled.is_set)
+            self.assertLess(time.monotonic() - started, 3)
+            self.assert_reaped(children[0])
+        finally:
+            if timer:
+                timer.cancel()
+                timer.join()
+            for child in children:
+                if child.poll() is None:
+                    child.kill()
+                child.wait()
+                child.stdout.close()
+
+    def test_deadline_reaps_real_stalled_capture(self):
+        original_popen = subprocess.Popen
+        children = []
+
+        def spawn(*args, **kwargs):
+            child = original_popen([sys.executable, "-c", "import time; time.sleep(60)"],
+                                   stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+            children.append(child)
+            return child
+
+        try:
+            with patch.object(calibrate.subprocess, "Popen", side_effect=spawn), \
+                    patch.object(calibrate, "GRACE_SECONDS", -1):
+                with self.assertRaisesRegex(calibrate.CalibrationError, "incomplete audio"):
+                    calibrate.capture_raw("raw_mic", 0.5)
+            self.assert_reaped(children[0])
+        finally:
+            for child in children:
+                if child.poll() is None:
+                    child.kill()
+                child.wait()
+                child.stdout.close()
+
+    def test_raw_capture_rejects_processed_and_default_targets(self):
+        with patch.object(calibrate.subprocess, "Popen") as popen:
+            for target in ("openwave_fx_mic", "0", "-1", "", "raw\0mic"):
+                with self.subTest(target=target), self.assertRaises(calibrate.CalibrationError):
+                    calibrate.capture_raw(target, 1)
+            popen.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1,0 +1,128 @@
+import copy
+import json
+import math
+import unittest
+
+from wavexlr.effects import DEFAULT_FX, fx, fx_active, fx_node_name, render_fx_config
+
+
+def source(**settings):
+    return {"id": "mic-1", "name": "Microphone", "node_name": "alsa_input.mic",
+            "fx": settings}
+
+
+def graph_args(record):
+    config = json.loads(render_fx_config(record))
+    return next(module["args"] for module in config["context.modules"]
+                if module["name"] == "libpipewire-module-filter-chain")
+
+
+class EffectsTests(unittest.TestCase):
+    def test_hostile_metadata_cannot_add_spa_properties(self):
+        hostile = 'Mic"\n} ] context.modules = [{ name = "evil" }] #\\'
+        record = source(gate=True)
+        record.update(name=hostile, node_name=hostile)
+        config = json.loads(render_fx_config(record))
+        self.assertNotIn("evil", [module["name"] for module in config["context.modules"]])
+        args = graph_args(record)
+        self.assertEqual(args["capture.props"]["target.object"], hostile)
+        self.assertEqual(args["node.description"], "OpenWave FX: " + hostile)
+        renamed = dict(record, name="New label")
+        other = graph_args(renamed)
+        for props in ("capture.props", "playback.props"):
+            self.assertEqual(args[props]["media.name"], other[props]["media.name"])
+            self.assertEqual(args[props]["node.name"], other[props]["node.name"])
+
+    def test_identifier_rejects_path_and_config_injection(self):
+        for value in ("../mic", "mic/child", "a\nb", 'a"', "", None, "a" * 129):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                fx_node_name(value)
+
+    def test_invalid_schema_cannot_reach_pipewire(self):
+        for settings in ({"eq_low": math.nan}, {"delay_ms": math.inf},
+                         {"gate_thresh": -math.inf}, {"comp_ratio": 10 ** 1000},
+                         {"mono": "false"}, {"gate_thresh": True},
+                         {"delay_ms": "20"}, {"lowcut": 90}, {"unknown": 1}):
+            with self.subTest(settings=settings), self.assertRaises(ValueError):
+                render_fx_config(source(**settings))
+        for value in (None, [], "gate"):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                fx({"fx": value})
+
+    def test_finite_values_clamp_to_supported_plugin_ranges(self):
+        record = source(gate=True, gate_thresh=-1000, comp=True,
+                        comp_thresh=-1000, comp_ratio=1000, eq_low=-1000,
+                        eq_mid=1000, delay_ms=1000)
+        args = graph_args(record)
+        nodes = {node["name"]: node for node in args["filter.graph"]["nodes"]}
+        self.assertEqual(nodes["gate_0"]["control"]["Threshold (dB)"], -70)
+        self.assertEqual(nodes["comp_0"]["control"]["Threshold level (dB)"], -30)
+        self.assertEqual(nodes["comp_0"]["control"]["Ratio (1:n)"], 10)
+        self.assertEqual(nodes["eq_low_0"]["control"]["Gain"], -12)
+        self.assertEqual(nodes["eq_mid_0"]["control"]["Gain"], 12)
+        self.assertEqual(nodes["delay_0"]["control"]["Delay (s)"], 0.5)
+
+    def test_neutral_identity_has_no_filter_process(self):
+        for settings in ({}, DEFAULT_FX, {"gate_thresh": -25, "comp_thresh": -5},
+                         {"comp": True, "comp_ratio": 1}, {"delay_ms": -10}):
+            record = source(**settings)
+            original = copy.deepcopy(record)
+            self.assertFalse(fx_active(record))
+            self.assertIsNone(render_fx_config(record))
+            self.assertEqual(record, original)
+
+    def test_stereo_strips_never_cross_or_lose_a_channel(self):
+        args = graph_args(source(lowcut=80, gate=True, comp=True, eq_low=1,
+                                 eq_mid=2, eq_high=3, delay_ms=10))
+        graph = args["filter.graph"]
+        nodes = {node["name"]: node for node in graph["nodes"]}
+        links = {link["output"]: link["input"] for link in graph["links"]}
+        self.assertEqual(args["capture.props"]["audio.position"], ["FL", "FR"])
+        self.assertEqual(args["playback.props"]["audio.position"], ["FL", "FR"])
+        self.assertEqual(len(graph["inputs"]), 2)
+        self.assertEqual(len(graph["outputs"]), 2)
+        visited = []
+        for start, end in zip(graph["inputs"], graph["outputs"]):
+            path, port = [], start
+            while True:
+                name, input_port = port.split(":")
+                node = nodes[name]
+                path.append(name)
+                ladspa = node["type"] == "ladspa"
+                self.assertEqual(input_port, "Input" if ladspa else "In")
+                output = name + (":Output" if ladspa else ":Out")
+                if output == end:
+                    break
+                port = links[output]
+            self.assertEqual([nodes[name]["label"] for name in path],
+                             ["bq_highpass", "gate", "sc4m", "bq_lowshelf",
+                              "bq_peaking", "bq_highshelf", "delay"])
+            visited.append(set(path))
+        self.assertFalse(visited[0] & visited[1])
+        gate = next(node for node in graph["nodes"] if node["label"] == "gate")
+        self.assertIn("Output select (-1 = key listen, 0 = gate, 1 = bypass)", gate["control"])
+
+    def test_explicit_downmix_averages_both_inputs_before_processing(self):
+        args = graph_args(source(mono=True, comp=True))
+        graph = args["filter.graph"]
+        downmix = next(node for node in graph["nodes"] if node["label"] == "mixer")
+        self.assertEqual(graph["inputs"], [downmix["name"] + ":In 1", downmix["name"] + ":In 2"])
+        self.assertEqual(downmix["control"], {"Gain 1": 0.5, "Gain 2": 0.5})
+        self.assertEqual(len(graph["outputs"]), 1)
+        self.assertIn({"output": downmix["name"] + ":Out", "input": "comp_0:Input"}, graph["links"])
+        self.assertEqual(args["capture.props"]["audio.channels"], 2)
+        self.assertEqual(args["playback.props"]["audio.position"], ["MONO"])
+
+    def test_known_mono_input_needs_no_lossy_downmix(self):
+        record = dict(source(eq_high=2), channels=1)
+        args = graph_args(record)
+        self.assertEqual(args["capture.props"]["audio.position"], ["MONO"])
+        self.assertEqual(args["playback.props"]["audio.position"], ["MONO"])
+        self.assertEqual(len(args["filter.graph"]["inputs"]), 1)
+        self.assertFalse(any(node["label"] == "mixer" for node in args["filter.graph"]["nodes"]))
+        with self.assertRaises(ValueError):
+            render_fx_config(dict(record, channels=6))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wavexlr/app.py
+++ b/wavexlr/app.py
@@ -10,6 +10,7 @@ import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from collections import Counter
+import threading
 
 from .device import WaveDevice, DeviceUnresponsiveError, scan
 from .audio import SOURCE_MATCHES
@@ -20,6 +21,7 @@ from .mixdialog import MixDialog
 from .sourcedialog import AddSourceDialog
 from . import paths, setup, service, sources as sources_module, mixes as mixes_module, desktop as desktop_module
 from . import scenes as scenes_module
+from . import effects, calibrate
 
 logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
 KNOB_LABELS = {"gain": "Gain", "hp": "Headphones", "mix": "Monitor Mix"}
@@ -62,6 +64,10 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self._updating_ui = False
         self._last_state = None
         self._cell_debounce_ids = {}
+        self._fx_debounce_ids = {}
+        self._calibration = None
+        self._calibration_executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="openwave-calibration")
         self._remote_levels = {}
         self._capture_mute_seen = {}
         self._service_problem = False
@@ -597,6 +603,10 @@ class WaveXLRWindow(Adw.ApplicationWindow):
     def shutdown(self):
         """Quiesce every device worker before closing its libusb handle."""
         self._shutting_down = True
+        self._cancel_calibration()
+        self._calibration_executor.shutdown(wait=False, cancel_futures=True)
+        for source_id in list(self._fx_debounce_ids):
+            self._cancel_fx_edit(source_id)
         for name in (
             "_reconnect_id", "_poll_id", "_stream_poll_id",
             "_gain_timeout", "_hp_timeout", "_mix_timeout",
@@ -830,6 +840,9 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         if source.get("protected") and self.mixer.capture_device_present(source["node_name"]):
             return
         self._cancel_cell_edits(source_id=source_id)
+        self._cancel_fx_edit(source_id)
+        if self._calibration is not None and self._calibration["source_id"] == source_id:
+            self._cancel_calibration()
         candidate = {sid: record for sid, record in self._sources.items() if sid != source_id}
         sources_module.save(candidate)
         self._sources = candidate
@@ -1185,7 +1198,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
     def _add_source_widget(self, source):
         sid = source["id"]
         self.matrix.add_source(sid, name=source["name"], icon_name=source["icon_name"],
-            has_level=True, removable=not source.get("protected"), editable=True,
+            has_level=True, removable=True, editable=True,
             reorderable=True, is_capture=sources_module.kind(source) == sources_module.KIND_DEVICE)
         self._wire_source_row(sid)
 
@@ -1197,6 +1210,12 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self.matrix.set_source_group(source_id, sources_module.group(source))
         row.connect("volume-changed", self._on_source_level_changed, source_id)
         row.connect("mute-toggled", self._on_source_mute_toggled, source_id)
+        if source.get("protected"):
+            row.set_removable(False)
+        if sources_module.kind(source) == sources_module.KIND_DEVICE:
+            row.set_fx(effects.fx(source))
+            row.connect("fx-changed", self._on_source_fx_changed, source_id)
+            row.connect("fx-autotune", self._on_fx_autotune, source_id)
 
     def _install_source(self, source):
         self._sources = sources_module.add(self._sources, source)
@@ -1412,6 +1431,181 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self._refresh_mix_emptiness()
         return muted
 
+    def _cancel_fx_edit(self, source_id):
+        timer = self._fx_debounce_ids.pop(source_id, None)
+        if timer is not None:
+            GLib.source_remove(timer)
+
+    def _set_source_fx(self, source_id, settings):
+        source = self._sources.get(source_id)
+        if source is None or sources_module.kind(source) != sources_module.KIND_DEVICE:
+            raise ValueError("Effects require a capture source")
+        settings = effects.fx({"fx": settings})
+        self._cancel_fx_edit(source_id)
+        self._sources = sources_module.update(self._sources, source_id, fx=settings)
+        self.matrix.source(source_id).set_fx(settings)
+        self.mixer.set_sources(self._sources)
+        self._push_remote_state()
+
+    def _on_source_fx_changed(self, row, source_id):
+        self._cancel_fx_edit(source_id)
+        settings = row.fx_settings()
+        def apply():
+            self._fx_debounce_ids.pop(source_id, None)
+            if source_id in self._sources and not self._shutting_down:
+                try:
+                    self._set_source_fx(source_id, settings)
+                except (OSError, ValueError) as error:
+                    self.matrix.source(source_id).set_fx(effects.fx(self._sources[source_id]))
+                    self._show_error("Unable to save effects", error)
+            return False
+        self._fx_debounce_ids[source_id] = GLib.timeout_add(400, apply)
+
+    def toggle_fx(self, source_id, effect):
+        source = self._sources.get(source_id)
+        if source is None or sources_module.kind(source) != sources_module.KIND_DEVICE:
+            raise ValueError("Effects require a capture source")
+        settings = effects.fx(source)
+        if effect == "lowcut":
+            settings[effect] = 0 if settings[effect] else 80
+        elif effect in ("gate", "comp", "mono"):
+            settings[effect] = not settings[effect]
+        else:
+            raise ValueError("Only lowcut, gate, comp and mono are toggles")
+        self._set_source_fx(source_id, settings)
+        return settings[effect]
+
+    def _cancel_calibration(self):
+        session = self._calibration
+        if session is not None:
+            self._calibration = None
+            session["cancel"].set()
+            if session["dialog"] is not None:
+                session["dialog"].close()
+
+    def _on_fx_autotune(self, _row, source_id):
+        if self._calibration is not None:
+            return
+        source = self._sources.get(source_id)
+        capture = next((item for item in self.mixer.capture_sources()
+                        if source is not None and item["name"] == source.get("node_name")), None)
+        if capture is None:
+            self._show_error("Calibration unavailable", "Connect the capture device first.")
+            return
+        session = {"source_id": source_id, "node_name": capture["name"],
+                   "identity": capture["identity"], "channels": source.get("channels", 2),
+                   "cancel": threading.Event(), "dialog": None, "floor": None}
+        self._calibration = session
+        self._calibration_prompt(session, speech=False)
+
+    def _calibration_prompt(self, session, *, speech):
+        dialog = Adw.AlertDialog(
+            heading="Measure speech" if speech else "Measure room noise",
+            body=("Speak normally for five seconds after pressing Record."
+                  if speech else "Stay quiet for three seconds after pressing Record. "
+                  "Only the raw microphone is measured. Current effects and hardware gain "
+                  "stay unchanged; proposed settings require explicit confirmation."))
+        session["dialog"] = dialog
+        dialog.add_response("cancel", "Cancel")
+        dialog.add_response("record", "Record")
+        dialog.set_response_appearance("record", Adw.ResponseAppearance.SUGGESTED)
+        dialog.set_default_response("record")
+        def response(alert, result):
+            answer = alert.choose_finish(result)
+            if self._calibration is not session or session["dialog"] is not alert:
+                return
+            if answer == "record":
+                self._measure_calibration(session, speech=speech)
+            else:
+                self._cancel_calibration()
+        dialog.choose(self, None, response)
+
+    def _measure_calibration(self, session, *, speech):
+        dialog = Adw.AlertDialog(
+            heading="Recording speech" if speech else "Recording room noise",
+            body="Speak normally." if speech else "Please stay quiet.")
+        spinner = Gtk.Spinner(spinning=True)
+        dialog.set_extra_child(spinner)
+        session["dialog"] = dialog
+        dialog.add_response("cancel", "Cancel")
+        def cancelled(alert, result):
+            alert.choose_finish(result)
+            if self._calibration is session and session["dialog"] is alert:
+                self._cancel_calibration()
+        dialog.choose(self, None, cancelled)
+        def measure():
+            raw = calibrate.capture_raw(session["node_name"],
+                calibrate.SPEECH_SECONDS if speech else calibrate.FLOOR_SECONDS,
+                session["channels"], cancel=session["cancel"].is_set)
+            metrics = calibrate.metrics_from_raw(raw, session["channels"])
+            if not speech:
+                return metrics
+            proposal = calibrate.analyze(session["floor"]["peaks_db"], metrics["peaks_db"])
+            proposal["fx"].update(calibrate.analyze_tone(session["floor"], metrics))
+            return proposal
+        future = self._calibration_executor.submit(measure)
+        future.add_done_callback(lambda completed: GLib.idle_add(
+            self._calibration_complete, session, speech, completed))
+
+    def _calibration_complete(self, session, speech, future):
+        if self._calibration is not session or self._shutting_down:
+            return False
+        dialog, session["dialog"] = session["dialog"], None
+        dialog.close()
+        try:
+            result = future.result()
+        except calibrate.CalibrationCancelled:
+            self._cancel_calibration()
+            return False
+        except (calibrate.CalibrationError, OSError, ValueError) as error:
+            self._cancel_calibration()
+            self._show_error("Calibration could not produce safe settings", error)
+            return False
+        if not speech:
+            session["floor"] = result
+            self._calibration_prompt(session, speech=True)
+            return False
+        self._review_calibration(session, result)
+        return False
+
+    def _review_calibration(self, session, proposal):
+        measured, settings = proposal["measured"], proposal["fx"]
+        summary = (
+            f"Noise floor: {measured['floor_db']:.1f} dB\n"
+            f"Quiet / loud speech: {measured['quiet_voice_db']:.1f} / "
+            f"{measured['loud_voice_db']:.1f} dB\n\n"
+            f"Gate: {settings['gate_thresh']:.1f} dB\n"
+            f"Compressor: {settings['comp_thresh']:.1f} dB, {settings['comp_ratio']:.1f}:1\n"
+            f"Low cut: {settings['lowcut']} Hz\nHigh shelf: {settings['eq_high']:+.0f} dB"
+        )
+        if settings.get("mono"):
+            summary += "\nMono: enabled (one channel is very quiet)"
+        dialog = Adw.AlertDialog(heading="Review calibration", body=summary)
+        session["dialog"] = dialog
+        dialog.add_response("cancel", "Keep current settings")
+        dialog.add_response("apply", "Apply")
+        dialog.set_response_appearance("apply", Adw.ResponseAppearance.SUGGESTED)
+        dialog.set_default_response("cancel")
+        def response(alert, result):
+            answer = alert.choose_finish(result)
+            if self._calibration is not session:
+                return
+            self._calibration = None
+            if answer != "apply":
+                return
+            source = self._sources.get(session["source_id"])
+            capture = next((item for item in self.mixer.capture_sources()
+                            if item["name"] == session["node_name"]), None)
+            if (source is None or source.get("node_name") != session["node_name"]
+                    or capture is None or capture["identity"] != session["identity"]):
+                self._show_error("Calibration expired", "The input changed. Repeat the measurements.")
+                return
+            try:
+                self._set_source_fx(session["source_id"], {**effects.fx(source), **settings})
+            except (OSError, ValueError) as error:
+                self._show_error("Unable to apply calibration", error)
+        dialog.choose(self, None, response)
+
     def scene_names(self):
         return {sid: scene["name"] for sid, scene in scenes_module.load().items()}
 
@@ -1604,7 +1798,8 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         levels = self.mixer.scene_state()
         return json.dumps({
             "sources": [dict(id=sid, name=source["name"], kind=sources_module.kind(source),
-                             group=sources_module.group(source), **levels["sources"][sid])
+                             group=sources_module.group(source), fx=effects.fx(source),
+                             **levels["sources"][sid])
                         for sid, source in self._sources.items()],
             "mixes": [dict(id=mid, name=mix["name"], sink=mix["sink"])
                       for mid, mix in self._mixes.items()],
@@ -1643,6 +1838,7 @@ class WaveXLRApp(Adw.Application):
             "apply-scene": ("s", "apply_scene"),
             "save-scene": ("s", "save_scene"),
             "delete-scene": ("s", "delete_scene"),
+            "toggle-fx": ("(ss)", "toggle_fx"),
         }
         for name, (signature, method) in mutations.items():
             action = Gio.SimpleAction.new(name, GLib.VariantType.new(signature))

--- a/wavexlr/calibrate.py
+++ b/wavexlr/calibrate.py
@@ -1,0 +1,256 @@
+"""Raw microphone measurements and proposals, never automatic source updates.
+
+Call capture_raw from a worker thread, not the GTK thread. Cancellation is a
+callable (for example threading.Event.is_set); no mixer or GTK dependency exists.
+"""
+
+import math
+import os
+import select
+import struct
+import subprocess
+import time
+from collections.abc import Mapping
+
+from .effects import FX_NODE_PREFIX, fx
+
+
+RATE = 48000
+WINDOW = 1600  # 800 signed-16 samples: 16.7 ms at 48 kHz
+FLOOR_SECONDS = 3
+SPEECH_SECONDS = 5
+GRACE_SECONDS = 3
+_POLL_SECONDS = 0.1
+_MIN_WINDOWS = 30
+
+
+class CalibrationError(Exception):
+    """The input did not support a safe calibration proposal."""
+
+
+class CalibrationCancelled(Exception):
+    """The caller cancelled capture; its child has been reaped."""
+
+
+def _check_cancel(cancel):
+    if cancel is not None and cancel():
+        raise CalibrationCancelled()
+
+
+def _channels(channels):
+    if type(channels) is not int or channels not in (1, 2):
+        raise CalibrationError("recording must have one or two channels")
+
+
+def _read_exactly(proc, budget, deadline, cancel):
+    chunks, got = [], 0
+    while got < budget:
+        _check_cancel(cancel)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        ready, _, _ = select.select([proc.stdout], [], [], min(_POLL_SECONDS, remaining))
+        if not ready:
+            continue
+        chunk = os.read(proc.stdout.fileno(), min(65536, budget - got))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        got += len(chunk)
+    _check_cancel(cancel)
+    return b"".join(chunks)
+
+
+def _stop_capture(proc):
+    """Terminate, escalate, and unconditionally reap our owned direct child."""
+    try:
+        if proc.poll() is None:
+            try:
+                proc.terminate()
+            except ProcessLookupError:
+                pass
+            try:
+                proc.wait(timeout=0.5)
+            except subprocess.TimeoutExpired:
+                try:
+                    proc.kill()
+                except ProcessLookupError:
+                    pass
+    finally:
+        # After SIGKILL, wait without abandoning the child on another timeout.
+        # Also reaps an already exited child and closes stdout on every path.
+        try:
+            proc.wait()
+        finally:
+            if proc.stdout is not None:
+                proc.stdout.close()
+
+
+def _capture(node_name, seconds, channels, cancel):
+    """Record requested audio plus a half-second startup transient."""
+    frame = 2 * channels
+    budget = int(RATE * seconds) * frame + RATE * frame // 2
+    proc = None
+    _check_cancel(cancel)
+    deadline = time.monotonic() + seconds + 0.5 + GRACE_SECONDS
+    try:
+        # No preexec_fn: this is called in threaded Python. No new session or
+        # detached process; ownership starts as soon as Popen returns, including
+        # when cancellation was requested during process creation.
+        proc = subprocess.Popen(
+            ["pw-cat", "--record", "--target", node_name,
+             "--rate", str(RATE), "--channels", str(channels),
+             "--format", "s16", "--properties",
+             '{ "media.name": "openwave_calibration", '
+             '"node.name": "openwave_calibration", '
+             '"application.name": "OpenWave", "node.dont-reconnect": true, '
+             '"node.dont-fallback": true, "node.dont-move": true }', "-"],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+        )
+        return _read_exactly(proc, budget, deadline, cancel)
+    except OSError as exc:
+        raise CalibrationError(f"could not record the raw microphone: {exc}") from exc
+    finally:
+        if proc is not None:
+            _stop_capture(proc)
+
+
+def capture_raw(node_name, seconds, channels=2, cancel=None):
+    """Return exactly the requested raw little-endian s16 audio, transient dropped.
+
+    Pass the physical source's node_name, never its processed FX node. A missing
+    or stalled target fails rather than switching to the default microphone.
+    Cancellation during spawn/read always tears down and reaps the direct child.
+    """
+    _channels(channels)
+    if (not isinstance(node_name, str) or not node_name or "\0" in node_name
+            or node_name in ("0", "-1") or node_name.startswith(FX_NODE_PREFIX)):
+        raise CalibrationError("select a raw microphone node for calibration")
+    if not _finite(seconds) or not 0.5 <= seconds <= 60:
+        raise CalibrationError("capture duration must be between 0.5 and 60 seconds")
+    frame = channels * 2
+    expected = int(RATE * seconds) * frame
+    raw = _capture(node_name, seconds, channels, cancel)[RATE * frame // 2:]
+    if len(raw) != expected:
+        raise CalibrationError(
+            "The microphone delivered incomplete audio; check that it is connected "
+            "and not suspended, then try again.")
+    _check_cancel(cancel)
+    return raw
+
+
+def _one_pole_energy(samples, cutoff):
+    a = math.exp(-2.0 * math.pi * cutoff / RATE)
+    b = 1.0 - a
+    y = acc = 0.0
+    for sample in samples:
+        y = b * sample + a * y
+        acc += y * y
+    return acc / len(samples)
+
+
+def metrics_from_raw(raw, channels=2):
+    """Measure levels, tone, and stereo balance from complete s16 frames.
+
+    Levels use the louder channel per window; tone uses the higher-energy channel.
+    Averaging first would hide clipping or cancel opposite-polarity stereo input.
+    """
+    _channels(channels)
+    if not isinstance(raw, (bytes, bytearray)) or len(raw) % (2 * channels):
+        raise CalibrationError("malformed audio: expected complete signed-16 PCM frames")
+    half = WINDOW // 2
+    frames = len(raw) // (2 * channels)
+    if frames < half * _MIN_WINDOWS:
+        raise CalibrationError("not enough audio was measured; record at least half a second")
+    ints = struct.unpack(f"<{frames * channels}h", raw)
+    clipped = sum(abs(sample) >= 32760 for sample in ints)
+    if clipped >= max(3, len(ints) * 0.001):
+        raise CalibrationError("The microphone is clipping; lower its hardware gain and try again.")
+    tracks = [ints[channel::channels] for channel in range(channels)]
+    energies = [sum(sample * sample for sample in track) / frames for track in tracks]
+    total = max(energies)
+    tone = tracks[energies.index(total)]
+    balance = min(energies) / total if total else 1.0
+    peaks = []
+    for start in range(0, frames - half + 1, half):
+        peak = max(max(abs(sample) for sample in track[start:start + half])
+                   for track in tracks) / 32768.0
+        peaks.append(20 * math.log10(max(peak, 1e-7)))
+    e90 = _one_pole_energy(tone, 90)
+    e180 = _one_pole_energy(tone, 180)
+    e2k = _one_pole_energy(tone, 2000)
+
+    def db(energy):
+        return 10 * math.log10(max(energy, 1e-9) / max(total, 1e-9))
+
+    return {"peaks_db": peaks, "balance": balance,
+            "sub_db": db(e90), "voice_low_db": db(e180 - e90),
+            "tilt_db": db(total - e2k)}
+
+
+def _finite(value):
+    try:
+        return not isinstance(value, bool) and isinstance(value, (int, float)) and math.isfinite(value)
+    except OverflowError:
+        return False
+
+
+def analyze_tone(floor_metrics, speech_metrics):
+    """Propose bounded low cut, shelf, and optional mono; never modify input."""
+    for metrics in (floor_metrics, speech_metrics):
+        if not isinstance(metrics, Mapping):
+            raise CalibrationError("malformed tone measurements")
+        for key in ("balance", "sub_db", "voice_low_db", "tilt_db"):
+            if key not in metrics or not _finite(metrics[key]):
+                raise CalibrationError("malformed tone measurements")
+        if not 0 <= metrics["balance"] <= 1:
+            raise CalibrationError("malformed channel balance")
+    deep_voice = speech_metrics["voice_low_db"] > -12.0
+    rumbly_floor = floor_metrics["sub_db"] > -6.0
+    proposal = {
+        "lowcut": 80 if deep_voice else (120 if rumbly_floor else 80),
+        "eq_high": float(max(-4.0, min(4.0, round((-15.0 - speech_metrics["tilt_db"]) * 0.5)))),
+    }
+    if speech_metrics["balance"] < 0.05:
+        proposal["mono"] = True
+    return proposal
+
+
+def _percentile(values, pct):
+    ordered = sorted(values)
+    return ordered[min(len(ordered) - 1, int(len(ordered) * pct / 100))]
+
+
+def analyze(floor_peaks_db, speech_peaks_db):
+    """Return measured levels and a gate/compressor proposal, without applying it."""
+    for peaks in (floor_peaks_db, speech_peaks_db):
+        if not isinstance(peaks, (list, tuple)) or len(peaks) < _MIN_WINDOWS:
+            raise CalibrationError("not enough audio was measured; repeat both recording phases")
+        if any(not _finite(peak) or not -140 <= peak <= 0 for peak in peaks):
+            raise CalibrationError("malformed audio level measurements")
+    if max(speech_peaks_db) >= -0.1 or max(floor_peaks_db) >= -0.1:
+        raise CalibrationError("The microphone is clipping; lower its hardware gain and try again.")
+    floor = _percentile(floor_peaks_db, 50)
+    if floor > -25:
+        raise CalibrationError("The noise floor is too high; reduce room noise or hardware gain and try again.")
+    voiced = [peak for peak in speech_peaks_db if peak > floor + 10]
+    if len(voiced) < max(_MIN_WINDOWS, len(speech_peaks_db) * 0.1):
+        raise CalibrationError(
+            "Speech was not clearly above the noise floor; speak longer and closer to the microphone.")
+    quiet_voice = _percentile(voiced, 10)
+    loud_voice = _percentile(voiced, 90)
+    if loud_voice < -45 or quiet_voice < -58:
+        raise CalibrationError("Speech is too quiet; move closer or increase hardware gain, then try again.")
+    if quiet_voice - floor < 18:
+        raise CalibrationError("Speech is too close to the noise floor; reduce room noise or move closer.")
+    gate_thresh = max(-70.0, min(-20.0, floor + 8.0, quiet_voice - 6.0))
+    proposal = {"gate": True, "gate_thresh": round(gate_thresh, 1),
+                "comp": True, "comp_thresh": round(loud_voice - 6.0, 1),
+                "comp_ratio": 3.0}
+    validated = fx({"fx": proposal})
+    return {
+        "measured": {"floor_db": round(floor, 1),
+                     "quiet_voice_db": round(quiet_voice, 1),
+                     "loud_voice_db": round(loud_voice, 1)},
+        "fx": {key: validated[key] for key in proposal},
+    }

--- a/wavexlr/calibrate.py
+++ b/wavexlr/calibrate.py
@@ -13,6 +13,7 @@ import time
 from collections.abc import Mapping
 
 from .effects import FX_NODE_PREFIX, fx
+from . import child
 
 
 RATE = 48000
@@ -94,10 +95,9 @@ def _capture(node_name, seconds, channels, cancel):
     _check_cancel(cancel)
     deadline = time.monotonic() + seconds + 0.5 + GRACE_SECONDS
     try:
-        # No preexec_fn: this is called in threaded Python. No new session or
-        # detached process; ownership starts as soon as Popen returns, including
-        # when cancellation was requested during process creation.
-        proc = subprocess.Popen(
+        # Parent-death setup runs in a fresh interpreter, not threaded preexec.
+        # Cancellation during spawn still transfers ownership to this worker.
+        proc = child.spawn(
             ["pw-cat", "--record", "--target", node_name,
              "--rate", str(RATE), "--channels", str(channels),
              "--format", "s16", "--properties",

--- a/wavexlr/effects.py
+++ b/wavexlr/effects.py
@@ -97,7 +97,7 @@ def fx_node_name(source_id):
     return FX_NODE_PREFIX + source_id
 
 
-def render_fx_config(source):
+def render_fx_config(source, *, owner=None):
     """Return a SPA-safe JSON PipeWire config, or None for exact raw bypass.
 
     Unknown inputs are stereo. Set source['channels']=1 only for a known mono
@@ -204,6 +204,11 @@ def render_fx_config(source):
             "audio.channels": output_channels, "audio.position": output_position,
         },
     }
+    if owner is not None:
+        if not isinstance(owner, str) or not owner or "\0" in owner:
+            raise ValueError("invalid effect owner")
+        args["capture.props"]["openwave.owner"] = owner
+        args["playback.props"]["openwave.owner"] = owner
     # JSON is valid SPA syntax; serialize every string, including all metadata.
     return json.dumps({
         "context.properties": {"log.level": 2},

--- a/wavexlr/effects.py
+++ b/wavexlr/effects.py
@@ -1,0 +1,220 @@
+"""Validated per-source DSP settings and pure PipeWire configuration rendering.
+
+The mixer owns processes; this module never changes the graph or source store.
+A neutral strip renders no configuration, so bypass is the original raw source.
+"""
+
+import json
+import math
+import re
+from collections.abc import Mapping
+
+
+DEFAULT_FX = {
+    "lowcut": 0,
+    "gate": False,
+    "gate_thresh": -50.0,
+    "comp": False,
+    "comp_thresh": -18.0,
+    "comp_ratio": 3.0,
+    "eq_low": 0.0,
+    "eq_mid": 0.0,
+    "eq_high": 0.0,
+    "delay_ms": 0,
+    "mono": False,
+}
+
+# SC4 mono's documented threshold minimum is -30 dB, not -40 dB.
+FX_RANGES = {
+    "gate_thresh": (-70.0, -20.0),
+    "comp_thresh": (-30.0, 0.0),
+    "comp_ratio": (1.0, 10.0),
+    "eq_low": (-12.0, 12.0),
+    "eq_mid": (-12.0, 12.0),
+    "eq_high": (-12.0, 12.0),
+    "delay_ms": (0.0, 500.0),
+}
+FX_NODE_PREFIX = "openwave_fx_"
+
+
+def fx(source):
+    """Return canonical settings; reject malformed values, clamp finite ranges.
+
+    Unknown fields are rejected rather than silently accepting misspelled controls.
+    This is the shared schema used by persistence callers, UI, and the renderer.
+    """
+    if source is None:
+        source = {}
+    if not isinstance(source, Mapping):
+        raise ValueError("source must be a mapping")
+    stored = source.get("fx", {})
+    if not isinstance(stored, Mapping):
+        raise ValueError("fx must be a mapping")
+    if stored.keys() - DEFAULT_FX.keys():
+        raise ValueError("unknown effect setting")
+    result = {**DEFAULT_FX, **stored}
+    for key in ("gate", "comp", "mono"):
+        if not isinstance(result[key], bool):
+            raise ValueError(f"{key} must be a boolean")
+    for key in ("lowcut", *FX_RANGES):
+        value = result[key]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"{key} must be a finite number")
+        try:
+            value = float(value)
+        except OverflowError as exc:
+            raise ValueError(f"{key} must be a finite number") from exc
+        if not math.isfinite(value):
+            raise ValueError(f"{key} must be a finite number")
+        if key == "lowcut":
+            if value not in (0, 80, 120):
+                raise ValueError("lowcut must be 0, 80, or 120 Hz")
+            result[key] = int(value)
+        else:
+            low, high = FX_RANGES[key]
+            result[key] = max(low, min(high, value))
+    return result
+
+
+def _active(settings):
+    return bool(
+        settings["lowcut"] or settings["gate"]
+        or (settings["comp"] and settings["comp_ratio"] > 1)
+        or settings["eq_low"] or settings["eq_mid"] or settings["eq_high"]
+        or settings["delay_ms"] or settings["mono"]
+    )
+
+
+def fx_active(source):
+    """Whether the validated strip changes audio (disabled thresholds do not)."""
+    return _active(fx(source))
+
+
+def fx_node_name(source_id):
+    """Stable virtual-source identity, also safe for use as a config basename."""
+    if not isinstance(source_id, str) or not re.fullmatch(r"[A-Za-z0-9_-]{1,128}", source_id):
+        raise ValueError("invalid source identifier")
+    return FX_NODE_PREFIX + source_id
+
+
+def render_fx_config(source):
+    """Return a SPA-safe JSON PipeWire config, or None for exact raw bypass.
+
+    Unknown inputs are stereo. Set source['channels']=1 only for a known mono
+    device. Stereo uses independent strips, including gate/compressor envelopes;
+    only an explicit mono toggle averages the two inputs into one output.
+    """
+    if not isinstance(source, Mapping):
+        raise ValueError("source must be a mapping")
+    settings = fx(source)
+    node_name = fx_node_name(source.get("id"))
+    channels = source.get("channels", 2)
+    if type(channels) is not int or channels not in (1, 2):
+        raise ValueError("source channels must be 1 or 2")
+    if not _active(settings):
+        return None
+    target = source.get("node_name")
+    if (not isinstance(target, str) or not target or "\0" in target
+            or target in ("0", "-1") or target.startswith(FX_NODE_PREFIX)):
+        raise ValueError("an effect chain requires a raw node_name")
+    label = source.get("name", source["id"])
+    if not isinstance(label, str) or "\0" in label:
+        raise ValueError("source name must be a string without NUL")
+
+    nodes, links, inputs, outputs = [], [], [], []
+    downmix = settings["mono"] and channels == 2
+    output_channels = 1 if settings["mono"] else channels
+    if downmix:
+        nodes.append({"type": "builtin", "name": "downmix", "label": "mixer",
+                      "control": {"Gain 1": 0.5, "Gain 2": 0.5}})
+        inputs.extend(("downmix:In 1", "downmix:In 2"))
+
+    for channel in range(output_channels):
+        strip = []
+
+        def add(name, label, control=None, plugin=None, config=None):
+            name = f"{name}_{channel}"
+            node = {"type": "ladspa" if plugin else "builtin", "name": name,
+                    "label": label}
+            if control:
+                node["control"] = control
+            if plugin:
+                node["plugin"] = plugin
+            if config:
+                node["config"] = config
+            nodes.append(node)
+            strip.append((name + (":Input" if plugin else ":In"),
+                          name + (":Output" if plugin else ":Out")))
+
+        if settings["lowcut"]:
+            add("hp", "bq_highpass", {"Freq": settings["lowcut"], "Q": 0.70710678})
+        if settings["gate"]:
+            add("gate", "gate", {
+                "Threshold (dB)": settings["gate_thresh"],
+                "Attack (ms)": 10.0, "Hold (ms)": 120.0, "Decay (ms)": 150.0,
+                "Range (dB)": -70.0, "LF key filter (Hz)": 40.0,
+                "HF key filter (Hz)": 20000.0,
+                "Output select (-1 = key listen, 0 = gate, 1 = bypass)": 0.0,
+            }, plugin="gate_1410")
+        if settings["comp"] and settings["comp_ratio"] > 1:
+            add("comp", "sc4m", {
+                "Threshold level (dB)": settings["comp_thresh"],
+                "Ratio (1:n)": settings["comp_ratio"], "RMS/peak": 0.0,
+                "Attack time (ms)": 15.0, "Release time (ms)": 150.0,
+                "Knee radius (dB)": 3.0, "Makeup gain (dB)": 0.0,
+            }, plugin="sc4m_1916")
+        for key, label_name, freq in (("eq_low", "bq_lowshelf", 100.0),
+                                      ("eq_mid", "bq_peaking", 1000.0),
+                                      ("eq_high", "bq_highshelf", 8000.0)):
+            if settings[key]:
+                add(key, label_name, {"Freq": freq, "Gain": settings[key], "Q": 0.70710678})
+        if settings["delay_ms"]:
+            add("delay", "delay", {"Delay (s)": settings["delay_ms"] / 1000.0},
+                config={"max-delay": 1.0})
+        if not strip:
+            add("thru", "copy")
+        links.extend({"output": a[1], "input": b[0]}
+                     for a, b in zip(strip, strip[1:]))
+        if downmix:
+            links.append({"output": "downmix:Out", "input": strip[0][0]})
+        else:
+            inputs.append(strip[0][0])
+        outputs.append(strip[-1][1])
+
+    description = "OpenWave FX: " + label
+    capture_position = ["MONO"] if channels == 1 else ["FL", "FR"]
+    output_position = ["MONO"] if output_channels == 1 else ["FL", "FR"]
+    args = {
+        "node.description": description,
+        "media.name": node_name,
+        "audio.rate": 48000,
+        "filter.graph": {"nodes": nodes, "links": links, "inputs": inputs, "outputs": outputs},
+        "capture.props": {
+            "node.name": node_name + "_cap", "media.name": node_name + "_cap",
+            "target.object": target, "node.passive": True,
+            "node.dont-reconnect": True, "application.name": "OpenWave",
+            "node.dont-fallback": True, "node.dont-move": True,
+            "node.description": description + " (capture)",
+            "audio.channels": channels, "audio.position": capture_position,
+        },
+        "playback.props": {
+            "node.name": node_name, "media.name": node_name,
+            "media.class": "Audio/Source", "application.name": "OpenWave",
+            "node.description": description,
+            "audio.channels": output_channels, "audio.position": output_position,
+        },
+    }
+    # JSON is valid SPA syntax; serialize every string, including all metadata.
+    return json.dumps({
+        "context.properties": {"log.level": 2},
+        "context.spa-libs": {"audio.convert.*": "audioconvert/libspa-audioconvert",
+                             "support.*": "support/libspa-support"},
+        "context.modules": [
+            {"name": "libpipewire-module-rt", "args": {"nice.level": -11},
+             "flags": ["ifexists", "nofail"]},
+            {"name": "libpipewire-module-protocol-native"},
+            {"name": "libpipewire-module-client-node"},
+            {"name": "libpipewire-module-adapter"},
+            {"name": "libpipewire-module-filter-chain", "args": args},
+        ],
+    }, allow_nan=False, indent=2) + "\n"

--- a/wavexlr/mixer.py
+++ b/wavexlr/mixer.py
@@ -14,8 +14,10 @@ import os
 import subprocess
 import threading
 import uuid
+import tempfile
+import time
 
-from . import child, mixes as mix_store, sources
+from . import child, effects, mixes as mix_store, sources
 
 _log = logging.getLogger(__name__)
 CONFIG_PATH = os.path.join(os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")), "openwave", "mixes.json")
@@ -245,6 +247,11 @@ class SubprocessPipeWire:
         except OSError:
             return None
 
+    @staticmethod
+    def spawn_filter(config_path):
+        return child.spawn(["pipewire", "-c", config_path],
+                           stdout=subprocess.DEVNULL)
+
 
 class Mixer:
     """Desired state setters enqueue work; stop is a synchronous drain barrier.
@@ -306,6 +313,10 @@ class Mixer:
         self._graph = None
         self._error = None
         self._procs = {}
+        self._effects = {}
+        self._effects_retry = {}
+        self._effects_directory = None
+        self._effects_error = None
         self._owned_sinks = {}
         self._moved = {}
         self.mic = self.hp = None
@@ -575,7 +586,7 @@ class Mixer:
                     self._discover(graph)
                     self._reconcile(graph)
                     with self._lock:
-                        self._error = None
+                        self._error = self._effects_error
                 except Exception as exc:
                     with self._lock:
                         self._error = str(exc)
@@ -653,6 +664,73 @@ class Mixer:
         route = self._procs.pop(key, None)
         if route is not None:
             self._reap(route["proc"])
+
+    def _drop_effect(self, source_id):
+        effect = self._effects.pop(source_id, None)
+        if effect is not None:
+            self._reap(effect["proc"])
+            try:
+                os.unlink(effect["path"])
+            except FileNotFoundError:
+                pass
+
+    def _sync_effects(self, graph, records):
+        """An unavailable requested chain is silent, never an implicit raw bypass."""
+        effective, wanted, errors = {}, set(), []
+        captures = {item["name"]: item for item in graph["captures"]}
+        now = time.monotonic()
+        for sid, source in records.items():
+            if sources.kind(source) != sources.KIND_DEVICE or not effects.fx_active(source):
+                continue
+            effective[sid] = None
+            capture = captures.get(source["node_name"])
+            if capture is None:
+                continue
+            wanted.add(sid)
+            settings = effects.fx(source)
+            spec = (capture.get("identity"), source["node_name"], source["name"],
+                    source.get("channels", 2), tuple(settings.items()))
+            current = self._effects.get(sid)
+            if current is not None and (current["spec"] != spec or current["proc"].poll() is not None):
+                self._drop_effect(sid)
+                current = None
+            if current is None:
+                previous, retry_after = self._effects_retry.get(sid, (None, 0))
+                if previous == spec and now < retry_after:
+                    errors.append(f"Effects unavailable for {source['name']}; retrying shortly")
+                    continue
+                self._effects_retry[sid] = (spec, now + 5)
+                try:
+                    owner = uuid.uuid4().hex
+                    rendered = effects.render_fx_config(source, owner=owner)
+                    if self._effects_directory is None:
+                        self._effects_directory = tempfile.TemporaryDirectory(prefix="openwave-fx-")
+                    path = os.path.join(self._effects_directory.name, sid + ".conf")
+                    with open(path, "w", encoding="utf-8") as file:
+                        file.write(rendered)
+                    proc = self._pw.spawn_filter(path)
+                    current = {"proc": proc, "path": path, "spec": spec, "owner": owner,
+                               "name": effects.fx_node_name(sid), "started": now}
+                    self._effects[sid] = current
+                except (OSError, ValueError, GraphError) as error:
+                    errors.append(f"Effects unavailable for {source['name']}: {error}")
+                    continue
+            node = graph["nodes"].get(current["name"])
+            if node and node.get("props", {}).get("openwave.owner") == current["owner"]:
+                effective[sid] = current["name"]
+            elif now - current["started"] > 5:
+                self._drop_effect(sid)
+                errors.append(f"Effects failed to initialize for {source['name']}")
+            else:
+                errors.append(f"Starting effects for {source['name']}")
+        for sid in list(self._effects):
+            if sid not in wanted:
+                self._drop_effect(sid)
+        for sid in list(self._effects_retry):
+            if sid not in wanted:
+                del self._effects_retry[sid]
+        self._effects_error = "; ".join(errors) or None
+        return effective
 
     def _route(self, key, source, target, name, volume, muted, graph, *, publish=False, description=None):
         spec = (source, target, publish, description)
@@ -755,6 +833,7 @@ class Mixer:
         ready = {mid for mid, mix in mixes.items() if self._ensure_sink(mix["sink"], mix["description"], graph)}
         ready &= self._sync_masters(graph, mixes)
         claims = claim_streams(records, graph["streams"])
+        processed = self._sync_effects(graph, records)
         desired = set()
         # Silence departing/muted sends before any group hand-over opens another.
         for key, route in list(self._procs.items()):
@@ -788,6 +867,9 @@ class Mixer:
             else:
                 capture = source.get("node_name")
                 if capture not in {item["name"] for item in graph["captures"]}:
+                    continue
+                capture = processed.get(sid, capture)
+                if capture is None:
                     continue
             for mid in ready:
                 cell = state.get(f"{sid}.{mid}", {})
@@ -849,6 +931,11 @@ class Mixer:
     def _teardown(self):
         for key in list(self._procs):
             self._drop_route(key)
+        for sid in list(self._effects):
+            self._drop_effect(sid)
+        if self._effects_directory is not None:
+            self._effects_directory.cleanup()
+            self._effects_directory = None
         try:
             graph = self._pw.snapshot()
             self._restore_streams(graph, {})

--- a/wavexlr/mixmatrix.py
+++ b/wavexlr/mixmatrix.py
@@ -21,6 +21,7 @@ gi.require_version("Adw", "1")
 from gi.repository import Gtk, Adw, GObject, Gdk, GLib, Pango  # noqa: E402
 
 from . import icons
+from .effects import FX_RANGES
 
 
 def _emit_later(obj, signal, *args):
@@ -995,7 +996,7 @@ class SourceCell(Gtk.Box):
             r.append(widget)
             box.append(r)
 
-        auto_btn = Gtk.Button(label="Auto-calibrate gate + comp")
+        auto_btn = Gtk.Button(label="Auto-calibrate microphone")
         # Defer calibration until the popover's Wayland grab is released.
         auto_btn.connect("clicked",
                          lambda _b: (pop.popdown(),
@@ -1027,14 +1028,14 @@ class SourceCell(Gtk.Box):
 
         self._fx_gate = switch()
         row("Gate", self._fx_gate)
-        self._fx_gate_thresh = scale(-70, -20, 1)
+        self._fx_gate_thresh = scale(*FX_RANGES["gate_thresh"], 1)
         row("Gate dB", self._fx_gate_thresh)
 
         self._fx_comp = switch()
         row("Comp", self._fx_comp)
-        self._fx_comp_thresh = scale(-40, 0, 1)
+        self._fx_comp_thresh = scale(*FX_RANGES["comp_thresh"], 1)
         row("Comp dB", self._fx_comp_thresh)
-        self._fx_comp_ratio = scale(1, 10, 0.5, digits=1)
+        self._fx_comp_ratio = scale(*FX_RANGES["comp_ratio"], 0.5, digits=1)
         row("Ratio", self._fx_comp_ratio)
 
         # A slider whose effect is off is either misleading (it moves,
@@ -1099,7 +1100,7 @@ class SourceCell(Gtk.Box):
         self.emit(self.__FX_SIGNAL)
 
     def fx_settings(self):
-        """The popover's current values, in the sources.DEFAULT_FX shape."""
+        """The popover's current values in the effects.DEFAULT_FX schema."""
         lowcut = (0, 80, 120)[self._fx_lowcut.get_selected()]
         return {
             "lowcut": lowcut,

--- a/wavexlr/sources.py
+++ b/wavexlr/sources.py
@@ -8,6 +8,8 @@ import re
 import tempfile
 import uuid
 
+from . import effects
+
 CONFIG_PATH = os.path.join(os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")), "openwave", "sources.json")
 KIND_APP = "app"
 KIND_DEVICE = "device"
@@ -92,6 +94,8 @@ def normalize(records):
         for field in ("name", "icon_name", "group", "node_name"):
             if not isinstance(source[field], str):
                 raise ValueError(f"Source {field} must be a string")
+        if "fx" in source:
+            source["fx"] = effects.fx(source)
         source["group"] = group(source)
         if source["group"] and not source["muted"]:
             if source["group"] in live_groups:


### PR DESCRIPTION
Reviewed replacement for #8, part 9/12. Original contribution: Zedwil / NyleGarcia.

## Stack
Depends on https://github.com/rikkichy/openwave/pull/20; base is `pr8-08-scenes-actions`. Merge the parent first. These are ordered review slices, not independent cherry-picks.

## Scope
- Validate and render per-capture low cut, gate, compressor, EQ, delay and optional mono using owned PipeWire filter processes.
- Preserve stereo and exact neutral bypass; a failed enabled chain silences sends instead of exposing unprocessed audio.
- Measure the raw selected capture in a cancellable worker, require explicit proposal acceptance, and reject stale hotplug identities. Never adjust hardware gain or phantom power.

## Verification
Real private PipeWire/SWH PCM verified stereo EQ, mono, gate/compressor, bypass and failed-plugin silence. Actual GTK calibration remained responsive; cancel left settings untouched, explicit apply worked, and unplug/replug prevented stale application.

Runtime scenarios were exercised on the integrated stack. Hardware-facing tests do not imply physical USB/phantom-power certification.
