### PR TITLE
Add observe-only health monitoring with bounded opt-in recovery

### DIFF
--- a/tests/test_diag.py
+++ b/tests/test_diag.py
@@ -1,0 +1,116 @@
+"""Opt-in diagnostics must not open USB or expose private details by default."""
+
+import builtins
+import contextlib
+import io
+import json
+import os
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+from wavexlr import daemon, diag
+
+
+class Privacy(unittest.TestCase):
+    def test_paths_are_redacted_in_both_modes_including_errors(self):
+        secret_paths = [
+            os.path.expanduser("~/private/project"),
+            "/opt/private/python",
+            "/srv/private/workspace",
+            "/tmp/private folder/audio.wav",
+        ]
+        def broken():
+            raise OSError("failed at '/srv/private/workspace'")
+        for full in (False, True):
+            with self.subTest(full=full):
+                text = diag.assemble(full=full, sections=(
+                    ("Paths", lambda: " ".join(repr(path) for path in secret_paths)),
+                    ("Broken", broken),
+                    ("Good", lambda: "survived"),
+                ))
+                for path in secret_paths:
+                    self.assertNotIn(path, text)
+                self.assertNotIn("private folder", text)
+                self.assertIn("survived", text)
+                self.assertIn("https://github.com/rikkichy/openwave", text)
+
+    def test_default_graph_withholds_serial_and_description(self):
+        node = {"info": {"state": "running", "props": {
+            "node.name": "alsa_input.usb-Elgato_XLR_Dock_PRIVATE_SERIAL-00.mono-fallback",
+            "node.description": "PRIVATE_DESCRIPTION",
+        }}}
+        with mock.patch.object(diag, "_run", return_value=json.dumps([node])):
+            text = diag.collect_pipewire()
+            self.assertNotIn("PRIVATE_SERIAL", text)
+            self.assertNotIn("PRIVATE_DESCRIPTION", text)
+            self.assertIn("running", text)
+            self.assertIn("PRIVATE_SERIAL", diag.collect_pipewire(full=True))
+
+    def test_full_does_not_authorize_usb_reads(self):
+        with mock.patch.object(diag, "collect_device", return_value="device read") as device:
+            sections = (("Device", device),)
+            for full in (False, True):
+                diag.assemble(full=full, sections=sections)
+            device.assert_not_called()
+            self.assertIn("device read", diag.assemble(device=True, sections=sections))
+
+    def test_device_details_do_not_read_config_or_reveal_serial_by_default(self):
+        dev = types.SimpleNamespace(
+            profile=types.SimpleNamespace(display_name="Dock", vid=0x0fd9, pid=0x00ab, config_len=4),
+            usbbus="001/002", _card=2,
+            read_device_info=mock.Mock(return_value={"fw_version": "1", "api_version": "2", "serial": "SECRET_SERIAL"}),
+            read_config=mock.Mock(return_value=b"ABCD"),
+        )
+        text = "\n".join(diag.describe_device(dev))
+        self.assertNotIn("SECRET_SERIAL", text)
+        self.assertIn("0fd9:00ab", text)
+        dev.read_config.assert_not_called()
+        text = "\n".join(diag.describe_device(dev, full=True))
+        self.assertIn("SECRET_SERIAL", text)
+        self.assertIn("41 42 43 44", text)
+
+    def test_default_config_summary_never_includes_app_names(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "sources.json")
+            with open(path, "w") as stream:
+                json.dump({"private": "SECRET_APP_NAME"}, stream)
+            with mock.patch.object(diag.os.path, "expanduser", return_value=path):
+                self.assertNotIn("SECRET_APP_NAME", diag.collect_configs())
+                self.assertIn("SECRET_APP_NAME", diag.collect_configs(full=True))
+
+    def test_journal_is_not_collected_without_full(self):
+        with mock.patch.object(diag, "_run") as run:
+            diag.collect_journal()
+            run.assert_not_called()
+
+    def test_export_is_private_and_never_overwrites_existing_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "report.txt")
+            with mock.patch.object(diag, "assemble", return_value="safe report"), contextlib.redirect_stdout(io.StringIO()):
+                diag.main(["-o", path])
+                self.assertEqual(os.stat(path).st_mode & 0o777, 0o600)
+                with self.assertRaises(FileExistsError):
+                    diag.main(["-o", path])
+            with open(path) as stream:
+                self.assertEqual(stream.read(), "safe report")
+
+
+class HeadlessCli(unittest.TestCase):
+    def test_help_and_version_precede_audio_usb_and_gi_imports(self):
+        real_import = builtins.__import__
+        def guarded(name, *args, **kwargs):
+            if name in ("audio", "device", "health", "gi") or name.startswith(("gi.", "wavexlr.audio", "wavexlr.device")):
+                raise AssertionError(f"premature import: {name}")
+            return real_import(name, *args, **kwargs)
+        with mock.patch("builtins.__import__", side_effect=guarded):
+            for main in (daemon.main, diag.main):
+                for flag in ("--help", "--version"):
+                    with self.subTest(main=main.__module__, flag=flag), contextlib.redirect_stdout(io.StringIO()), self.assertRaises(SystemExit) as exit:
+                        main([flag])
+                    self.assertEqual(exit.exception.code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -6,6 +6,7 @@ audio that every layer reports as healthy, and acting too eagerly cycles
 hardware underneath someone who is using it.
 """
 
+import json
 import threading
 import unittest
 from unittest import mock
@@ -47,16 +48,39 @@ class ParsingPwTop(unittest.TestCase):
         self.assertNotIn("FORMAT", counts)
 
 
+class WatchedOutputs(unittest.TestCase):
+    def test_follows_real_output_links_not_target_hints_or_capture_legs(self):
+        def node(ident, name, media_class, **props):
+            return {"id": ident, "type": "PipeWire:Interface:Node",
+                    "info": {"state": "running",
+                             "props": {"node.name": name, "media.class": media_class, **props}}}
+
+        def link(source, target):
+            return {"type": "PipeWire:Interface:Link",
+                    "info": {"output-node-id": source, "input-node-id": target}}
+
+        alsa = {"api.alsa.pcm.card": 0, "api.alsa.pcm.device": 1}
+        dump = [
+            node(1, DOCK, "Audio/Source"),
+            node(2, SINK, "Audio/Sink", **alsa),
+            node(3, "alsa_output.unrelated", "Audio/Sink", **alsa),
+            node(4, "openwave_loop_output_personal_cap", "Stream/Input/Audio"),
+            node(5, "openwave_loop_output_personal", "Stream/Output/Audio",
+                 **{"target.object": "alsa_output.unrelated"}),
+            node(6, "unrelated_player", "Stream/Output/Audio"),
+            link(5, 2), link(4, 3), link(6, 3),
+        ]
+        captures, sinks = health.snapshot_graph(mock.Mock(run=lambda _args: json.dumps(dump)))
+        self.assertEqual(captures, {DOCK: True})
+        self.assertEqual(sinks, {SINK: {"running": True, "card": 0, "device": 1, "subdevice": 0}})
+
+
 class GlitchDeciding(unittest.TestCase):
     def setUp(self):
-        self.w = health.GlitchWatch(
-            threshold=50, confirm=2, cooldown_seconds=60, max_attempts=2)
+        self.w = health.GlitchWatch(threshold=50, confirm=2)
 
-    def feed(self, counts, start=0.0, step=10.0):
-        verdicts = []
-        for i, c in enumerate(counts):
-            verdicts.append(self.w.observe(DOCK, c, start + i * step))
-        return verdicts
+    def feed(self, counts):
+        return [self.w.observe(DOCK, count) for count in counts]
 
     def test_first_sight_only_baselines(self):
         """A node first seen with a huge historical count has not been
@@ -72,7 +96,6 @@ class GlitchDeciding(unittest.TestCase):
         # ~23 xruns/s over 10 s windows, as measured on hardware.
         self.feed([0, 230, 460])
         self.assertTrue(self.w.glitching(DOCK))
-        self.assertTrue(self.w.should_recover(DOCK, now=100.0))
 
     def test_one_burst_is_an_event_not_a_state(self):
         """A single bad window (game launch, compile) must not cycle a
@@ -92,84 +115,19 @@ class GlitchDeciding(unittest.TestCase):
         self.feed([30000, 30230, 5])
         self.assertFalse(self.w.glitching(DOCK))
 
-    def test_attempts_are_capped(self):
-        self.feed([0, 230, 460])
-        self.w.record_attempt(DOCK, 20.0)
-        self.feed([690, 920], start=100.0)
-        self.w.record_attempt(DOCK, 120.0)
-        self.feed([1150, 1380], start=300.0)
-        self.assertFalse(self.w.should_recover(DOCK, now=400.0))
-
-    def test_cooldown_blocks_a_rapid_second_attempt(self):
-        self.feed([0, 230, 460])
-        self.w.record_attempt(DOCK, 20.0)
-        self.feed([690], start=30.0)
-        self.assertFalse(self.w.should_recover(DOCK, now=30.0))
-        self.assertTrue(self.w.should_recover(DOCK, now=90.0))
-
-    def test_one_clean_window_does_not_refill_the_budget(self):
-        """The loop observed on hardware: a card cycle buys a quiet
-        window while the capture reopens, the refill re-arms, and a
-        persistent fault becomes a pop every two minutes. One quiet
-        window is the incident still going, not recovery."""
-        w = health.GlitchWatch(threshold=50, confirm=2,
-                               cooldown_seconds=60, max_attempts=2,
-                               clean_refill=3)
-        for i, c in enumerate([0, 230, 460]):
-            w.observe(DOCK, c, i * 10.0)
-        w.record_attempt(DOCK, 20.0)
-        w.record_attempt(DOCK, 90.0)
-        w.observe(DOCK, 461, 100.0)            # one quiet window
-        for i, c in enumerate([700, 940, 1180]):
-            w.observe(DOCK, c, 200.0 + i * 10.0)
-        self.assertFalse(w.should_recover(DOCK, now=300.0))
-
-    def test_sustained_quiet_refills_the_budget(self):
-        """Recovery is per incident, not per process lifetime — but the
-        incident has to actually end first."""
-        w = health.GlitchWatch(threshold=50, confirm=2,
-                               cooldown_seconds=60, max_attempts=2,
-                               clean_refill=3)
-        for i, c in enumerate([0, 230, 460]):
-            w.observe(DOCK, c, i * 10.0)
-        w.record_attempt(DOCK, 20.0)
-        w.record_attempt(DOCK, 90.0)
-        for i, c in enumerate([461, 462, 463]):  # sustained quiet
-            w.observe(DOCK, c, 100.0 + i * 10.0)
-        for i, c in enumerate([700, 940, 1180]):  # a fresh incident
-            w.observe(DOCK, c, 300.0 + i * 10.0)
-        self.assertTrue(w.should_recover(DOCK, now=400.0))
-
-    def test_a_post_cycle_counter_reset_is_not_a_clean_window(self):
-        """The reset after a card cycle proves nothing about the fault;
-        counting it toward refill would shave a window off the leash."""
-        w = health.GlitchWatch(threshold=50, confirm=2,
-                               cooldown_seconds=60, max_attempts=2,
-                               clean_refill=2)
-        for i, c in enumerate([0, 230, 460]):
-            w.observe(DOCK, c, i * 10.0)
-        w.record_attempt(DOCK, 20.0)
-        w.record_attempt(DOCK, 90.0)
-        w.observe(DOCK, 5, 100.0)     # recreated: baseline, not clean
-        w.observe(DOCK, 6, 110.0)     # one genuinely clean window
-        for i, c in enumerate([200, 440, 680]):
-            w.observe(DOCK, c, 200.0 + i * 10.0)
-        self.assertFalse(w.should_recover(DOCK, now=300.0))
-
     def test_confirmation_fires_exactly_once_per_incident(self):
         """The window that crosses `confirm` is the one to log; every
         later glitchy window would repeat the same warning every 10 s
         for the life of the fault."""
         self.feed([0, 230, 460])
         self.assertTrue(self.w.just_confirmed(DOCK))
-        self.feed([690], start=100.0)
+        self.feed([690])
         self.assertFalse(self.w.just_confirmed(DOCK))
         self.assertTrue(self.w.glitching(DOCK))
 
-    def test_forget_starts_clean(self):
+    def test_pause_requires_a_new_baseline(self):
         self.feed([0, 230, 460])
-        self.w.record_attempt(DOCK, 20.0)
-        self.w.forget(DOCK)
+        self.w.pause(DOCK)
         self.assertEqual(self.feed([9000]), [False])
         self.assertFalse(self.w.glitching(DOCK))
 
@@ -313,6 +271,48 @@ class MonitorBehavior(unittest.TestCase):
         self.feed(monitor, [0, 230, 460, 690, 920, 1150, 1380])
         self.assertEqual(self.cycle.call_count, 2)
         self.assertEqual(self.recycle.call_count, 2)
+
+    def test_no_data_and_xruns_share_one_card_budget_and_cooldown(self):
+        gaps = {DOCK: 9}
+        monitor = health.HealthMonitor(auto_recover=True, capture_gaps=lambda: gaps)
+        self.feed(monitor, [0], 0)
+        self.assertEqual(self.cycle.call_count, 1)
+        gaps[DOCK] = 0
+        with mock.patch.object(health, "sample_xruns", return_value={DOCK: 230}):
+            monitor.check_once(10)
+        with mock.patch.object(health, "sample_xruns", return_value={DOCK: 460}):
+            monitor.check_once(20)
+        self.assertEqual(self.cycle.call_count, 1)
+        self.feed(monitor, [690], 60)
+        self.assertEqual(self.cycle.call_count, 2)
+        gaps[DOCK] = 90
+        self.feed(monitor, [690, 690], 300)
+        self.assertEqual(self.cycle.call_count, 2)
+
+    def test_refill_requires_healthy_bytes_and_xruns_for_five_minutes(self):
+        gaps = {DOCK: 0}
+        monitor = health.HealthMonitor(auto_recover=True, capture_gaps=lambda: gaps)
+        self.feed(monitor, [0, 230, 460, 690])
+        self.assertEqual(self.cycle.call_count, 2)
+        self.feed(monitor, [690], 300)
+        self.feed(monitor, [690], 599)
+        gaps[DOCK] = 9
+        self.feed(monitor, [690], 600)
+        self.assertEqual(self.cycle.call_count, 2)
+        gaps[DOCK] = 0
+        self.feed(monitor, [690], 700)
+        self.feed(monitor, [690], 1000)
+        gaps[DOCK] = 9
+        self.feed(monitor, [690], 1001)
+        self.assertEqual(self.cycle.call_count, 3)
+
+    def test_counter_recreation_does_not_start_the_clean_interval(self):
+        monitor = health.HealthMonitor(auto_recover=True, capture_gaps=lambda: {DOCK: 0})
+        self.feed(monitor, [0, 230, 460, 690])
+        self.feed(monitor, [0], 300)
+        self.feed(monitor, [1], 600)
+        self.feed(monitor, [231, 461], 601)
+        self.assertEqual(self.cycle.call_count, 2)
 
     def test_muted_idle_or_unknown_capture_needs_a_new_baseline(self):
         monitor = health.HealthMonitor(auto_recover=True)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -288,8 +288,12 @@ class MonitorBehavior(unittest.TestCase):
         patcher = mock.patch.object(health.recovery, "card_name_for", return_value="alsa_card.dock")
         patcher.start()
         self.addCleanup(patcher.stop)
-        self.cycle = self.enterContext(mock.patch.object(health.recovery, "cycle_card"))
-        self.recycle = self.enterContext(mock.patch.object(health, "recycle_sink"))
+        patcher = mock.patch.object(health.recovery, "cycle_card")
+        self.cycle = patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = mock.patch.object(health, "recycle_sink")
+        self.recycle = patcher.start()
+        self.addCleanup(patcher.stop)
 
     def feed(self, monitor, counts, start=0):
         for index, count in enumerate(counts):
@@ -336,6 +340,43 @@ class MonitorBehavior(unittest.TestCase):
         self.sample_source_mutes.return_value = {DOCK: False}
         self.feed(monitor, [1380, 1610, 1840], 500)
         self.assertEqual(self.cycle.call_count, 2)
+
+    def test_valid_graph_omission_does_not_refill_either_remedy_budget(self):
+        monitor = health.HealthMonitor(auto_recover=True)
+        self.feed(monitor, [0, 230, 460, 690], 0)
+        self.assertEqual(self.cycle.call_count, 2)
+        self.assertEqual(self.recycle.call_count, 2)
+        self.snapshot_graph.return_value = ({}, {})
+        monitor.check_once(300)
+        self.snapshot_graph.return_value = self.graph
+        # A recreated counter starts at zero; no clean period has occurred.
+        self.feed(monitor, [0, 230, 460, 690], 400)
+        self.assertEqual(self.cycle.call_count, 2)
+        self.assertEqual(self.recycle.call_count, 2)
+
+    def test_valid_graph_omission_preserves_both_remedy_cooldowns(self):
+        monitor = health.HealthMonitor(auto_recover=True)
+
+        def sample(now, count):
+            with mock.patch.object(health, "sample_xruns", return_value={DOCK: count}):
+                monitor.check_once(now)
+
+        sample(0, 0)
+        sample(10, 230)
+        sample(20, 460)
+        self.assertEqual(self.cycle.call_count, 1)
+        self.assertEqual(self.recycle.call_count, 1)
+        self.snapshot_graph.return_value = ({}, {})
+        monitor.check_once(21)
+        self.snapshot_graph.return_value = self.graph
+        sample(22, 0)
+        sample(23, 230)
+        sample(24, 460)
+        self.assertEqual(self.cycle.call_count, 1)
+        self.assertEqual(self.recycle.call_count, 1)
+        sample(80, 690)
+        self.assertEqual(self.cycle.call_count, 2)
+        self.assertEqual(self.recycle.call_count, 2)
 
     def test_stop_cancels_and_reaps_a_blocked_sampler_before_returning(self):
         entered = threading.Event()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,408 @@
+"""The watchdogs for faults every byte-level check passes.
+
+Both decisions are pure so they can be tested without a sound card, and
+both mistakes are silent: missing the fault leaves robotic or inaudible
+audio that every layer reports as healthy, and acting too eagerly cycles
+hardware underneath someone who is using it.
+"""
+
+import threading
+import unittest
+from unittest import mock
+
+from wavexlr import health
+
+
+DOCK = ("alsa_input.usb-Elgato_Systems_Elgato_XLR_Dock_A8A9A40411NOP9-00"
+        ".mono-fallback")
+SINK = "alsa_output.usb-SteelSeries_Arctis_Nova_Pro_Wireless-00.analog-stereo"
+
+
+# Real pw-top output shapes, including the quirks the parser must
+# survive: the header, '---' placeholder rows, '???' warmup ratios, the
+# FORMAT column being present, absent, or three tokens wide, and the
+# first iteration printing zeros before the profiler warms up.
+PW_TOP_OUTPUT = f"""\
+S   ID  QUANT   RATE    WAIT    BUSY   W/Q   B/Q  ERR FORMAT           NAME
+C   73      0      0    ---     ---   ---   ---     0                  {DOCK}
+R   73      0      0   0.0us   0.0us  ???   ???     0    S24LE 1 48000 {DOCK}
+S   ID  QUANT   RATE    WAIT    BUSY   W/Q   B/Q  ERR FORMAT           NAME
+R   73      0      0  12.3us   4.2us  0.00  0.00  30367    S24LE 1 48000  + {DOCK}
+R  199      0      0   1.2us   7.4us  0.00  0.00    5         F32P 1 0  + openwave_fx_2f216c26f5e3
+"""
+
+
+class ParsingPwTop(unittest.TestCase):
+    def test_the_last_iteration_wins(self):
+        counts = health._parse_pw_top(PW_TOP_OUTPUT)
+        self.assertEqual(counts[DOCK], 30367)
+
+    def test_every_printed_node_is_counted(self):
+        counts = health._parse_pw_top(PW_TOP_OUTPUT)
+        self.assertEqual(counts["openwave_fx_2f216c26f5e3"], 5)
+
+    def test_headers_and_placeholder_rows_do_not_crash_or_count(self):
+        counts = health._parse_pw_top(PW_TOP_OUTPUT)
+        self.assertNotIn("NAME", counts)
+        self.assertNotIn("FORMAT", counts)
+
+
+class GlitchDeciding(unittest.TestCase):
+    def setUp(self):
+        self.w = health.GlitchWatch(
+            threshold=50, confirm=2, cooldown_seconds=60, max_attempts=2)
+
+    def feed(self, counts, start=0.0, step=10.0):
+        verdicts = []
+        for i, c in enumerate(counts):
+            verdicts.append(self.w.observe(DOCK, c, start + i * step))
+        return verdicts
+
+    def test_first_sight_only_baselines(self):
+        """A node first seen with a huge historical count has not been
+        observed glitching — the count could be weeks old."""
+        self.assertEqual(self.feed([61994]), [False])
+        self.assertFalse(self.w.glitching(DOCK))
+
+    def test_a_flat_counter_is_healthy(self):
+        self.feed([100, 100, 102, 102])
+        self.assertFalse(self.w.glitching(DOCK))
+
+    def test_the_robotic_fault_is_confirmed_in_two_windows(self):
+        # ~23 xruns/s over 10 s windows, as measured on hardware.
+        self.feed([0, 230, 460])
+        self.assertTrue(self.w.glitching(DOCK))
+        self.assertTrue(self.w.should_recover(DOCK, now=100.0))
+
+    def test_one_burst_is_an_event_not_a_state(self):
+        """A single bad window (game launch, compile) must not cycle a
+        card someone is speaking into."""
+        self.feed([0, 230, 235])
+        self.assertFalse(self.w.glitching(DOCK))
+
+    def test_a_wireless_followers_own_jitter_stays_below_threshold(self):
+        # The Arctis was observed bursting 23 in one window while healthy.
+        self.feed([238, 261, 284])
+        self.assertFalse(self.w.glitching(DOCK))
+
+    def test_a_recreated_node_baselines_instead_of_panicking(self):
+        """The profiler counter resets when a node is recreated; the
+        shrink must start a fresh baseline, not be treated as glitching
+        or as a 4-billion-xrun window."""
+        self.feed([30000, 30230, 5])
+        self.assertFalse(self.w.glitching(DOCK))
+
+    def test_attempts_are_capped(self):
+        self.feed([0, 230, 460])
+        self.w.record_attempt(DOCK, 20.0)
+        self.feed([690, 920], start=100.0)
+        self.w.record_attempt(DOCK, 120.0)
+        self.feed([1150, 1380], start=300.0)
+        self.assertFalse(self.w.should_recover(DOCK, now=400.0))
+
+    def test_cooldown_blocks_a_rapid_second_attempt(self):
+        self.feed([0, 230, 460])
+        self.w.record_attempt(DOCK, 20.0)
+        self.feed([690], start=30.0)
+        self.assertFalse(self.w.should_recover(DOCK, now=30.0))
+        self.assertTrue(self.w.should_recover(DOCK, now=90.0))
+
+    def test_one_clean_window_does_not_refill_the_budget(self):
+        """The loop observed on hardware: a card cycle buys a quiet
+        window while the capture reopens, the refill re-arms, and a
+        persistent fault becomes a pop every two minutes. One quiet
+        window is the incident still going, not recovery."""
+        w = health.GlitchWatch(threshold=50, confirm=2,
+                               cooldown_seconds=60, max_attempts=2,
+                               clean_refill=3)
+        for i, c in enumerate([0, 230, 460]):
+            w.observe(DOCK, c, i * 10.0)
+        w.record_attempt(DOCK, 20.0)
+        w.record_attempt(DOCK, 90.0)
+        w.observe(DOCK, 461, 100.0)            # one quiet window
+        for i, c in enumerate([700, 940, 1180]):
+            w.observe(DOCK, c, 200.0 + i * 10.0)
+        self.assertFalse(w.should_recover(DOCK, now=300.0))
+
+    def test_sustained_quiet_refills_the_budget(self):
+        """Recovery is per incident, not per process lifetime — but the
+        incident has to actually end first."""
+        w = health.GlitchWatch(threshold=50, confirm=2,
+                               cooldown_seconds=60, max_attempts=2,
+                               clean_refill=3)
+        for i, c in enumerate([0, 230, 460]):
+            w.observe(DOCK, c, i * 10.0)
+        w.record_attempt(DOCK, 20.0)
+        w.record_attempt(DOCK, 90.0)
+        for i, c in enumerate([461, 462, 463]):  # sustained quiet
+            w.observe(DOCK, c, 100.0 + i * 10.0)
+        for i, c in enumerate([700, 940, 1180]):  # a fresh incident
+            w.observe(DOCK, c, 300.0 + i * 10.0)
+        self.assertTrue(w.should_recover(DOCK, now=400.0))
+
+    def test_a_post_cycle_counter_reset_is_not_a_clean_window(self):
+        """The reset after a card cycle proves nothing about the fault;
+        counting it toward refill would shave a window off the leash."""
+        w = health.GlitchWatch(threshold=50, confirm=2,
+                               cooldown_seconds=60, max_attempts=2,
+                               clean_refill=2)
+        for i, c in enumerate([0, 230, 460]):
+            w.observe(DOCK, c, i * 10.0)
+        w.record_attempt(DOCK, 20.0)
+        w.record_attempt(DOCK, 90.0)
+        w.observe(DOCK, 5, 100.0)     # recreated: baseline, not clean
+        w.observe(DOCK, 6, 110.0)     # one genuinely clean window
+        for i, c in enumerate([200, 440, 680]):
+            w.observe(DOCK, c, 200.0 + i * 10.0)
+        self.assertFalse(w.should_recover(DOCK, now=300.0))
+
+    def test_confirmation_fires_exactly_once_per_incident(self):
+        """The window that crosses `confirm` is the one to log; every
+        later glitchy window would repeat the same warning every 10 s
+        for the life of the fault."""
+        self.feed([0, 230, 460])
+        self.assertTrue(self.w.just_confirmed(DOCK))
+        self.feed([690], start=100.0)
+        self.assertFalse(self.w.just_confirmed(DOCK))
+        self.assertTrue(self.w.glitching(DOCK))
+
+    def test_forget_starts_clean(self):
+        self.feed([0, 230, 460])
+        self.w.record_attempt(DOCK, 20.0)
+        self.w.forget(DOCK)
+        self.assertEqual(self.feed([9000]), [False])
+        self.assertFalse(self.w.glitching(DOCK))
+
+
+class SinkStallDeciding(unittest.TestCase):
+    def setUp(self):
+        self.w = health.SinkStallWatch(cooldown_seconds=60, max_attempts=2)
+
+    def test_an_advancing_pointer_is_healthy(self):
+        self.w.observe(SINK, True, 1000, "RUNNING", 0.0)
+        stalled = self.w.observe(SINK, True, 49000, "RUNNING", 10.0)
+        self.assertFalse(stalled)
+
+    def test_the_first_observation_only_baselines(self):
+        """A sink that just started gets a full window before being
+        judged, even though its pointer has no history."""
+        self.assertFalse(self.w.observe(SINK, True, 1000, "RUNNING", 0.0))
+        self.assertFalse(self.w.should_recover(SINK, now=0.0))
+
+    def test_a_static_pointer_while_running_is_a_stall(self):
+        self.w.observe(SINK, True, 1000, "RUNNING", 0.0)
+        stalled = self.w.observe(SINK, True, 1000, "RUNNING", 10.0)
+        self.assertTrue(stalled)
+        self.assertTrue(self.w.should_recover(SINK, now=10.0))
+
+    def test_an_idle_sink_holding_still_is_not_a_stall(self):
+        """Suspended and idle sinks legitimately stop consuming; cycling
+        one would wake hardware nobody is playing to."""
+        self.w.observe(SINK, False, 1000, "SETUP", 0.0)
+        stalled = self.w.observe(SINK, False, 1000, "SETUP", 10.0)
+        self.assertFalse(stalled)
+
+    def test_xrun_state_is_an_immediate_stall(self):
+        stalled = self.w.observe(SINK, True, 1000, "XRUN", 0.0)
+        self.assertTrue(stalled)
+
+    def test_a_missing_proc_entry_is_not_ours_to_judge(self):
+        self.w.observe(SINK, True, None, None, 0.0)
+        stalled = self.w.observe(SINK, True, None, None, 10.0)
+        self.assertFalse(stalled)
+
+    def test_a_recycle_does_not_feed_its_own_reset_back_as_a_stall(self):
+        """suspend/resume resets hw_ptr to zero; comparing the next
+        window against the pre-recycle value would misread recovery."""
+        self.w.observe(SINK, True, 1000, "RUNNING", 0.0)
+        self.w.observe(SINK, True, 1000, "RUNNING", 10.0)
+        self.w.record_attempt(SINK, 10.0)
+        self.assertFalse(self.w.observe(SINK, True, 0, "RUNNING", 20.0))
+
+    def test_attempts_are_capped_and_cooled_down(self):
+        self.w.observe(SINK, True, 1000, "RUNNING", 0.0)
+        self.w.observe(SINK, True, 1000, "RUNNING", 10.0)
+        self.w.record_attempt(SINK, 10.0)
+        self.w.observe(SINK, True, 500, "RUNNING", 20.0)
+        self.w.observe(SINK, True, 500, "RUNNING", 30.0)
+        self.assertFalse(self.w.should_recover(SINK, now=30.0))   # cooling
+        self.assertTrue(self.w.should_recover(SINK, now=80.0))
+        self.w.record_attempt(SINK, 80.0)
+        self.w.observe(SINK, True, 500, "RUNNING", 150.0)
+        self.w.observe(SINK, True, 500, "RUNNING", 160.0)
+        self.assertFalse(self.w.should_recover(SINK, now=300.0))  # spent
+
+    def test_sustained_movement_refills_the_budget(self):
+        w = health.SinkStallWatch(cooldown_seconds=60, max_attempts=2,
+                                  clean_refill=2)
+        w.observe(SINK, True, 1000, "RUNNING", 0.0)
+        w.observe(SINK, True, 1000, "RUNNING", 10.0)
+        w.record_attempt(SINK, 10.0)
+        w.record_attempt(SINK, 80.0)
+        w.observe(SINK, True, 2000, "RUNNING", 90.0)    # moving…
+        w.observe(SINK, True, 50000, "RUNNING", 100.0)  # …recovered
+        w.observe(SINK, True, 90000, "RUNNING", 110.0)
+        w.observe(SINK, True, 90000, "RUNNING", 120.0)  # new stall
+        self.assertTrue(w.should_recover(SINK, now=200.0))
+
+    def test_one_moving_window_does_not_refill(self):
+        """A recycle resets the pointer, and the window after can move
+        once without the PCM being healthy."""
+        w = health.SinkStallWatch(cooldown_seconds=60, max_attempts=2,
+                                  clean_refill=2)
+        w.observe(SINK, True, 1000, "RUNNING", 0.0)
+        w.observe(SINK, True, 1000, "RUNNING", 10.0)
+        w.record_attempt(SINK, 10.0)
+        w.record_attempt(SINK, 80.0)
+        w.observe(SINK, True, 2000, "RUNNING", 90.0)    # moved once
+        w.observe(SINK, True, 2000, "RUNNING", 100.0)   # stalled again
+        w.observe(SINK, True, 2000, "RUNNING", 110.0)
+        self.assertFalse(w.should_recover(SINK, now=300.0))
+
+    def test_a_stall_announces_itself_exactly_once(self):
+        self.w.observe(SINK, True, 1000, "RUNNING", 0.0)
+        self.w.observe(SINK, True, 1000, "RUNNING", 10.0)
+        self.assertTrue(self.w.just_stalled(SINK))
+        self.w.observe(SINK, True, 1000, "RUNNING", 20.0)
+        self.assertFalse(self.w.just_stalled(SINK))
+
+
+class MonitorBehavior(unittest.TestCase):
+    """Every hardware/command seam is fake; synchronization uses events."""
+
+    def setUp(self):
+        self.graph = ({DOCK: True}, {SINK: {
+            "running": True, "card": 1, "device": 0, "subdevice": 0}})
+        for target, value in (
+            ("snapshot_graph", self.graph),
+            ("sample_source_mutes", {DOCK: False}),
+            ("read_playback_status", (1000, "RUNNING")),
+        ):
+            patcher = mock.patch.object(health, target, return_value=value)
+            setattr(self, target, patcher.start())
+            self.addCleanup(patcher.stop)
+        patcher = mock.patch.object(health.recovery, "_listing",
+                                   return_value=[{"name": SINK, "mute": False}])
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = mock.patch.object(health.recovery, "card_name_for", return_value="alsa_card.dock")
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.cycle = self.enterContext(mock.patch.object(health.recovery, "cycle_card"))
+        self.recycle = self.enterContext(mock.patch.object(health, "recycle_sink"))
+
+    def feed(self, monitor, counts, start=0):
+        for index, count in enumerate(counts):
+            with mock.patch.object(health, "sample_xruns", return_value={DOCK: count}):
+                monitor.check_once(start + index * 70)
+
+    def test_default_observes_both_faults_without_modifying_audio(self):
+        monitor = health.HealthMonitor()
+        self.feed(monitor, [0, 230, 460, 690])
+        self.assertTrue(monitor.glitch.glitching(DOCK))
+        self.assertTrue(monitor.stall.should_recover(SINK, 300))
+        self.cycle.assert_not_called()
+        self.recycle.assert_not_called()
+
+    def test_opt_in_remedies_are_capped_at_two(self):
+        monitor = health.HealthMonitor(auto_recover=True)
+        self.feed(monitor, [0, 230, 460, 690, 920, 1150, 1380])
+        self.assertEqual(self.cycle.call_count, 2)
+        self.assertEqual(self.recycle.call_count, 2)
+
+    def test_muted_idle_or_unknown_capture_needs_a_new_baseline(self):
+        monitor = health.HealthMonitor(auto_recover=True)
+        self.feed(monitor, [0, 230])
+        self.sample_source_mutes.return_value = {DOCK: True}
+        self.feed(monitor, [460], 140)
+        self.sample_source_mutes.return_value = {DOCK: False}
+        self.feed(monitor, [10000, 10230], 210)
+        self.cycle.assert_not_called()
+        self.sample_source_mutes.return_value = {}
+        self.feed(monitor, [10460], 350)
+        self.sample_source_mutes.return_value = {DOCK: False}
+        self.graph[0][DOCK] = False
+        self.feed(monitor, [10690], 420)
+        self.cycle.assert_not_called()
+
+    def test_missing_graph_and_mute_do_not_refill_spent_budget(self):
+        monitor = health.HealthMonitor(auto_recover=True)
+        self.feed(monitor, [0, 230, 460, 690], 0)
+        self.snapshot_graph.return_value = None
+        self.feed(monitor, [920], 300)
+        self.snapshot_graph.return_value = self.graph
+        self.sample_source_mutes.return_value = {DOCK: True}
+        self.feed(monitor, [1150], 400)
+        self.sample_source_mutes.return_value = {DOCK: False}
+        self.feed(monitor, [1380, 1610, 1840], 500)
+        self.assertEqual(self.cycle.call_count, 2)
+
+    def test_stop_cancels_and_reaps_a_blocked_sampler_before_returning(self):
+        entered = threading.Event()
+        killed = threading.Event()
+        reaped = threading.Event()
+
+        class Child:
+            returncode = -9
+
+            def communicate(self, timeout=None):
+                entered.set()
+                if not killed.wait(2):
+                    raise AssertionError("collector was not cancelled")
+                reaped.set()
+                return "", ""
+
+            def kill(self):
+                killed.set()
+
+        monitor = health.HealthMonitor(auto_recover=True)
+        with mock.patch.object(health.recovery.subprocess, "Popen", return_value=Child()):
+            monitor.start()
+            try:
+                self.assertTrue(entered.wait(2), "sampler never started")
+            finally:
+                monitor.stop()
+        self.assertTrue(reaped.is_set())
+        self.feed(monitor, [0, 230, 460])
+        self.cycle.assert_not_called()
+        self.recycle.assert_not_called()
+
+    def test_stop_waits_for_an_in_flight_remedy_to_restore_audio(self):
+        entered = threading.Event()
+        release = threading.Event()
+        restored = threading.Event()
+        stopped = threading.Event()
+        monitor = health.HealthMonitor(auto_recover=True)
+
+        def remedy(*args):
+            entered.set()
+            if not release.wait(2):
+                raise AssertionError("restoration was never released")
+            restored.set()
+            return True
+
+        def stop():
+            monitor.stop()
+            stopped.set()
+
+        self.recycle.side_effect = remedy
+        self.feed(monitor, [0])
+        with mock.patch.object(health, "sample_xruns", return_value={DOCK: 0}):
+            monitor.start()
+            stopper = threading.Thread(target=stop)
+            try:
+                self.assertTrue(entered.wait(2), "remedy never started")
+                stopper.start()
+                self.assertTrue(monitor._stop.wait(2), "shutdown never started")
+                self.assertFalse(stopped.is_set(), "stop returned before restoration")
+            finally:
+                release.set()
+                if stopper.ident is not None:
+                    stopper.join(2)
+                monitor.stop()
+        self.assertTrue(restored.is_set())
+        self.assertTrue(stopped.is_set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_meter_lifecycle.py
+++ b/tests/test_meter_lifecycle.py
@@ -138,6 +138,20 @@ class MeterLifecycleTests(unittest.TestCase):
         self.monitor.stop_all()
         self.assertIsNone(self.monitor.silent_for("mic"))
 
+    def test_one_flowing_tap_disproves_a_shared_capture_stall(self):
+        clock = [10.0]
+        self.module.time = types.SimpleNamespace(monotonic=lambda: clock[0])
+        self.monitor.start("flowing", "capture", lambda _peak: None)
+        self.await_condition(lambda: self.monitor.running("flowing"))
+        self.monitor.start("stalled", "capture", lambda _peak: None)
+        self.await_condition(lambda: self.monitor.running("stalled"))
+        clock[0] = 20.0
+        self.processes[0].stdin.write(b"\x00\x00" * 512)
+        self.await_condition(lambda: self.monitor.capture_gaps() == {"capture": 0.0})
+        self.assertEqual(self.monitor.silent_for("stalled"), 10.0)
+        self.monitor.stop("flowing")
+        self.assertEqual(self.monitor.capture_gaps(), {"capture": 10.0})
+
     def test_cancel_during_spawn_still_closes_pipe_and_reaps_child(self):
         entered, release = threading.Event(), threading.Event()
         original_spawn = self.spawn

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -1,0 +1,120 @@
+"""Recovery decisions and transactions without a sound card or command."""
+
+import json
+import unittest
+from unittest import mock
+
+from wavexlr import recovery
+
+DOCK = "alsa_input.usb-Elgato_XLR_Dock_SERIAL-00.mono-fallback"
+
+
+class Deciding(unittest.TestCase):
+    def test_absent_unmetered_and_recently_flowing_are_not_stalled(self):
+        watch = recovery.StallWatch()
+        self.assertFalse(watch.should_recover(DOCK, False, 999, 100))
+        self.assertFalse(watch.should_recover(DOCK, True, None, 100))
+        self.assertFalse(watch.should_recover(DOCK, True, 1, 100))
+        self.assertTrue(watch.should_recover(DOCK, True, 9, 100))
+
+    def test_attempts_have_cooldown_cap_and_separate_device_budgets(self):
+        watch = recovery.StallWatch()
+        watch.record_attempt(DOCK, 100)
+        self.assertFalse(watch.should_recover(DOCK, True, 9, 110))
+        self.assertTrue(watch.should_recover(DOCK, True, 9, 160))
+        watch.record_attempt(DOCK, 160)
+        self.assertFalse(watch.should_recover(DOCK, True, 9, 1000))
+        self.assertTrue(watch.should_recover("other", True, 9, 1000))
+        watch.forget(DOCK)
+        self.assertTrue(watch.should_recover(DOCK, True, 9, 1010))
+
+    def test_only_sustained_flow_refills_an_incident_budget(self):
+        watch = recovery.StallWatch(clean_refill_seconds=300)
+        watch.record_attempt(DOCK, 0)
+        watch.record_attempt(DOCK, 60)
+        watch.record_recovered(DOCK, 100)
+        watch.record_recovered(DOCK, 110)
+        self.assertFalse(watch.should_recover(DOCK, True, 9, 200))
+        watch.record_recovered(DOCK, 210)
+        watch.record_recovered(DOCK, 509)
+        self.assertFalse(watch.should_recover(DOCK, True, 9, 509))
+        watch.record_recovered(DOCK, 600)
+        watch.record_recovered(DOCK, 900)
+        self.assertTrue(watch.should_recover(DOCK, True, 9, 901))
+
+
+class CardIdentity(unittest.TestCase):
+    def test_uses_exact_node_card_index_not_name_stem_or_first_device(self):
+        data = {
+            "sources": [
+                {"name": DOCK + "extra", "card": 1},
+                {"name": DOCK, "card": 2},
+            ],
+            "cards": [
+                {"name": "alsa_card.wrong", "index": 1},
+                {"name": "alsa_card.correct", "index": 2},
+            ],
+        }
+        with mock.patch.object(recovery, "_pactl", side_effect=lambda *a, **k: json.dumps(data[a[-1]])):
+            self.assertEqual(recovery.card_name_for(DOCK), "alsa_card.correct")
+            self.assertIsNone(recovery.card_name_for(DOCK + "missing"))
+            data["sources"].append({"name": DOCK, "card": 1})
+            self.assertIsNone(recovery.card_name_for(DOCK))
+
+    def test_unknown_mapping_never_guesses_a_card(self):
+        with mock.patch.object(recovery, "_pactl", return_value=None):
+            self.assertIsNone(recovery.card_name_for(DOCK))
+
+
+class Cycling(unittest.TestCase):
+    def setUp(self):
+        self.cards = {
+            "alsa_card.other": "off",
+            "alsa_card.dock": "output:analog-stereo+input:mono-fallback",
+        }
+        self.original = self.cards["alsa_card.dock"]
+        self.closed = []
+        self.runner = recovery.CommandRunner()
+        self.cancel_on_off = False
+        self.timeout_on_off = False
+        patcher = mock.patch.object(recovery, "_pactl", side_effect=self.pactl)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def pactl(self, *args, **kwargs):
+        if args[:3] == ("--format=json", "list", "cards"):
+            return json.dumps([{"name": name, "active_profile": profile}
+                               for name, profile in self.cards.items()])
+        action, card, profile = args
+        self.assertEqual(action, "set-card-profile")
+        self.cards[card] = profile
+        if profile == "off":
+            self.closed.append(card)
+            if self.cancel_on_off:
+                self.runner.cancel()
+            if self.timeout_on_off:
+                return None
+        return ""
+
+    def test_restores_exact_original_profile_even_during_stop(self):
+        self.cancel_on_off = True
+        self.assertTrue(recovery.cycle_card("alsa_card.dock", self.runner))
+        self.assertEqual(self.closed, ["alsa_card.dock"])
+        self.assertEqual(self.cards["alsa_card.dock"], self.original)
+        self.assertEqual(self.cards["alsa_card.other"], "off")
+
+    def test_off_timeout_still_restores_potentially_applied_change(self):
+        self.timeout_on_off = True
+        self.assertFalse(recovery.cycle_card("alsa_card.dock", self.runner))
+        self.assertEqual(self.cards["alsa_card.dock"], self.original)
+
+    def test_off_missing_and_cancelled_cards_are_never_touched(self):
+        self.assertFalse(recovery.cycle_card("alsa_card.other", self.runner))
+        self.assertFalse(recovery.cycle_card("alsa_card.absent", self.runner))
+        self.runner.cancel()
+        self.assertFalse(recovery.cycle_card("alsa_card.dock", self.runner))
+        self.assertEqual(self.closed, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wavexlr/app.py
+++ b/wavexlr/app.py
@@ -15,6 +15,7 @@ import threading
 from .device import WaveDevice, DeviceUnresponsiveError, scan
 from .audio import SOURCE_MATCHES
 from .meter import MeterMonitor
+from .health import HealthMonitor
 from .mixer import Mixer, claim_streams, stream_matches, source_sink_name, OUTPUT_AUTO, OUTPUT_NONE
 from .mixmatrix import MixMatrix
 from .mixdialog import MixDialog
@@ -75,6 +76,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self._mixes = mixes_module.load_seeded()
         self._offered_nodes = set(self._load_ui_state().get("offered_capture_nodes", []))
         self.meter = MeterMonitor()
+        self.health = HealthMonitor(capture_gaps=self.meter.capture_gaps)
         self._meter_targets = {}
         self.mixer = Mixer(capture_ready=lambda capture: self.meter.ready(
             capture["name"], capture["identity"]))
@@ -88,6 +90,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
         self._update_service_status()
         self._start_meters()
         self.mixer.start()
+        self.health.start()
         self._start_stream_poll()
         self._try_connect()
         self._schedule_reconnect()
@@ -603,6 +606,7 @@ class WaveXLRWindow(Adw.ApplicationWindow):
     def shutdown(self):
         """Quiesce every device worker before closing its libusb handle."""
         self._shutting_down = True
+        self.health.stop()
         self._cancel_calibration()
         self._calibration_executor.shutdown(wait=False, cancel_futures=True)
         for source_id in list(self._fx_debounce_ids):

--- a/wavexlr/audio.py
+++ b/wavexlr/audio.py
@@ -42,6 +42,8 @@ import threading
 import time
 import logging
 
+from . import child
+
 log = logging.getLogger("wavexlr.audio")
 
 # Every Wave family capture node. Two stems, not one "Elgato_" prefix,
@@ -187,6 +189,7 @@ class _Pin:
         self._proc = None
         self._reader = None
         self._last_data_at = 0.0
+        self._last_flow_at = 0.0
         self._last_signal_at = 0.0
         self._started_at = 0.0
         self._silence_recycles = 0
@@ -199,9 +202,11 @@ class _Pin:
         self.kill()
         now = time.monotonic()
         self._last_data_at = now
+        if not self._last_flow_at:
+            self._last_flow_at = now
         self._last_signal_at = now
         self._started_at = now
-        self._proc = subprocess.Popen(
+        self._proc = child.spawn(
             [
                 "pw-cat", "--record",
                 "--target", self.source_name,
@@ -214,6 +219,8 @@ class _Pin:
                     "node.description": "OpenWave capture keepalive",
                     "media.name": f"OpenWave keepalive: {self.source_name}",
                     "application.name": "OpenWave",
+                    "node.dont-fallback": True,
+                    "node.dont-move": True,
                 }),
                 "-",
             ],
@@ -236,25 +243,20 @@ class _Pin:
         proc, reader = self._proc, self._reader
         self._proc = None
         self._reader = None
-        if proc and proc.poll() is None:
-            try:
+        if proc is not None:
+            if proc.poll() is None:
                 proc.terminate()
-                proc.wait(timeout=SIGTERM_GRACE)
-            except subprocess.TimeoutExpired:
-                # Wedged streams sometimes ignore SIGTERM — kill the
-                # whole process group to be sure.
                 try:
-                    os.killpg(proc.pid, signal.SIGKILL)
-                except (ProcessLookupError, PermissionError):
-                    proc.kill()
-                try:
-                    proc.wait(timeout=1)
+                    proc.wait(timeout=SIGTERM_GRACE)
                 except subprocess.TimeoutExpired:
-                    pass
+                    try:
+                        os.killpg(proc.pid, signal.SIGKILL)
+                    except (ProcessLookupError, PermissionError):
+                        proc.kill()
+            proc.wait()
             log.info(f"Stopped capture keepalive for {self.source_name}")
-        # Reader thread exits when the pipe closes.
-        if reader and reader.is_alive():
-            reader.join(timeout=2)
+        if reader is not None:
+            reader.join()
 
     def _drain(self, proc):
         """Drain pw-cat's stdout, updating the last-data-received timestamp.
@@ -271,6 +273,7 @@ class _Pin:
                 if self._proc is proc:
                     now = time.monotonic()
                     self._last_data_at = now
+                    self._last_flow_at = now
                     if chunk.count(0) != len(chunk):
                         self._last_signal_at = now
         except Exception:
@@ -284,7 +287,8 @@ class _Pin:
     # --- health ---
 
     def _alive(self):
-        return self._proc is not None and self._proc.poll() is None
+        proc = self._proc
+        return proc is not None and proc.poll() is None
 
     def _data_flowing(self):
         return (time.monotonic() - self._last_data_at) < WEDGE_TIMEOUT
@@ -371,6 +375,7 @@ class AudioManager:
         self._running = False
         self._loop_thread = None
         self._pins = {}  # source node name -> _Pin
+        self._capture_pins = ()
         self._stop = threading.Event()
         self._absent_retry = ABSENT_RETRY_INITIAL
         self._status_reported = False
@@ -391,6 +396,13 @@ class AudioManager:
     @property
     def device_present(self):
         return self._device_present
+
+    def capture_gaps(self):
+        """Live byte ages across owned tap restarts, excluding startup and exits."""
+        now = time.monotonic()
+        return {pin.source_name: now - pin._last_flow_at
+                for pin in self._capture_pins
+                if pin._alive() and now - pin._started_at >= STARTUP_GRACE}
 
     def start(self):
         if self._running:
@@ -440,8 +452,9 @@ class AudioManager:
                             break
                         if name not in self._pins:
                             self._pins[name] = _Pin(name)
+                    self._capture_pins = tuple(self._pins.values())
                     states = []
-                    for pin in self._pins.values():
+                    for pin in self._capture_pins:
                         if self._stop.is_set():
                             break
                         states.append(pin.step())
@@ -461,3 +474,4 @@ class AudioManager:
             for pin in self._pins.values():
                 pin.kill()
             self._pins.clear()
+            self._capture_pins = ()

--- a/wavexlr/daemon.py
+++ b/wavexlr/daemon.py
@@ -49,7 +49,7 @@ def main(argv=None):
             log.warning("Establishing capture keepalive...")
 
     manager = AudioManager(on_status_change=on_status)
-    health = HealthMonitor(auto_recover=args.auto_recover)
+    health = HealthMonitor(auto_recover=args.auto_recover, capture_gaps=manager.capture_gaps)
     previous = {sig: signal.signal(sig, shutdown)
                 for sig in (signal.SIGTERM, signal.SIGINT)}
 

--- a/wavexlr/daemon.py
+++ b/wavexlr/daemon.py
@@ -1,47 +1,73 @@
-"""Headless daemon that just runs the audio capture fix."""
+"""Headless capture keepalive with observation-only health checks by default."""
 
+import argparse
 import logging
 import signal
-import time
-import sys
+import threading
 
-from .audio import AudioManager
+from .paths import data_file
 
-logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
 log = logging.getLogger("openwave.daemon")
 
 
-def main():
-    log.info("Starting OpenWave audio daemon")
+def _version():
+    path = data_file("VERSION")
+    if path is not None:
+        try:
+            with open(path) as stream:
+                return stream.read().strip()
+        except OSError:
+            pass
+    return "unknown"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog="openwave-daemon", description=__doc__)
+    parser.add_argument("--version", action="version", version=f"OpenWave {_version()}")
+    parser.add_argument("--auto-recover", action="store_true",
+                        help="allow bounded card-profile cycles and sink suspend/resume on confirmed faults")
+    args = parser.parse_args(argv)
+
+    # --help and --version must work without audio, USB or GTK dependencies.
+    from .audio import AudioManager
+    from .health import HealthMonitor
+
+    logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
+    stopped = threading.Event()
+
+    def shutdown(sig, frame):
+        stopped.set()
 
     def on_status(present, healthy, state):
         if not present:
             log.info("Device not detected")
         elif state == "silent":
-            log.error(
-                "Capture stream is up but every sample is zero -- the device "
-                "is delivering digital silence. Power-cycle it; a USB "
-                "re-enumeration does not clear this state."
-            )
+            log.error("Capture delivers digital silence; power-cycle the device")
         elif healthy:
             log.info("Capture keepalive active")
         else:
             log.warning("Establishing capture keepalive...")
 
-    mgr = AudioManager(on_status_change=on_status)
-    mgr.start()
+    manager = AudioManager(on_status_change=on_status)
+    health = HealthMonitor(auto_recover=args.auto_recover)
+    previous = {sig: signal.signal(sig, shutdown)
+                for sig in (signal.SIGTERM, signal.SIGINT)}
 
-    def shutdown(sig, frame):
-        log.info("Shutting down")
-        mgr.stop()
-        sys.exit(0)
-
-    signal.signal(signal.SIGTERM, shutdown)
-    signal.signal(signal.SIGINT, shutdown)
-
-    # Keep main thread alive
-    while True:
-        time.sleep(3600)
+    try:
+        log.info("Starting OpenWave audio daemon (auto-recover: %s)", args.auto_recover)
+        manager.start()
+        health.start()
+        stopped.wait()
+    finally:
+        try:
+            # Finish any owed restoration before tearing down capture pins.
+            health.stop()
+        finally:
+            try:
+                manager.stop()
+            finally:
+                for sig, handler in previous.items():
+                    signal.signal(sig, handler)
 
 
 if __name__ == "__main__":

--- a/wavexlr/diag.py
+++ b/wavexlr/diag.py
@@ -1,0 +1,301 @@
+"""Opt-in diagnostics: python -m wavexlr.diag [--full] [--device] [-o FILE].
+
+Paths are redacted in both modes. Default reports retain vendor/product IDs,
+but withhold serials, node names/descriptions, journals and config bodies.
+--full includes those private details; review before sharing.
+Only --device permits USB vendor reads: close OpenWave, including its tray,
+first. --full alone never opens a USB handle. No collector writes hardware.
+"""
+
+import argparse
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+TIMEOUT = 3
+
+
+def _run(*argv):
+    """stdout of a command, or a one-line failure note."""
+    try:
+        r = subprocess.run(argv, capture_output=True, text=True,
+                           timeout=TIMEOUT)
+    except FileNotFoundError:
+        return f"({argv[0]}: not found)"
+    except subprocess.TimeoutExpired:
+        return f"({argv[0]}: timed out after {TIMEOUT}s)"
+    out = r.stdout.strip()
+    if r.returncode != 0:
+        err = (r.stderr or "").strip().splitlines()
+        return f"({argv[0]}: exit {r.returncode}{': ' + err[0] if err else ''})"
+    return out
+
+
+def _hexdump(data):
+    lines = []
+    for i in range(0, len(data), 16):
+        chunk = data[i:i + 16]
+        hexs = " ".join(f"{b:02x}" for b in chunk)
+        text = "".join(chr(b) if 32 <= b < 127 else "." for b in chunk)
+        lines.append(f"  {i:04x}  {hexs:<47}  {text}")
+    return "\n".join(lines)
+
+
+# --- Collectors. Each returns a string; assemble() isolates failures. ---
+
+
+def collect_versions():
+    lines = [f"python: {sys.version.split()[0]} ({sys.executable})"]
+    try:
+        with open("/etc/os-release") as f:
+            for line in f:
+                if line.startswith("PRETTY_NAME="):
+                    lines.append("distro: " + line.split("=", 1)[1].strip().strip('"'))
+    except OSError:
+        lines.append("distro: unknown (/etc/os-release unreadable)")
+    lines.append("pipewire: " + _run("pipewire", "--version").splitlines()[-1])
+    lines.append("wireplumber: " + _run("wireplumber", "--version").splitlines()[-1])
+    return "\n".join(lines)
+
+
+def collect_usb():
+    """Which supported devices sysfs sees — no USB permissions needed."""
+    from .profiles import PROFILES
+    present = {}
+    for entry in glob.glob("/sys/bus/usb/devices/*"):
+        try:
+            with open(os.path.join(entry, "idVendor")) as f:
+                vid = f.read().strip()
+            with open(os.path.join(entry, "idProduct")) as f:
+                pid = f.read().strip()
+        except OSError:
+            continue
+        present[(vid, pid)] = True
+    lines = []
+    for p in PROFILES:
+        seen = (f"{p.vid:04x}", f"{p.pid:04x}") in present
+        lines.append(f"{p.display_name} ({p.vid:04x}:{p.pid:04x}): "
+                     + ("present" if seen else "absent"))
+    return "\n".join(lines)
+
+
+def describe_device(dev, full=False):
+    """Hardware identity; serial and config bytes only with --full."""
+    p = dev.profile
+    lines = [f"profile: {p.display_name} ({p.vid:04x}:{p.pid:04x})"
+             + (f" at {dev.usbbus}" if dev.usbbus else ""),
+             f"alsa card: {dev._card}"]
+    try:
+        info = dev.read_device_info()
+        serial = info["serial"] if full else "[withheld]"
+        lines.append(f"firmware: {info['fw_version']}  "
+                     f"api: {info['api_version']}  serial: {serial}")
+    except Exception as e:
+        lines.append(f"devinfo: unreadable ({e if full else type(e).__name__})")
+    if full:
+        try:
+            lines.append(f"config ({p.config_len} bytes expected):")
+            lines.append(_hexdump(dev.read_config()))
+        except Exception as e:
+            lines.append(f"config: unreadable ({e})")
+    else:
+        lines.append("device config: contents withheld (--full includes them)")
+    return lines
+
+
+def collect_device(full=False):
+    """Every supported device, each through a fresh handle in turn."""
+    from .device import WaveDevice, scan
+    units = scan()
+    if not units:
+        return "no supported device on the bus"
+    lines = []
+    for profile, bus, addr in units:
+        dev = WaveDevice()
+        try:
+            dev.connect(profile, bus, addr)
+        except RuntimeError as e:
+            lines.append(f"{profile.display_name} at {bus:03d}/{addr:03d}: "
+                         f"could not open ({e if full else type(e).__name__})")
+            continue
+        try:
+            lines.extend(describe_device(dev, full=full))
+        finally:
+            dev.disconnect()
+        lines.append("")
+    if any("unreadable" in line or "could not open" in line for line in lines):
+        lines.append("(a device was seen but reads failed: OpenWave is "
+                     "probably running and holds the one handle the "
+                     "firmware serves — quit OpenWave including the tray "
+                     "icon before using --device)")
+    return "\n".join(lines).rstrip()
+
+
+def collect_udev():
+    from . import setup
+    lines = [f"udev rules complete: {setup.udev_installed()}"]
+    for path in (setup.UDEV_PATH, setup.UDEV_PATH_OLD):
+        lines.append(f"{path}: "
+                     + ("present" if os.path.exists(path) else "absent"))
+    return "\n".join(lines)
+
+
+def collect_service():
+    from . import service
+    return "\n".join([
+        f"backend: {service.backend_name}",
+        f"installed: {service.is_installed()}",
+        f"running: {service.is_running()}",
+        f"failed: {service.is_failed()}",
+    ])
+
+
+def collect_journal(full=False):
+    if not full:
+        return "(journal withheld: may contain serials, paths and app names; --full includes it)"
+    from . import service
+    if service.backend_name != "systemd":
+        return f"(journal only collected on systemd; backend is {service.backend_name})"
+    return _run("journalctl", "--user", "-u", "openwave",
+                "-n", "100", "--no-pager")
+
+
+def collect_pipewire(full=False):
+    out = _run("pw-dump")
+    if out.startswith("("):
+        return out
+    try:
+        objects = json.loads(out)
+    except ValueError as e:
+        return f"(pw-dump output unparseable: {e})"
+    lines = []
+    for obj in objects:
+        props = (obj.get("info") or {}).get("props") or {}
+        name = props.get("node.name", "")
+        if not name:
+            continue
+        ours = name.startswith("openwave_") or "Elgato" in name \
+            or "Wave" in props.get("node.description", "")
+        if not (ours or full):
+            continue
+        state = (obj.get("info") or {}).get("state", "?")
+        if full:
+            lines.append(f"{name}  [{state}]  {props.get('node.description', '')}")
+        else:
+            label = "OpenWave node" if name.startswith("openwave_") else "supported hardware node"
+            lines.append(f"{label}  [{state}] (name and description withheld)")
+    header = "all nodes:" if full else "openwave / Elgato nodes:"
+    return header + "\n" + ("\n".join(lines) or "(none)")
+
+
+def collect_configs(full=False):
+    lines = []
+    paths = {
+        "sources.json": os.path.expanduser("~/.config/openwave/sources.json"),
+        "mixdefs.json": os.path.expanduser("~/.config/openwave/mixdefs.json"),
+        "mixes.json": os.path.expanduser("~/.config/openwave/mixes.json"),
+        "ui-state.json": os.path.expanduser("~/.config/openwave/ui-state.json"),
+    }
+    for name, path in paths.items():
+        if not os.path.exists(path):
+            lines.append(f"{name}: absent")
+            continue
+        size = os.path.getsize(path)
+        try:
+            with open(path) as f:
+                body = f.read()
+            json.loads(body)
+            state = "parses"
+        except (OSError, ValueError) as e:
+            body, state = None, f"BROKEN ({e})"
+        lines.append(f"{name}: {size} bytes, {state}")
+        if full and body is not None:
+            lines.append(body.rstrip())
+    if not full:
+        lines.append("(contents withheld — app names are personal; --full includes them)")
+    return "\n".join(lines)
+
+
+SECTIONS = (
+    ("Versions", collect_versions),
+    ("USB devices", collect_usb),
+    ("Device", collect_device),
+    ("udev", collect_udev),
+    ("Service", collect_service),
+    ("Journal", collect_journal),
+    ("PipeWire", collect_pipewire),
+    ("Config files", collect_configs),
+)
+
+
+def redact_paths(text):
+    """Remove absolute/private paths, including quoted paths containing spaces.
+
+    Leave URLs intact. Redact executables even when outside the home directory;
+    no allowlist of installation prefixes can anticipate a private checkout.
+    """
+    text = re.sub(r'''(["'])(?:file://)?(?:/|~/)[^\n]*?\1''', '"[path]"', text)
+    text = re.sub(r'''file:///[^\s"'<>),;]*''', "[path]", text)
+    for value in (os.path.expanduser("~"), sys.executable):
+        if value and value != "/":
+            text = text.replace(value, "[path]")
+    text = re.sub(r'''(?<![\w/])(?:/(?!/)|~/)[^\s"'<>),;]*''', "[path]", text)
+    text = re.sub(r'''\[path\](?:/[^\s"'<>),;]*)?''', "[path]", text)
+    return text
+
+
+def assemble(full=False, sections=SECTIONS, device=False):
+    """The whole bundle as a string. No collector failure escapes."""
+    stamp = time.strftime("%Y-%m-%d %H:%M:%S %z")
+    out = [f"OpenWave diagnostics — {stamp}"
+           + ("  (--full: includes serials, configs, journal and all node names)"
+              if full else "")]
+    out.append("Source: https://github.com/rikkichy/openwave")
+    out.append("Privacy: filesystem paths redacted; vendor/product IDs retained. "
+               + ("Serials and other private details included; review before sharing."
+                  if full else "Serials, node names, journal and config bodies withheld."))
+    for title, collect in sections:
+        out.append(f"\n== {title} ==")
+        try:
+            if collect is collect_device and not device:
+                out.append("(USB detail reads disabled; close OpenWave, including its tray, then use --device)")
+            elif collect in (collect_pipewire, collect_configs, collect_device, collect_journal):
+                out.append(collect(full=full))
+            else:
+                out.append(collect())
+        except Exception as exc:
+            detail = f": {exc}" if full else ""
+            out.append(f"unavailable ({type(exc).__name__}{detail})")
+    return redact_paths("\n".join(out) + "\n")
+
+
+def default_path():
+    return os.path.abspath(
+        time.strftime("openwave-diag-%Y%m%d-%H%M%S.txt"))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog="python3 -m wavexlr.diag", description=__doc__)
+    parser.add_argument("--full", action="store_true",
+                        help="include serials, config contents, journal and all node names (not USB access)")
+    parser.add_argument("--device", action="store_true",
+                        help="read USB device details; close OpenWave including its tray first (read-only)")
+    parser.add_argument("-o", "--output", default=None,
+                        help="write here instead of ./openwave-diag-<stamp>.txt")
+    from .daemon import _version
+    parser.add_argument("--version", action="version", version=f"OpenWave {_version()}")
+    args = parser.parse_args(argv)
+    path = args.output or default_path()
+    bundle = assemble(full=args.full, device=args.device)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(bundle)
+    print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/wavexlr/health.py
+++ b/wavexlr/health.py
@@ -18,7 +18,6 @@ GLITCH_XRUNS_PER_CHECK = 50
 GLITCH_CONFIRM_CHECKS = 2
 COOLDOWN_SECONDS = 60.0
 MAX_ATTEMPTS = 2
-GLITCH_CLEAN_REFILL_CHECKS = 30
 STALL_CLEAN_REFILL_CHECKS = 6
 
 
@@ -96,6 +95,7 @@ def snapshot_graph(runner=None):
     if not isinstance(dump, list):
         return None
     nodes = {}
+    names = {}
     targets = set()
     captures = {}
     for obj in dump:
@@ -104,24 +104,34 @@ def snapshot_graph(runner=None):
         info = obj.get("info") or {}
         props = info.get("props") or {}
         name = props.get("node.name", "")
+        if not isinstance(name, str):
+            continue
+        names[obj["id"]] = name
         nodes[name] = (info, props)
-        if name.startswith(SOURCE_MATCHES):
+        if props.get("media.class") == "Audio/Source" and name.startswith(SOURCE_MATCHES):
             captures[name] = info.get("state") == "running"
-        if name.startswith("openwave_loop_out") and not name.endswith("_cap"):
-            target = props.get("target.object")
-            if isinstance(target, str) and target.startswith("alsa_output."):
+    for obj in dump:
+        if not isinstance(obj, dict) or obj.get("type") != "PipeWire:Interface:Link":
+            continue
+        info = obj.get("info") or {}
+        source = names.get(info.get("output-node-id"), "")
+        target = names.get(info.get("input-node-id"), "")
+        if source.startswith("openwave_loop_output_") and not source.endswith("_cap"):
+            if target.startswith("alsa_output."):
                 targets.add(target)
     sinks = {}
     for name in targets:
         if name not in nodes:
             continue
         info, props = nodes[name]
+        if props.get("media.class") != "Audio/Sink":
+            continue
         try:
             sinks[name] = {
                 "running": info.get("state") == "running",
-                "card": int(props["alsa.card"]),
-                "device": int(props["alsa.device"]),
-                "subdevice": int(props.get("alsa.subdevice", 0)),
+                "card": int(props.get("api.alsa.pcm.card", props.get("alsa.card"))),
+                "device": int(props.get("api.alsa.pcm.device", props.get("alsa.device"))),
+                "subdevice": int(props.get("api.alsa.pcm.subdevice", props.get("alsa.subdevice", 0))),
             }
         except (KeyError, TypeError, ValueError):
             continue
@@ -129,96 +139,39 @@ def snapshot_graph(runner=None):
 
 
 class GlitchWatch:
-    """Decides when a capture node's xrun counter means glitching audio.
+    """Confirm sustained xrun growth; baselines are not healthy observations."""
 
-    Fed one cumulative count per check window. The counter resets to
-    zero when a node is recreated; a shrinking count therefore starts a
-    fresh baseline instead of celebrating a negative delta.
-    """
-
-    def __init__(self, threshold=GLITCH_XRUNS_PER_CHECK,
-                 confirm=GLITCH_CONFIRM_CHECKS,
-                 cooldown_seconds=COOLDOWN_SECONDS,
-                 max_attempts=MAX_ATTEMPTS,
-                 clean_refill=GLITCH_CLEAN_REFILL_CHECKS):
+    def __init__(self, threshold=GLITCH_XRUNS_PER_CHECK, confirm=GLITCH_CONFIRM_CHECKS):
         self.threshold = threshold
         self.confirm = confirm
-        self.cooldown_seconds = cooldown_seconds
-        self.max_attempts = max_attempts
-        self.clean_refill = clean_refill
-        self._prev = {}          # node_name -> last cumulative count
-        self._streak = {}        # node_name -> consecutive bad windows
-        self._clean = {}         # node_name -> consecutive clean windows
-        self._delta = {}         # node_name -> xruns in the last window
-        self._attempts = {}      # node_name -> remedies spent
-        self._last_attempt = {}  # node_name -> monotonic time
-
-    def forget(self, node_name):
-        for d in (self._prev, self._streak, self._clean, self._delta,
-                  self._attempts, self._last_attempt):
-            d.pop(node_name, None)
+        self._prev = {}
+        self._streak = {}
+        self._delta = {}
 
     def pause(self, node_name):
-        """Unknown, idle or muted samples break continuity, not remedy budgets."""
-        for state in (self._prev, self._streak, self._clean, self._delta):
+        for state in (self._prev, self._streak, self._delta):
             state.pop(node_name, None)
 
-    def observe(self, node_name, xruns, now):
-        """Account one window; True when that window was glitchy."""
+    def observe(self, node_name, xruns):
         prev = self._prev.get(node_name)
         self._prev[node_name] = xruns
         if prev is None or xruns < prev:
-            # First sight, or the node was recreated: baseline only.
-            # Deliberately not a clean window — the reset after a card
-            # cycle proves nothing about the fault.
             self._streak[node_name] = 0
-            self._clean[node_name] = 0
-            self._delta[node_name] = 0
+            self._delta[node_name] = None
             return False
-        self._delta[node_name] = xruns - prev
-        if xruns - prev >= self.threshold:
-            self._streak[node_name] = self._streak.get(node_name, 0) + 1
-            self._clean[node_name] = 0
-            return True
-        # One clean window is not recovery — a card cycle buys a quiet
-        # window while the capture reopens, and refilling on it turns a
-        # persistent fault into an endless cycle-pop loop. The budget
-        # refills only after a sustained stretch of quiet.
-        self._streak[node_name] = 0
-        clean = self._clean.get(node_name, 0) + 1
-        self._clean[node_name] = clean
-        if clean >= self.clean_refill:
-            self._attempts.pop(node_name, None)
-        return False
+        delta = xruns - prev
+        self._delta[node_name] = delta
+        self._streak[node_name] = self._streak.get(node_name, 0) + 1 if delta >= self.threshold else 0
+        return delta >= self.threshold
 
     def glitching(self, node_name):
         return self._streak.get(node_name, 0) >= self.confirm
 
     def just_confirmed(self, node_name):
-        """True exactly once per incident, when it crosses `confirm`."""
         return self._streak.get(node_name, 0) == self.confirm
 
     def last_delta(self, node_name):
-        """xruns accumulated in the last observed window, for logging."""
-        return self._delta.get(node_name, 0)
-
-    def spent(self, node_name):
-        """Remedy attempts spent on the current incident."""
-        return self._attempts.get(node_name, 0)
-
-    def should_recover(self, node_name, now):
-        if not self.glitching(node_name):
-            return False
-        if self._attempts.get(node_name, 0) >= self.max_attempts:
-            return False
-        last = self._last_attempt.get(node_name)
-        if last is not None and now - last < self.cooldown_seconds:
-            return False
-        return True
-
-    def record_attempt(self, node_name, now):
-        self._attempts[node_name] = self._attempts.get(node_name, 0) + 1
-        self._last_attempt[node_name] = now
+        return self._delta.get(node_name)
 
 
 class SinkStallWatch:
@@ -313,14 +266,17 @@ class SinkStallWatch:
 class HealthMonitor:
     """Log confirmed faults; only auto_recover=True permits remedies."""
 
-    def __init__(self, auto_recover=False):
+    def __init__(self, auto_recover=False, capture_gaps=None):
         self.auto_recover = auto_recover
+        self._capture_gaps = capture_gaps
         self._stop = threading.Event()
         self._runner = recovery.CommandRunner(self._stop)
         self._thread = None
         self._lifecycle = threading.Lock()
         self._check_lock = threading.Lock()
         self.glitch = GlitchWatch()
+        self.capture = recovery.StallWatch()
+        self._no_data = set()
         self.stall = SinkStallWatch()
         self._known_captures = set()
         self._known_sinks = set()
@@ -352,13 +308,18 @@ class HealthMonitor:
         with self._check_lock:
             if self._stop.is_set():
                 return
-            self._check_once(time.monotonic() if now is None else now)
+            self._check_once(now)
+
+    def _pause_capture(self, name):
+        self.glitch.pause(name)
+        self.capture.pause(name)
+        self._no_data.discard(name)
 
     def _check_once(self, now):
         graph = snapshot_graph(self._runner)
         if graph is None or self._stop.is_set():
             for name in self._known_captures:
-                self.glitch.pause(name)
+                self._pause_capture(name)
             for name in self._known_sinks:
                 self.stall.observe(name, False, None, None, now)
             return
@@ -366,7 +327,7 @@ class HealthMonitor:
         for gone in self._known_captures - set(captures):
             # Profile cycling and graph reconstruction can temporarily remove
             # the same node. Absence is not proof that its incident ended.
-            self.glitch.pause(gone)
+            self._pause_capture(gone)
         for gone in self._known_sinks - set(sinks):
             self.stall.observe(gone, False, None, None, now)
         self._known_captures = set(captures)
@@ -374,24 +335,47 @@ class HealthMonitor:
         if captures:
             counts = sample_xruns(self._runner)
             mutes = sample_source_mutes(self._runner)
+            gaps = self._capture_gaps() if self._capture_gaps is not None else {}
+            observed_at = time.monotonic() if now is None else now
             for name, running in captures.items():
                 if self._stop.is_set():
                     return
-                if not running or name not in counts or mutes.get(name) is not False:
-                    self.glitch.pause(name)
+                if not running or mutes.get(name) is not False:
+                    self._pause_capture(name)
                     continue
-                self.glitch.observe(name, counts[name], now)
+                if name in counts:
+                    self.glitch.observe(name, counts[name])
+                else:
+                    self.glitch.pause(name)
+                age = gaps.get(name)
+                no_data = age is not None and age >= self.capture.stall_seconds
+                if no_data and name not in self._no_data:
+                    log.warning("%s has no capture data for %.1fs; auto-recover %s",
+                                name, age, self.auto_recover)
+                if no_data:
+                    self._no_data.add(name)
+                else:
+                    self._no_data.discard(name)
+                delta = self.glitch.last_delta(name)
+                healthy = (delta is not None and delta < self.glitch.threshold
+                           and (self._capture_gaps is None
+                                or (age is not None and age < self.capture.stall_seconds)))
+                if healthy:
+                    self.capture.record_recovered(name, observed_at)
+                else:
+                    self.capture.pause(name)
                 if self.glitch.just_confirmed(name):
                     log.warning("%s has sustained capture xruns (%d/window); auto-recover %s",
                                 name, self.glitch.last_delta(name), self.auto_recover)
-                if self.auto_recover and self.glitch.should_recover(name, now):
+                fault = no_data or self.glitch.glitching(name)
+                if self.auto_recover and fault and self.capture.can_recover(name, observed_at):
                     card = recovery.card_name_for(name, self._runner)
                     if card and not self._stop.is_set():
-                        self.glitch.record_attempt(name, now)
+                        self.capture.record_attempt(name, time.monotonic() if now is None else now)
                         recovered = recovery.cycle_card(card, self._runner)
                         log.warning("Card recovery for %s: %s (attempt %d/%d)",
-                                    name, recovered, self.glitch.spent(name),
-                                    self.glitch.max_attempts)
+                                    name, recovered, self.capture.spent(name),
+                                    self.capture.max_attempts)
         sink_mutes = {item["name"]: item["mute"]
                       for item in recovery._listing("sinks", self._runner)
                       if isinstance(item.get("name"), str) and isinstance(item.get("mute"), bool)} if sinks else {}
@@ -399,15 +383,16 @@ class HealthMonitor:
             if self._stop.is_set():
                 return
             ptr, state = read_playback_status(sink["card"], sink["device"], sink["subdevice"])
+            observed_at = time.monotonic() if now is None else now
             running = sink["running"] and sink_mutes.get(name) is False
-            self.stall.observe(name, running, ptr, state, now)
+            self.stall.observe(name, running, ptr, state, observed_at)
             if self.stall.just_stalled(name):
                 log.warning("%s playback hardware is stalled; auto-recover %s",
                             name, self.auto_recover)
-            if self.auto_recover and self.stall.should_recover(name, now):
+            if self.auto_recover and self.stall.should_recover(name, observed_at):
                 if self._stop.is_set():
                     return
-                self.stall.record_attempt(name, now)
+                self.stall.record_attempt(name, time.monotonic() if now is None else now)
                 recovered = recycle_sink(name, self._runner)
                 log.warning("Sink recovery for %s: %s (attempt %d/%d)",
                             name, recovered, self.stall.spent(name), self.stall.max_attempts)

--- a/wavexlr/health.py
+++ b/wavexlr/health.py
@@ -364,9 +364,11 @@ class HealthMonitor:
             return
         captures, sinks = graph
         for gone in self._known_captures - set(captures):
-            self.glitch.forget(gone)
+            # Profile cycling and graph reconstruction can temporarily remove
+            # the same node. Absence is not proof that its incident ended.
+            self.glitch.pause(gone)
         for gone in self._known_sinks - set(sinks):
-            self.stall.forget(gone)
+            self.stall.observe(gone, False, None, None, now)
         self._known_captures = set(captures)
         self._known_sinks = set(sinks)
         if captures:

--- a/wavexlr/health.py
+++ b/wavexlr/health.py
@@ -1,0 +1,419 @@
+"""Observe audio health by default; disruptive remedies require explicit opt-in.
+
+No graph-driver changes or profile preferences are imposed. stop() cancels
+collection and waits for restoration of any transaction already started.
+"""
+
+import json
+import logging
+import re
+import threading
+import time
+
+from . import recovery
+
+log = logging.getLogger("wavexlr.health")
+CHECK_INTERVAL = 10.0
+GLITCH_XRUNS_PER_CHECK = 50
+GLITCH_CONFIRM_CHECKS = 2
+COOLDOWN_SECONDS = 60.0
+MAX_ATTEMPTS = 2
+GLITCH_CLEAN_REFILL_CHECKS = 30
+STALL_CLEAN_REFILL_CHECKS = 6
+
+
+def sample_xruns(runner=None):
+    runner = runner or recovery.CommandRunner()
+    text = runner.run(["pw-top", "--batch-mode", "--iterations", "3"], timeout=15)
+    return _parse_pw_top(text) if text is not None else {}
+
+
+def _parse_pw_top(text):
+    counts = {}
+    for line in text.splitlines():
+        tokens = line.split()
+        # S ID QUANT RATE WAIT BUSY W/Q B/Q ERR [FORMAT...] NAME
+        if len(tokens) < 10 or not tokens[8].isdigit():
+            continue
+        # Later iterations overwrite earlier ones: last wins.
+        counts[tokens[-1]] = int(tokens[8])
+    return counts
+
+
+def read_playback_status(card, device, subdevice):
+    """(hw_ptr, state) of one ALSA playback substream, or (None, None).
+
+    hw_ptr is the DMA position the hardware has consumed up to. A
+    running playback stream always advances it — even one playing pure
+    silence — which is what makes a static pointer a hardware verdict
+    rather than a signal-level one.
+    """
+    path = (f"/proc/asound/card{card}/pcm{device}p/"
+            f"sub{subdevice}/status")
+    try:
+        with open(path) as f:
+            text = f.read()
+    except OSError:
+        return None, None
+    ptr = re.search(r"^hw_ptr\s*:\s*(\d+)", text, re.MULTILINE)
+    state = re.search(r"^state:\s*(\S+)", text, re.MULTILINE)
+    return (int(ptr.group(1)) if ptr else None,
+            state.group(1) if state else None)
+
+
+def sample_source_mutes(runner=None):
+    """Unknown mute state cannot enable recovery."""
+    sources = recovery._listing("sources", runner)
+    return {source["name"]: source["mute"] for source in sources
+            if isinstance(source.get("name"), str) and isinstance(source.get("mute"), bool)}
+
+
+def recycle_sink(sink_name, runner=None):
+    """Resume even if cancellation or timeout interrupts suspension."""
+    if runner and runner.stopped.is_set():
+        return False
+    suspended = False
+    try:
+        suspended = recovery._pactl("suspend-sink", sink_name, "1") is not None
+        if suspended:
+            (runner.stopped if runner else threading.Event()).wait(1.0)
+    finally:
+        resumed = recovery._pactl("suspend-sink", sink_name, "0") is not None
+        if not resumed:
+            log.error("Could not resume %s after suspension", sink_name)
+    return suspended and resumed
+
+
+def snapshot_graph(runner=None):
+    """Return {capture: running}, watched sinks; None means unknown graph."""
+    from .audio import SOURCE_MATCHES
+    runner = runner or recovery.CommandRunner()
+    text = runner.run(["pw-dump"])
+    try:
+        dump = json.loads(text)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(dump, list):
+        return None
+    nodes = {}
+    targets = set()
+    captures = {}
+    for obj in dump:
+        if not isinstance(obj, dict) or obj.get("type") != "PipeWire:Interface:Node":
+            continue
+        info = obj.get("info") or {}
+        props = info.get("props") or {}
+        name = props.get("node.name", "")
+        nodes[name] = (info, props)
+        if name.startswith(SOURCE_MATCHES):
+            captures[name] = info.get("state") == "running"
+        if name.startswith("openwave_loop_out") and not name.endswith("_cap"):
+            target = props.get("target.object")
+            if isinstance(target, str) and target.startswith("alsa_output."):
+                targets.add(target)
+    sinks = {}
+    for name in targets:
+        if name not in nodes:
+            continue
+        info, props = nodes[name]
+        try:
+            sinks[name] = {
+                "running": info.get("state") == "running",
+                "card": int(props["alsa.card"]),
+                "device": int(props["alsa.device"]),
+                "subdevice": int(props.get("alsa.subdevice", 0)),
+            }
+        except (KeyError, TypeError, ValueError):
+            continue
+    return captures, sinks
+
+
+class GlitchWatch:
+    """Decides when a capture node's xrun counter means glitching audio.
+
+    Fed one cumulative count per check window. The counter resets to
+    zero when a node is recreated; a shrinking count therefore starts a
+    fresh baseline instead of celebrating a negative delta.
+    """
+
+    def __init__(self, threshold=GLITCH_XRUNS_PER_CHECK,
+                 confirm=GLITCH_CONFIRM_CHECKS,
+                 cooldown_seconds=COOLDOWN_SECONDS,
+                 max_attempts=MAX_ATTEMPTS,
+                 clean_refill=GLITCH_CLEAN_REFILL_CHECKS):
+        self.threshold = threshold
+        self.confirm = confirm
+        self.cooldown_seconds = cooldown_seconds
+        self.max_attempts = max_attempts
+        self.clean_refill = clean_refill
+        self._prev = {}          # node_name -> last cumulative count
+        self._streak = {}        # node_name -> consecutive bad windows
+        self._clean = {}         # node_name -> consecutive clean windows
+        self._delta = {}         # node_name -> xruns in the last window
+        self._attempts = {}      # node_name -> remedies spent
+        self._last_attempt = {}  # node_name -> monotonic time
+
+    def forget(self, node_name):
+        for d in (self._prev, self._streak, self._clean, self._delta,
+                  self._attempts, self._last_attempt):
+            d.pop(node_name, None)
+
+    def pause(self, node_name):
+        """Unknown, idle or muted samples break continuity, not remedy budgets."""
+        for state in (self._prev, self._streak, self._clean, self._delta):
+            state.pop(node_name, None)
+
+    def observe(self, node_name, xruns, now):
+        """Account one window; True when that window was glitchy."""
+        prev = self._prev.get(node_name)
+        self._prev[node_name] = xruns
+        if prev is None or xruns < prev:
+            # First sight, or the node was recreated: baseline only.
+            # Deliberately not a clean window — the reset after a card
+            # cycle proves nothing about the fault.
+            self._streak[node_name] = 0
+            self._clean[node_name] = 0
+            self._delta[node_name] = 0
+            return False
+        self._delta[node_name] = xruns - prev
+        if xruns - prev >= self.threshold:
+            self._streak[node_name] = self._streak.get(node_name, 0) + 1
+            self._clean[node_name] = 0
+            return True
+        # One clean window is not recovery — a card cycle buys a quiet
+        # window while the capture reopens, and refilling on it turns a
+        # persistent fault into an endless cycle-pop loop. The budget
+        # refills only after a sustained stretch of quiet.
+        self._streak[node_name] = 0
+        clean = self._clean.get(node_name, 0) + 1
+        self._clean[node_name] = clean
+        if clean >= self.clean_refill:
+            self._attempts.pop(node_name, None)
+        return False
+
+    def glitching(self, node_name):
+        return self._streak.get(node_name, 0) >= self.confirm
+
+    def just_confirmed(self, node_name):
+        """True exactly once per incident, when it crosses `confirm`."""
+        return self._streak.get(node_name, 0) == self.confirm
+
+    def last_delta(self, node_name):
+        """xruns accumulated in the last observed window, for logging."""
+        return self._delta.get(node_name, 0)
+
+    def spent(self, node_name):
+        """Remedy attempts spent on the current incident."""
+        return self._attempts.get(node_name, 0)
+
+    def should_recover(self, node_name, now):
+        if not self.glitching(node_name):
+            return False
+        if self._attempts.get(node_name, 0) >= self.max_attempts:
+            return False
+        last = self._last_attempt.get(node_name)
+        if last is not None and now - last < self.cooldown_seconds:
+            return False
+        return True
+
+    def record_attempt(self, node_name, now):
+        self._attempts[node_name] = self._attempts.get(node_name, 0) + 1
+        self._last_attempt[node_name] = now
+
+
+class SinkStallWatch:
+    """Decides when a running sink's hardware has stopped consuming.
+
+    Fed (running, hw_ptr, alsa_state) per check window. A stall is a
+    pointer that did not move between two windows while the node claims
+    to be running, or the kernel reporting the stream in XRUN. The first
+    observation of a sink only baselines the pointer — a sink that just
+    started gets a full window before being judged.
+    """
+
+    def __init__(self, cooldown_seconds=COOLDOWN_SECONDS,
+                 max_attempts=MAX_ATTEMPTS,
+                 clean_refill=STALL_CLEAN_REFILL_CHECKS):
+        self.cooldown_seconds = cooldown_seconds
+        self.max_attempts = max_attempts
+        self.clean_refill = clean_refill
+        self._prev_ptr = {}      # sink_name -> last hw_ptr
+        self._stalled = {}       # sink_name -> bool
+        self._was_stalled = {}   # sink_name -> stalled on previous window
+        self._clean = {}         # sink_name -> consecutive moving windows
+        self._attempts = {}      # sink_name -> remedies spent
+        self._last_attempt = {}  # sink_name -> monotonic time
+
+    def forget(self, sink_name):
+        for d in (self._prev_ptr, self._stalled, self._was_stalled,
+                  self._clean, self._attempts, self._last_attempt):
+            d.pop(sink_name, None)
+
+    def observe(self, sink_name, running, hw_ptr, alsa_state, now):
+        """Account one window; True when the sink is stalled."""
+        self._was_stalled[sink_name] = self._stalled.get(sink_name, False)
+        prev = self._prev_ptr.get(sink_name)
+        self._prev_ptr[sink_name] = hw_ptr
+        if not running or hw_ptr is None or alsa_state not in ("RUNNING", "XRUN"):
+            # Idle and suspended sinks legitimately hold still, and a
+            # sink whose /proc entry vanished is not ours to judge.
+            self._stalled[sink_name] = False
+            self._prev_ptr.pop(sink_name, None)
+            self._clean[sink_name] = 0
+            return False
+        if alsa_state == "XRUN":
+            self._stalled[sink_name] = True
+            self._clean[sink_name] = 0
+            return True
+        if prev is None:
+            self._stalled[sink_name] = False
+            return False
+        stalled = hw_ptr == prev
+        self._stalled[sink_name] = stalled
+        if stalled:
+            self._clean[sink_name] = 0
+        else:
+            # Same reasoning as the glitch watch, shorter leash: a
+            # recycle resets the pointer and the next window can move
+            # once without the PCM being healthy, so refill only after
+            # a sustained stretch of movement.
+            clean = self._clean.get(sink_name, 0) + 1
+            self._clean[sink_name] = clean
+            if clean >= self.clean_refill:
+                self._attempts.pop(sink_name, None)
+        return stalled
+
+    def just_stalled(self, sink_name):
+        """True on the window a stall begins, for logging it once."""
+        return (self._stalled.get(sink_name, False)
+                and not self._was_stalled.get(sink_name, False))
+
+    def spent(self, sink_name):
+        """Remedy attempts spent on the current incident."""
+        return self._attempts.get(sink_name, 0)
+
+    def should_recover(self, sink_name, now):
+        if not self._stalled.get(sink_name):
+            return False
+        if self._attempts.get(sink_name, 0) >= self.max_attempts:
+            return False
+        last = self._last_attempt.get(sink_name)
+        if last is not None and now - last < self.cooldown_seconds:
+            return False
+        return True
+
+    def record_attempt(self, sink_name, now):
+        self._attempts[sink_name] = self._attempts.get(sink_name, 0) + 1
+        self._last_attempt[sink_name] = now
+        # The recycle itself resets the pointer; don't let the next
+        # window compare against a pre-recycle value.
+        self._prev_ptr.pop(sink_name, None)
+
+
+class HealthMonitor:
+    """Log confirmed faults; only auto_recover=True permits remedies."""
+
+    def __init__(self, auto_recover=False):
+        self.auto_recover = auto_recover
+        self._stop = threading.Event()
+        self._runner = recovery.CommandRunner(self._stop)
+        self._thread = None
+        self._lifecycle = threading.Lock()
+        self._check_lock = threading.Lock()
+        self.glitch = GlitchWatch()
+        self.stall = SinkStallWatch()
+        self._known_captures = set()
+        self._known_sinks = set()
+
+    def start(self):
+        with self._lifecycle:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._stop.clear()
+            self._thread = threading.Thread(target=self._run, daemon=True,
+                                            name="openwave-health")
+            self._thread.start()
+
+    def stop(self):
+        """Cancel/reap collection and wait for any owed restoration.
+
+        No timed join: a fifteen-second sampler cannot outlive shutdown.
+        Also waits for callers driving check_once directly.
+        """
+        with self._lifecycle:
+            self._runner.cancel()
+            if self._thread is not None:
+                self._thread.join()
+                self._thread = None
+            with self._check_lock:
+                pass
+
+    def check_once(self, now=None):
+        with self._check_lock:
+            if self._stop.is_set():
+                return
+            self._check_once(time.monotonic() if now is None else now)
+
+    def _check_once(self, now):
+        graph = snapshot_graph(self._runner)
+        if graph is None or self._stop.is_set():
+            for name in self._known_captures:
+                self.glitch.pause(name)
+            for name in self._known_sinks:
+                self.stall.observe(name, False, None, None, now)
+            return
+        captures, sinks = graph
+        for gone in self._known_captures - set(captures):
+            self.glitch.forget(gone)
+        for gone in self._known_sinks - set(sinks):
+            self.stall.forget(gone)
+        self._known_captures = set(captures)
+        self._known_sinks = set(sinks)
+        if captures:
+            counts = sample_xruns(self._runner)
+            mutes = sample_source_mutes(self._runner)
+            for name, running in captures.items():
+                if self._stop.is_set():
+                    return
+                if not running or name not in counts or mutes.get(name) is not False:
+                    self.glitch.pause(name)
+                    continue
+                self.glitch.observe(name, counts[name], now)
+                if self.glitch.just_confirmed(name):
+                    log.warning("%s has sustained capture xruns (%d/window); auto-recover %s",
+                                name, self.glitch.last_delta(name), self.auto_recover)
+                if self.auto_recover and self.glitch.should_recover(name, now):
+                    card = recovery.card_name_for(name, self._runner)
+                    if card and not self._stop.is_set():
+                        self.glitch.record_attempt(name, now)
+                        recovered = recovery.cycle_card(card, self._runner)
+                        log.warning("Card recovery for %s: %s (attempt %d/%d)",
+                                    name, recovered, self.glitch.spent(name),
+                                    self.glitch.max_attempts)
+        sink_mutes = {item["name"]: item["mute"]
+                      for item in recovery._listing("sinks", self._runner)
+                      if isinstance(item.get("name"), str) and isinstance(item.get("mute"), bool)} if sinks else {}
+        for name, sink in sinks.items():
+            if self._stop.is_set():
+                return
+            ptr, state = read_playback_status(sink["card"], sink["device"], sink["subdevice"])
+            running = sink["running"] and sink_mutes.get(name) is False
+            self.stall.observe(name, running, ptr, state, now)
+            if self.stall.just_stalled(name):
+                log.warning("%s playback hardware is stalled; auto-recover %s",
+                            name, self.auto_recover)
+            if self.auto_recover and self.stall.should_recover(name, now):
+                if self._stop.is_set():
+                    return
+                self.stall.record_attempt(name, now)
+                recovered = recycle_sink(name, self._runner)
+                log.warning("Sink recovery for %s: %s (attempt %d/%d)",
+                            name, recovered, self.stall.spent(name), self.stall.max_attempts)
+
+    def _run(self):
+        while not self._stop.is_set():
+            try:
+                self.check_once()
+            except Exception:
+                log.exception("Health monitor collection failed")
+            self._stop.wait(CHECK_INTERVAL)

--- a/wavexlr/meter.py
+++ b/wavexlr/meter.py
@@ -132,6 +132,17 @@ class MeterMonitor:
                 return None
             return time.monotonic() - state.last_data
 
+    def capture_gaps(self):
+        """Shortest live tap gap per node; another flowing tap disproves a stall."""
+        with self._lock:
+            now = time.monotonic()
+            gaps = {}
+            for source_id, state in self._meters.items():
+                if self.running(source_id):
+                    age = now - state.last_data
+                    gaps[state.node_name] = min(gaps.get(state.node_name, age), age)
+            return gaps
+
     def _reader(self, source_id, node_name, capture_sink, state):
         proc = None
         try:

--- a/wavexlr/recovery.py
+++ b/wavexlr/recovery.py
@@ -126,7 +126,7 @@ def cycle_card(card_name, runner=None):
 
 
 class StallWatch:
-    """Pure no-data capture decision; silence/mute is not evidence of a stall."""
+    """No-data decisions and the shared budget for capture-card remedies."""
 
     def __init__(self, stall_seconds=STALL_SECONDS,
                  cooldown_seconds=COOLDOWN_SECONDS, max_attempts=MAX_ATTEMPTS,
@@ -143,6 +143,19 @@ class StallWatch:
         for state in (self._attempts, self._last_attempt, self._clean_since):
             state.pop(node_name, None)
 
+    def pause(self, node_name):
+        """Unknown or unhealthy data ends the clean interval, not the budget."""
+        self._clean_since.pop(node_name, None)
+
+    def spent(self, node_name):
+        return self._attempts.get(node_name, 0)
+
+    def can_recover(self, node_name, now):
+        if self.spent(node_name) >= self.max_attempts:
+            return False
+        last = self._last_attempt.get(node_name)
+        return last is None or now - last >= self.cooldown_seconds
+
     def should_recover(self, node_name, node_present, silent_for, now):
         if not node_present or node_name is None:
             self._clean_since.pop(node_name, None)
@@ -152,11 +165,8 @@ class StallWatch:
             return False
         if silent_for < self.stall_seconds:
             return False
-        self._clean_since.pop(node_name, None)
-        if self._attempts.get(node_name, 0) >= self.max_attempts:
-            return False
-        last = self._last_attempt.get(node_name)
-        return last is None or now - last >= self.cooldown_seconds
+        self.pause(node_name)
+        return self.can_recover(node_name, now)
 
     def record_attempt(self, node_name, now):
         self._attempts[node_name] = self._attempts.get(node_name, 0) + 1

--- a/wavexlr/recovery.py
+++ b/wavexlr/recovery.py
@@ -1,0 +1,170 @@
+"""Explicit, bounded recovery; never select a profile on the user's behalf.
+
+Callers must opt in before invoking a remedy. Collection is cancellable;
+restoring a profile already switched off is mandatory even during shutdown.
+"""
+
+import json
+import logging
+import subprocess
+import threading
+
+STALL_SECONDS = 8.0
+COOLDOWN_SECONDS = 60.0
+MAX_ATTEMPTS = 2
+CLEAN_REFILL_SECONDS = 300.0
+log = logging.getLogger(__name__)
+
+
+class CommandRunner:
+    """One collector's child process, cancelled and reaped before returning."""
+
+    def __init__(self, stopped=None):
+        self.stopped = stopped if stopped is not None else threading.Event()
+        self._lock = threading.Lock()
+        self._process = None
+
+    def cancel(self):
+        with self._lock:
+            self.stopped.set()
+            if self._process is not None:
+                try:
+                    self._process.kill()
+                except ProcessLookupError:
+                    pass
+
+    def run(self, argv, timeout=5):
+        with self._lock:
+            if self.stopped.is_set():
+                return None
+            try:
+                process = subprocess.Popen(argv, stdout=subprocess.PIPE,
+                                           stderr=subprocess.PIPE, text=True)
+            except OSError:
+                return None
+            self._process = process
+        try:
+            try:
+                stdout, _ = process.communicate(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.communicate()
+                return None
+            if self.stopped.is_set() or process.returncode:
+                return None
+            return stdout
+        finally:
+            with self._lock:
+                self._process = None
+
+
+def _pactl(*args, timeout=5, runner=None):
+    if runner is not None:
+        return runner.run(["pactl", *args], timeout=timeout)
+    try:
+        result = subprocess.run(["pactl", *args], capture_output=True,
+                                text=True, timeout=timeout)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return result.stdout if result.returncode == 0 else None
+
+
+def _listing(kind, runner=None):
+    out = _pactl("--format=json", "list", kind, runner=runner)
+    try:
+        value = json.loads(out)
+    except (ValueError, TypeError):
+        return []
+    return [item for item in value if isinstance(item, dict)] if isinstance(value, list) else []
+
+
+def card_name_for(node_name, runner=None):
+    """Resolve an exact source/sink name via its card index, never a prefix."""
+    if not node_name or not node_name.startswith(("alsa_input.", "alsa_output.")):
+        return None
+    kind = "sources" if node_name.startswith("alsa_input.") else "sinks"
+    matches = [item for item in _listing(kind, runner) if item.get("name") == node_name]
+    if len(matches) != 1 or matches[0].get("card") is None:
+        return None
+    index = str(matches[0]["card"])
+    cards = [item for item in _listing("cards", runner)
+             if str(item.get("index")) == index]
+    if len(cards) == 1 and isinstance(cards[0].get("name"), str):
+        return cards[0]["name"]
+    return None
+
+
+def active_profile(card_name, runner=None):
+    """Read the exact card's original profile from locale-independent JSON."""
+    cards = [card for card in _listing("cards", runner) if card.get("name") == card_name]
+    if len(cards) != 1:
+        return None
+    profile = cards[0].get("active_profile")
+    if isinstance(profile, dict):
+        profile = profile.get("name")
+    return profile if isinstance(profile, str) and profile else None
+
+
+def cycle_card(card_name, runner=None):
+    """Close/reopen a card, always attempting restoration of its original profile.
+
+    Cancellation may abort discovery, but not half of a transaction. The
+    monitor waits for this bounded transaction before stop() returns.
+    """
+    profile = active_profile(card_name, runner)
+    if not profile or profile == "off" or (runner and runner.stopped.is_set()):
+        return False
+    switched = False
+    try:
+        switched = _pactl("set-card-profile", card_name, "off") is not None
+    finally:
+        # A timeout may have applied the off command: restore even on failure.
+        restored = _pactl("set-card-profile", card_name, profile) is not None
+        if not restored:
+            log.error("Could not restore %s to original profile %s", card_name, profile)
+    return switched and restored
+
+
+class StallWatch:
+    """Pure no-data capture decision; silence/mute is not evidence of a stall."""
+
+    def __init__(self, stall_seconds=STALL_SECONDS,
+                 cooldown_seconds=COOLDOWN_SECONDS, max_attempts=MAX_ATTEMPTS,
+                 clean_refill_seconds=CLEAN_REFILL_SECONDS):
+        self.stall_seconds = stall_seconds
+        self.cooldown_seconds = cooldown_seconds
+        self.max_attempts = max_attempts
+        self.clean_refill_seconds = clean_refill_seconds
+        self._attempts = {}
+        self._last_attempt = {}
+        self._clean_since = {}
+
+    def forget(self, node_name):
+        for state in (self._attempts, self._last_attempt, self._clean_since):
+            state.pop(node_name, None)
+
+    def should_recover(self, node_name, node_present, silent_for, now):
+        if not node_present or node_name is None:
+            self._clean_since.pop(node_name, None)
+            return False
+        if silent_for is None:
+            self._clean_since.pop(node_name, None)
+            return False
+        if silent_for < self.stall_seconds:
+            return False
+        self._clean_since.pop(node_name, None)
+        if self._attempts.get(node_name, 0) >= self.max_attempts:
+            return False
+        last = self._last_attempt.get(node_name)
+        return last is None or now - last >= self.cooldown_seconds
+
+    def record_attempt(self, node_name, now):
+        self._attempts[node_name] = self._attempts.get(node_name, 0) + 1
+        self._last_attempt[node_name] = now
+        self._clean_since.pop(node_name, None)
+
+    def record_recovered(self, node_name, now):
+        """Account sustained flowing audio, not one lucky frame after cycling."""
+        since = self._clean_since.setdefault(node_name, now)
+        if now - since >= self.clean_refill_seconds:
+            self.forget(node_name)


### PR DESCRIPTION
Reviewed replacement for #8, part 10/12. Original contribution: Zedwil / NyleGarcia.

## Stack
Depends on https://github.com/rikkichy/openwave/pull/21; base is `pr8-09-effects-calibration`. Merge the parent first. These are ordered review slices, not independent cherry-picks.

## Scope
- Observe capture byte flow/xruns and actual output links to ALSA sinks; silence samples still count as data.
- Keep GUI and daemon monitoring observe-only by default. Only daemon --auto-recover enables disruptive remedies.
- Share capture no-data/xrun recovery accounting, preserve cooldowns across unknown/muted/absent/recreated observations, and bound shutdown/restoration.

## Verification
Actual isolated daemon detected a deliberately frozen raw tap while another client continued receiving PCM. Output/module state stayed unchanged and children were reaped. Recovery budget and restoration decisions are regression-tested; physical card cycling was not exercised.

Runtime scenarios were exercised on the integrated stack. Hardware-facing tests do not imply physical USB/phantom-power certification.
